### PR TITLE
fix(v2): onInputFormat neu geschrieben - eigentliche Bug-Ursache

### DIFF
--- a/index.html
+++ b/index.html
@@ -402,12 +402,12 @@
       <h2>📐 Fläche & Aussaatstärke</h2>
       <div class="field">
         <label for="hektar">Hektar</label>
-        <input type="text" inputmode="decimal" id="hektar" placeholder="z.B. 12.5" inputmode="decimal" oninput="onInputFormat(this, 'decimal')">
+        <input type="text" inputmode="decimal" id="hektar" placeholder="z.B. 12,5" oninput="onInputFormat(this, 'decimal')">
         <div class="error-msg" id="err_hektar"></div>
       </div>
       <div class="field">
         <label for="koerner">Körner pro Hektar</label>
-        <input type="text" inputmode="numeric" id="koerner" placeholder="z.B. 90000" inputmode="numeric" oninput="onInputFormat(this, 'integer')">
+        <input type="text" inputmode="numeric" id="koerner" placeholder="z.B. 90000" oninput="onInputFormat(this, 'integer')">
         <div class="unit">üblich: 80.000 – 100.000</div>
         <div class="error-msg" id="err_koerner"></div>
       </div>
@@ -417,7 +417,7 @@
       <h2>🧪 Dünger</h2>
       <div class="field">
         <label for="duenger">Dünger (kg/ha)</label>
-        <input type="text" inputmode="decimal" id="duenger" placeholder="z.B. 150" inputmode="decimal" oninput="onInputFormat(this, 'decimal')">
+        <input type="text" inputmode="decimal" id="duenger" placeholder="z.B. 150" oninput="onInputFormat(this, 'decimal')">
       </div>
 
       <div class="fahrgassen-toggle">
@@ -427,7 +427,7 @@
       <div class="fahrgassen-settings" id="fahrgassen_settings">
         <div class="field" style="margin-bottom:8px">
           <label for="fahrgassen_breite">Fahrgassenbreite (m)</label>
-          <input type="text" inputmode="decimal" id="fahrgassen_breite" placeholder="z.B. 24" inputmode="decimal" oninput="onInputFormat(this, 'decimal')">
+          <input type="text" inputmode="decimal" id="fahrgassen_breite" placeholder="z.B. 24" oninput="onInputFormat(this, 'decimal')" onchange="fahrgassenUpdate()" onblur="fahrgassenUpdate()">
         </div>
         <div class="fahrgassen-saved" id="fahrgassen_saved"></div>
         <div class="fahrgassen-info">Die Körnerzahl wird um ca. 1/Fahrgassenbreite × 100 % reduziert.</div>
@@ -463,12 +463,12 @@
         </div>
         <div class="field">
           <label for="drill_hektar">Hektar-Zähler</label>
-          <input type="text" inputmode="decimal" id="drill_hektar" placeholder="z.B. 5.2" inputmode="decimal" oninput="onInputFormat(this, 'decimal')">
+          <input type="text" inputmode="decimal" id="drill_hektar" placeholder="z.B. 5,2" oninput="onInputFormat(this, 'decimal')">
         </div>
       </div>
       <div class="field">
         <label for="drill_duenger">Dünger (kg)</label>
-        <input type="text" inputmode="decimal" id="drill_duenger" placeholder="z.B. 500" inputmode="decimal" oninput="onInputFormat(this, 'decimal')">
+        <input type="text" inputmode="decimal" id="drill_duenger" placeholder="z.B. 500" oninput="onInputFormat(this, 'decimal')">
       </div>
       <button class="btn-add" onclick="drillAdd()">+ Einfüllen</button>
 
@@ -725,17 +725,48 @@ function fahrgassenUpdate() {
       return parseFloat(s.replace(/\./g, '')) || 0;
     }
 
