### PR TITLE
fix: Bestätigungsdialog vor Drill-Protokoll-Reset

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -696,6 +696,9 @@ function fahrgassenUpdate() {
       var usedEinheit = state.entries.reduce(function(s, e) { return s + e.einheit; }, 0);
       var usedDuenger = state.entries.reduce(function(s, e) { return s + e.duenger; }, 0);
       if (usedEinheit > getTotalEinheiten() || usedDuenger > getTotalDuenger()) {
+        if (!confirm('Die neuen Werte weichen von den eingetragenen Einheiten ab. Drill-Protokoll zurücksetzen?')) {
+          return;
+        }
         state.entries = [];
       }
       sv();


### PR DESCRIPTION
## Fix

**Problem:** Beim erneuten Berechnen mit geänderten Werten werden alle Drill-Einträge ohne Rückfrage gelöscht.

**Lösung:** -Dialog hinzugefügt — User kann Zurücksetzen abbrechen.

## Test-Matrix

- [x] confirm-Dialog erscheint wenn used > total
- [x] Bei Abbruch werden Einträge nicht gelöscht
- [x] Bei Bestätigung werden Einträge wie bisher zurückgesetzt

Fixes #32