### PR TITLE
fix: switchReiter() Ergebnisanzeige beim Tab-Wechsel

### DIFF
--- a/index.html
+++ b/index.html
@@ -607,8 +607,13 @@ state.reiter.forEach(function(r, i) {
       syncInputsFromState();
       renderTabs();
       sv();
-      if (state.hektar > 0 && state.koerner > 0) {
+      var r = getActiveReiter();
+      if (r.hektar > 0 && r.koerner > 0) {
         renderResults();
+        document.getElementById('results').style.display = 'block';
+      } else {
+        document.getElementById('results').style.display = 'none';
+        document.getElementById('drill_section').style.display = 'none';
       }
     }
 


### PR DESCRIPTION
## Fix

**Problem:**  prüfte  und  auf Root-Ebene — diese Properties existieren nach der Reiter-Migration nur noch unter .

**Lösung:**
- Nutze  um das aktive Tab-Objekt zu holen
- Prüfe 
- Blende  +  explizit ein/aus

## Test-Matrix

- [x] Tab wechseln nach Berechnung → Ergebnisse werden korrekt angezeigt
- [x] Tab wechseln ohne Berechnung → Ergebnisse werden ausgeblendet
- [x] Gleicher Tab geklickt → kein Doppel-Render

Fixes #29