-    // Formats number with thousand separators while typing, places cursor at end
-    function onInputFormat(el) {
-      var raw = el.value.replace(/[^\d,.-]/g, '').replace(',', '.');
-      var num = parseFloat(raw);
-      if (isNaN(num)) return;
-      var parts = raw.split('.');
-      var intPart = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, '.');
-      var formatted = parts.length > 1 ? intPart + ',' + parts[1] : intPart;
+    // Formats number with DE thousand separators while typing.
+    // mode: 'integer' (koerner) or 'decimal' (hektar, duenger, etc.)
+    // Key fix: strip ALL existing formatting dots before re-formatting,
+    // otherwise dots from a previous format step get misinterpreted as decimal.
+    function onInputFormat(el, mode) {
+      var val = el.value;
+      if (!val) return;
+
+      var hasComma = val.indexOf(',') !== -1;
+      var digitsOnly = val.replace(/[^\d]/g, '');
+      if (!digitsOnly) return;
+
+      if (mode === 'integer') {
+        // Pure integer: strip everything, format with DE thousand dots
+        var n = parseInt(digitsOnly, 10);
+        if (isNaN(n)) return;
+        var formatted = digitsOnly.replace(/\B(?=(\d{3})+(?!\d))/g, '.');
+        if (el.value !== formatted) {
+          el.value = formatted;
+          el.setSelectionRange(formatted.length, formatted.length);
+        }
+        return;
+      }
+
+      // Decimal mode: preserve decimal part after comma
+      var intDigits, decDigits;
+      if (hasComma) {
+        var parts = val.split(',');
+        intDigits = parts[0].replace(/[^\d]/g, '');
+        decDigits = parts[1] ? parts[1].replace(/[^\d]/g, '') : '';
+      } else {
+        intDigits = digitsOnly;
+        decDigits = '';
+      }
+      if (!intDigits) return;
+      var formatted = intDigits.replace(/\B(?=(\d{3})+(?!\d))/g, '.');
+      if (decDigits || hasComma) {
+        formatted += ',' + decDigits;
+      }
       if (el.value !== formatted) {
         el.value = formatted;
-        el.setSelectionRange(el.value.length, el.value.length);
+        el.setSelectionRange(formatted.length, formatted.length);
       }
     }
 


### PR DESCRIPTION
## Fix: onInputFormat war die eigentliche Ursache (#25)

### Warum der erste Fix nicht gereicht hat

PR #26 hat `parseFloat -> parseDE` in `syncStateFromInputs()` repariert. Das war noetig, aber nicht die Hauptursache. Der eigentliche Bug war in `onInputFormat()` selbst:

**Traces beim Tippen von `90000` (alte onInputFormat):**

| Schritt | Feld vorher | User tippt | Feld nachher | parseDE |
|---|---|---|---|---|
| 1 | `""` | `9` | `"9"` | 9 |
| 2 | `"9"` | `0` | `"90"` | 90 |
| 3 | `"90"` | `0` | `"900"` | 900 |
| 4 | `"900"` | `0` | `"9.000"` | 9000 |
| **5** | **`"9.000"`** | **`0`** | **`"9,0000"`** | **9 (!!)** |

Bei Schritt 5: Browser haengt `0` an `"9.000"` -> `"9.0000"`. Die alte `onInputFormat` machte:
1. `raw = "9.0000".replace(/,/g, '.') = "9.0000"` 
2. `parts = "9.0000".split('.') = ["9", "0000"]`
3. `intPart = "9"`, formatiert als `"9"`
4. `formatted = "9" + "," + "0000" = "9,0000"` (Komma = Dezimal!)
5. `parseDE("9,0000")` -> Komma ist Dezimal -> `9.0`

### Fix: onInputFormat komplett neu geschrieben

Neue Strategie: **erst alles strippen, dann frisch formatieren** — anstatt bestehende Punkte zu interpretieren.

- **Modus `'integer'`** (koerner): Nur Ziffern behalten, dann DE-Tausenderpunkte setzen
- **Modus `'decimal'`** (hektar, duenger, etc.): Komma als Dezimaltrennzeichen erkennen, Tausenderpunkte entfernen, Integer-Teil neu formatieren

### Typing-Trace mit neuem onInputFormat:

| Schritt | Feld vorher | User tippt | Feld nachher | parseDE |
|---|---|---|---|---|
| 4 | `"900"` | `0` | `"9.000"` | 9000 |
| **5** | **`"9.000"`** | **`0`** | **`"90.000"`** | **90000** |

### Weitere Fixes in diesem PR

- `fahrgassenUpdate()`: war eine tote Funktion (nie aufgerufen). `onchange`/`onblur` Handler hinzugefuegt
- Placeholder: `"z.B. 12.5"` -> `"z.B. 12,5"` (Konsistenz mit DE-Komma)
- Duplizierte `inputmode`-Attribute aufgeraeumt

### Test-Matrix

| Eingabe | Typ | Schritte | Finaler Wert | Erwartet | Status |
|---|---|---|---|---|---|
| 90000 | integer | 9->90->900->9.000->90.000 | 90000 | 90000 | OK |
| 100000 | integer | 1->10->100->1.000->10.000->100.000 | 100000 | 100000 | OK |
| 12,5 | decimal | 1->12->12,->12,5 | 12.5 | 12.5 | OK |
| 1500 | decimal | 1->15->150->1.500 | 1500 | 1500 | OK |
| 1234,56 | decimal | ...->1.234,56 | 1234.56 | 1234.56 | OK |

Closes #25
