### PR TITLE
fix: removeReiter() – syncStateFromInputs() vor splice

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -619,12 +619,11 @@
 
     function removeReiter(idx) {
       if (state.reiter.length <= 1) return;
+      syncStateFromInputs();  // Erst aktuellen Tab sichern
       state.reiter.splice(idx, 1);
       if (state.activeReiter >= state.reiter.length) {
         state.activeReiter = state.reiter.length - 1;
       }
-      // Sync active tab values back before switching
-      syncStateFromInputs();
       syncInputsFromState();
       renderTabs();
       sv();


### PR DESCRIPTION
## Fix

**Problem:** `removeReiter()` rief `syncStateFromInputs()` nach dem `splice()` auf — die Input-Werte wurden in den falschen (bereits verschobenen) Tab-Index geschrieben.

**Lösung:** `syncStateFromInputs()` jetzt vor dem `splice()` (wie im Issue vorgeschlagen).

## Test-Matrix

- [x] Tab A und Tab B mit unterschiedlichen Werten → Tab A löschen → Tab B behält korrekte Werte
- [x] Aktiver Tab wird gelöscht → neuer aktiver Tab zeigt korrekte Werte
- [x] Nur ein Tab vorhanden → Löschen verhindert (bestehendes Verhalten)

Fixes #30
