### PR TITLE
fix: Drill-Protokoll (entries) jetzt pro Reiter statt global

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -506,9 +506,8 @@
   <script>
     // --- State ---
     var state = {
-      reiter: [{ name: 'Reiter 1', hektar: 0, koerner: 0, duenger: 0 }],
+      reiter: [{ name: 'Reiter 1', hektar: 0, koerner: 0, duenger: 0, entries: [] }],
       activeReiter: 0,
-      entries: [],
       fahrgassenEnabled: false,
       fahrgassenBreite: 0
     };
@@ -528,12 +527,21 @@
               name: 'Reiter 1',
               hektar: parsed.hektar || 0,
               koerner: parsed.koerner || 0,
-              duenger: parsed.duenger || 0
+              duenger: parsed.duenger || 0,
+              entries: parsed.entries || []
             }];
             delete parsed.hektar;
             delete parsed.koerner;
             delete parsed.duenger;
+            delete parsed.entries;
             parsed.activeReiter = 0;
+          }
+          // Migrate: entries used to be global; move to first tab if missing
+          if (parsed.entries !== undefined) {
+            if (parsed.reiter && parsed.reiter[0] && parsed.reiter[0].entries === undefined) {
+              parsed.reiter[0].entries = parsed.entries;
+            }
+            delete parsed.entries;
           }
           state = parsed;
         }
