### PR TITLE
fix: drill_einheit type=number -> text mit DE-Dezimal

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -459,7 +459,7 @@
       <div class="inline-row">
         <div class="field">
           <label for="drill_einheit">Einheiten eingefüllt</label>
-          <input type="number" inputmode="numeric" id="drill_einheit" placeholder="z.B. 1.5" min="0">
+          <input type="text" inputmode="decimal" id="drill_einheit" placeholder="z.B. 1,5" oninput="onInputFormat(this, 'decimal')">
         </div>
         <div class="field">
           <label for="drill_hektar">Hektar-Zähler</label>


### PR DESCRIPTION
## Fix

**Problem:** `drill_einheit` nutzte `type="number"` — das interpretiert Dezimaltrenner je nach Browser-Locale unterschiedlich und zeigt Spinner-Buttons auf Desktop.

**Lösung:** Wie alle anderen numerischen Inputs auf `type="text"` + `inputmode="decimal"` + `oninput="onInputFormat(this, 'decimal')"` umgestellt.

## Test-Matrix

- [x] Komma als Dezimaltrenner funktioniert (z.B. `1,5`)
- [x] Keine Spinner-Buttons mehr auf Desktop
- [x] Dezimal-Tastatur auf Mobile

Fixes #34
