### PR TITLE
fix: SW Update-Strategie – Network-First für HTML, Activate-Handler

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,12 +1,27 @@
-const CACHE = 'mais-rechner-v2';
-const FILES = ['/', '/index.html', '/icon.svg', '/manifest.json'];
+const CACHE_VERSION = 'mais-rechner-v3';
+const STATIC_ASSETS = ['/', '/index.html', '/icon.svg', '/manifest.json', '/icon-192.png', '/icon-512.png'];
 
 self.addEventListener('install', e => {
-  e.waitUntil(caches.open(CACHE).then(c => c.addAll(FILES)));
+  e.waitUntil(caches.open(CACHE_VERSION).then(c => c.addAll(STATIC_ASSETS)));
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', e => {
+  e.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(k => k !== CACHE_VERSION).map(k => caches.delete(k)))
+    )
+  );
+  self.clients.claim();
 });
 
 self.addEventListener('fetch', e => {
-  e.respondWith(
-    caches.match(e.request).then(r => r || fetch(e.request))
-  );
+  const url = e.request.url;
+  if (url.endsWith('.html') || url.endsWith('/')) {
+    // Network-First für HTML → User bekommt Updates
+    e.respondWith(fetch(e.request).catch(() => caches.match(e.request)));
+  } else {
+    // Cache-First für statische Assets
+    e.respondWith(caches.match(e.request).then(r => r || fetch(e.request)));
+  }
 });


### PR DESCRIPTION
## Fix

**Problem:** Service Worker hatte keinen Update-Mechanismus — Nutzer sahen nach Deploy keine Änderungen.

**Lösung (nach Issue-Vorschlag):**
- `install`: `self.skipWaiting()` damit neuer SW sofort aktiviert wird
- `activate`: Alte Cache-Versionen werden gelöscht (`caches.keys()` + `filter`), `self.clients.claim()` für sofortige Kontrolle
- `fetch`: Network-First für HTML-Seiten (Updates werden sofort sichtbar), Cache-First für statische Assets (Icons, SVGs)
- Cache Version auf `v3` gebumped (v2 war ohne activate-Handler)

## Test-Matrix

- [x] Neuer SW wird nach Deploy sofort aktiv (skipWaiting)
- [x] Alte Cache-Versionen werden beim Activate aufgeräumt
- [x] HTML-Requests gehen zuerst an Network → User sieht Updates
- [x] Assets werden aus Cache bedient → offline-fähig

Fixes #35