@@ -601,7 +609,7 @@
 
     function addReiter() {
       var idx = state.reiter.length + 1;
-      state.reiter.push({ name: 'Reiter ' + idx, hektar: 0, koerner: 0, duenger: 0 });
+      state.reiter.push({ name: 'Reiter ' + idx, hektar: 0, koerner: 0, duenger: 0, entries: [] });
       state.activeReiter = state.reiter.length - 1;
       syncInputsFromState();
       renderTabs();
@@ -693,13 +701,14 @@ function fahrgassenUpdate() {
       r.hektar = h;
       r.koerner = k;
       r.duenger = (isNaN(d) || d < 0) ? 0 : d;
-      var usedEinheit = state.entries.reduce(function(s, e) { return s + e.einheit; }, 0);
-      var usedDuenger = state.entries.reduce(function(s, e) { return s + e.duenger; }, 0);
+      var entries = r.entries;
+      var usedEinheit = entries.reduce(function(s, e) { return s + e.einheit; }, 0);
+      var usedDuenger = entries.reduce(function(s, e) { return s + e.duenger; }, 0);
       if (usedEinheit > getTotalEinheiten() || usedDuenger > getTotalDuenger()) {
         if (!confirm('Die neuen Werte weichen von den eingetragenen Einheiten ab. Drill-Protokoll zurücksetzen?')) {
           return;
         }
-        state.entries = [];
+        entries.length = 0;
       }
       sv();
       renderTabs();
@@ -782,7 +791,7 @@ function fahrgassenUpdate() {
       var hektar = parseDE(hektarEl.value) || 0;
       var duenger = parseDE(duengerEl.value) || 0;
       if (einheit <= 0 && duenger <= 0) return;
-      state.entries.push({ einheit: einheit, hektar: hektar, duenger: duenger, time: new Date().toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' }) });
+      r.entries.push({ einheit: einheit, hektar: hektar, duenger: duenger, time: new Date().toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' }) });
       einheitEl.value = '';
       hektarEl.value = '';
       duengerEl.value = '';
@@ -791,12 +800,14 @@ function fahrgassenUpdate() {
     }
 
     function drillRemove(idx) {
-      state.entries.splice(idx, 1);
+      var r = getActiveReiter();
+      r.entries.splice(idx, 1);
       sv();
       renderResults();
     }
 
     function renderResults() {
+      var r = getActiveReiter();
       var kornerGesamt = getKornerGesamt();
       var einheiten = getTotalEinheiten();
       var duengerTotal = getTotalDuenger();
@@ -808,9 +819,9 @@ function fahrgassenUpdate() {
       } else {
         document.getElementById('r_info').textContent = formatEinheit(einheiten) + ' Saat (ohne Dünger)';
       }
-      var usedEinheit = state.entries.reduce(function(s, e) { return s + e.einheit; }, 0);
-      var usedDuenger = state.entries.reduce(function(s, e) { return s + e.duenger; }, 0);
-      var totalHektar = state.entries.reduce(function(s, e) { return s + (e.hektar || 0); }, 0);
+      var usedEinheit = r.entries.reduce(function(s, e) { return s + e.einheit; }, 0);
+      var usedDuenger = r.entries.reduce(function(s, e) { return s + e.duenger; }, 0);
+      var totalHektar = r.entries.reduce(function(s, e) { return s + (e.hektar || 0); }, 0);
       var remEinheit = Math.max(0, einheiten - usedEinheit);
       var remDuenger = Math.max(0, duengerTotal - usedDuenger);
       var sUsedLabel = usedEinheit === 1.0 ? 'Einheit' : 'Einheiten';
@@ -822,18 +833,18 @@ function fahrgassenUpdate() {
       document.getElementById('ds_duenger_total').textContent = duengerTotal > 0 ? duengerTotal.toLocaleString('de-DE') + ' kg' : '—';
       document.getElementById('ds_duenger_used').textContent = usedDuenger > 0 ? usedDuenger.toLocaleString('de-DE') + ' kg' : '0 kg';
       document.getElementById('ds_duenger_remaining').textContent = duengerTotal > 0 ? remDuenger.toLocaleString('de-DE') + ' kg' : '—';
-      var totalEinheit = state.entries.reduce(function(s, e) { return s + e.einheit; }, 0);
-      var totalHektarDrill = state.entries.reduce(function(s, e) { return s + (e.hektar || 0); }, 0);
-      var totalDuengerDrill = state.entries.reduce(function(s, e) { return s + (e.duenger || 0); }, 0);
+      var totalEinheit = r.entries.reduce(function(s, e) { return s + e.einheit; }, 0);
+      var totalHektarDrill = r.entries.reduce(function(s, e) { return s + (e.hektar || 0); }, 0);
+      var totalDuengerDrill = r.entries.reduce(function(s, e) { return s + (e.duenger || 0); }, 0);
       var parts = [];
       if (totalHektarDrill > 0) parts.push(totalHektarDrill.toFixed(1) + ' ha');
       parts.push(formatEinheit(totalEinheit));
       if (totalDuengerDrill > 0) parts.push(totalDuengerDrill.toLocaleString('de-DE') + ' kg Dünger');
-      document.getElementById('ds_total_summary').textContent = state.entries.length > 0 ? parts.join(', ') + ' eingefüllt' : '—';
+      document.getElementById('ds_total_summary').textContent = r.entries.length > 0 ? parts.join(', ') + ' eingefüllt' : '—';
       var container = document.getElementById('drill_entries');
-      document.getElementById('drill_summary').style.display = (einheiten > 0 || duengerTotal > 0 || state.entries.length > 0) ? 'block' : 'none';
+      document.getElementById('drill_summary').style.display = (einheiten > 0 || duengerTotal > 0 || r.entries.length > 0) ? 'block' : 'none';
       document.getElementById('drill_section').style.display = 'block';
-      if (state.entries.length === 0) {
+      if (r.entries.length === 0) {
         container.innerHTML = '';
         var empty = document.createElement('div');
         empty.className = 'drill-empty';
@@ -841,7 +852,7 @@ function fahrgassenUpdate() {
         container.appendChild(empty);
       } else {
         container.innerHTML = '';
-        state.entries.forEach(function(e, i) {
+        r.entries.forEach(function(e, i) {
           var ds = e.duenger > 0 ? e.duenger.toLocaleString('de-DE') + ' kg' : '';
           var dl = ds ? ' + ' + ds + ' Dünger' : '';
           var hl = e.hektar > 0 ? ' @ ' + e.hektar.toFixed(1) + ' ha' : '';
@@ -871,9 +882,8 @@ function fahrgassenUpdate() {
 
     function resetAll() {
       state = {
-        reiter: [{ name: 'Reiter 1', hektar: 0, koerner: 0, duenger: 0 }],
+        reiter: [{ name: 'Reiter 1', hektar: 0, koerner: 0, duenger: 0, entries: [] }],
         activeReiter: 0,
-        entries: [],
         fahrgassenEnabled: false,
         fahrgassenBreite: 0
       };


### PR DESCRIPTION
## Fix

**Problem:** `state.entries` war global auf Root-Ebene — alle Tabs teilten sich ein einziges Drill-Protokoll.

**Lösung:**
- `entries[]` in jeden `reiter[i]` verlagert
- `getActiveReiter().entries` überall statt `state.entries`
- Migration in `lv()`: Legacy-root-`entries` werden in den ersten Reiter verschoben
- `addReiter()` erstellt neuen Tab mit `entries: []`
- `resetAll()` setzt alle Tabs mit leerem `entries[]` zurück

## Test-Matrix

- [x] Reiter 1 mit Entries → Reiter 2 anlegen → Reiter 2 hat leeres Protokoll
- [x] Zurückwechseln → Reiter 1 zeigt wieder seine eigenen Entries
- [x] Legacy-User (root-level entries) behalten ihre Daten nach App-Start

Fixes #31
