### PR TITLE
fix: Tausender-Trennzeichen werden bei Berechnung falsch geparst

### DIFF
--- a/index.html
+++ b/index.html
@@ -547,16 +547,24 @@
 
     function syncStateFromInputs() {
       var r = getActiveReiter();
-      r.hektar = parseFloat(document.getElementById('hektar').value) || 0;
-      r.koerner = parseFloat(document.getElementById('koerner').value) || 0;
-      r.duenger = parseFloat(document.getElementById('duenger').value) || 0;
+      r.hektar = parseDE(document.getElementById('hektar').value) || 0;
+      r.koerner = parseDE(document.getElementById('koerner').value) || 0;
+      r.duenger = parseDE(document.getElementById('duenger').value) || 0;
+    }
+
+    function formatDEInput(num) {
+      if (!num || num === 0) return '';
+      var s = num.toString();
+      var parts = s.split('.');
+      var intPart = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, '.');
+      return parts.length > 1 ? intPart + ',' + parts[1] : intPart;
     }
 
     function syncInputsFromState() {
       var r = getActiveReiter();
-      document.getElementById('hektar').value = r.hektar > 0 ? r.hektar : '';
-      document.getElementById('koerner').value = r.koerner > 0 ? r.koerner : '';
-      document.getElementById('duenger').value = r.duenger > 0 ? r.duenger : '';
+      document.getElementById('hektar').value = formatDEInput(r.hektar);
+      document.getElementById('koerner').value = formatDEInput(r.koerner);
+      document.getElementById('duenger').value = formatDEInput(r.duenger);
     }
 
     // --- Tab management ---
@@ -843,7 +851,7 @@ function fahrgassenUpdate() {
         document.getElementById('fahrgassen_toggle').classList.add('active');
         document.getElementById('fahrgassen_settings').classList.add('open');
         if (state.fahrgassenBreite > 0) {
-          document.getElementById('fahrgassen_breite').value = state.fahrgassenBreite;
+          document.getElementById('fahrgassen_breite').value = formatDEInput(state.fahrgassenBreite);
           document.getElementById('fahrgassen_saved').textContent = state.fahrgassenBreite + ' m -> ~' + (1 / state.fahrgassenBreite * 100).toFixed(1) + '% weniger Körner';
         }
       }


### PR DESCRIPTION
## Fix: Tausender-Trennzeichen-Parsing (#25)

### Problem
`syncStateFromInputs()` nutzte `parseFloat()` statt `parseDE()` beim Lesen der formatierten DOM-Werte. Da `onInputFormat()` deutsche Tausenderpunkte erzeugt (z.B. `90.000`), interpretierte `parseFloat("90.000")` den Punkt als Dezimaltrennzeichen und lieferte `90` statt `90000`.

### Ursache
Die `parseDE()`-Funktion existierte bereits in `berechne()`, `fahrgassenUpdate()` und `drillAdd()`, aber **3 weitere Stellen** wurden beim ersten Fix-Versuch uebersehen:

| Funktion | Alt | Neu |
|---|---|---|
| `syncStateFromInputs()` | `parseFloat()` x3 | `parseDE()` x3 |
| `syncInputsFromState()` | Rohwert `90000` | DE-formatiert `90.000` |
| `initUI()` Fahrgassen | Rohwert | DE-formatiert |

### Aenderungen

1. **`syncStateFromInputs()`** — 3x `parseFloat()` -> `parseDE()`
   - Das ist der Hauptbug: Tab-Wechsel und Reiter-Entfernung rufen diese Funktion

2. **Neu: `formatDEInput()`** — Hilfsfunktion fuer DE-Formatierung
   - `90000` -> `"90.000"`, `12.5` -> `"12,5"`, `0` -> `""`

3. **`syncInputsFromState()`** — Werte jetzt DE-formatiert ins DOM
   - Konsistent mit dem, was `onInputFormat()` erzeugt

4. **`initUI()`** — Fahrgassenbreite beim Laden DE-formatiert

### Test-Matrix

| Eingabe | formatDEInput | parseDE (round-trip) | Ergebnis |
|---|---|---|---|
| 90000 | "90.000" | 90000 | OK |
| 90 | "90" | 90 | OK |
| 12.5 | "12,5" | 12.5 | OK |
| 1234.56 | "1.234,56" | 1234.56 | OK |
| 1000000 | "1.000.000" | 1000000 | OK |

### Risiko
- Niedrig: Aenderungen sind auf 3 Funktionen begrenzt
- Round-trip (formatDEInput -> parseDE) ist fuer alle getesteten Werte stabil
- Keine Aenderung an Berechnungslogik, nur an Input-Parsing

Closes #25
