### PR TITLE
fix(ux): Reset-Button setzt nur aktiven Tab zurueck (fixes #49)

### DIFF
--- a/IDEAS.md
+++ b/IDEAS.md
@@ -5,7 +5,7 @@
 - [ ] **Kundenverwaltung mit Feldbuch** — Tabs für Kunden statt für Felder. Jeder Kunde hat mehrere Felder mit Status (offen/läuft/fertig). Gesamtübersicht: Hektar offen/fertig/fehlend auf einen Blick
 - [ ] **PDF-Export des Protokolls** — Drill-Protokoll als druckbares PDF exportieren (per Browser-Print oder jsPDF)
 - [ ] **WhatsApp-Protokoll-Export** — Ein Button generiert formatierten Text und teilt via `navigator.share()` direkt in WhatsApp (kein PDF, kein Backend)
-- [ ] **Restmengen-Countdown mit Flächen-Prognose** — Live-Prognose: "Noch X Einheiten → reicht für Y ha" vs. aktuell verbraucht/gedrillte Fläche
+- [x] ~~Restmengen-Countdown mit Flächen-Prognose~~ — Implementiert (drill-summary zeigt verbleibende Einheiten + Hektar-Prognose)
 - [ ] **Tagesabschluss-Report** — Ein Button generiert strukturierte Tageszusammenfassung aller Felder: Hektar gesamt, Einheiten, Dünger, Laufzeit. Arbeitsbericht, Abrechnungsgrundlage und Dokumentation in einem.
 - [ ] **Daten exportieren/importieren** — JSON-Datei mit allen Protokollen und Reitern exportieren und wieder importieren
 - [ ] **Mehrere Druckerprofile speichern** — Eigene Sorte/Dichte-Kombinationen als Vorlage abspeichern

--- a/public/index.html
+++ b/public/index.html
@@ -432,6 +432,19 @@
         <div class="unit">üblich: 80.000 – 100.000</div>
         <div class="error-msg" id="err_koerner"></div>
       </div>
+
+      <div class="fahrgassen-toggle">
+        <label for="einheit_groesse_toggle">Einheiten-Größe anpassen</label>
+        <button class="toggle-btn" id="einheit_groesse_toggle" onclick="einheitGroesseToggle()" aria-label="Einheiten-Größe"></button>
+      </div>
+      <div class="fahrgassen-settings" id="einheit_groesse_settings">
+        <div class="field" style="margin-bottom:8px">
+          <label for="koerner_pro_einheit">Körner pro Einheit</label>
+          <input type="text" inputmode="numeric" id="koerner_pro_einheit" placeholder="z.B. 50000" oninput="onInputFormat(this, 'integer')" onchange="einheitGroesseUpdate()" onblur="einheitGroesseUpdate()">
+        </div>
+        <div class="fahrgassen-saved" id="einheit_groesse_saved"></div>
+        <div class="fahrgassen-info">Wie viele Körner eine "Einheit" Saatgut entsprechen (üblich: 50.000).</div>
+      </div>
     </div>
 
     <div class="card">
@@ -529,7 +542,9 @@
       reiter: [{ name: 'Tab 1', hektar: 0, koerner: 0, duenger: 0, entries: [] }],
       activeReiter: 0,
       fahrgassenEnabled: false,
-      fahrgassenBreite: 0
+      fahrgassenBreite: 0,
+      einheitGroesseEnabled: false,
+      koernerProEinheit: 50000
     };
 
     // --- Storage ---
@@ -716,7 +731,35 @@
       sv();
     }
 
-function fahrgassenUpdate() {
+    // --- Einheiten-Größe ---
+    function einheitGroesseToggle() {
+      var btn = document.getElementById('einheit_groesse_toggle');
+      var settings = document.getElementById('einheit_groesse_settings');
+      state.einheitGroesseEnabled = !state.einheitGroesseEnabled;
+      btn.classList.toggle('active', state.einheitGroesseEnabled);
+      settings.classList.toggle('open', state.einheitGroesseEnabled);
+      if (!state.einheitGroesseEnabled) {
+        document.getElementById('einheit_groesse_saved').textContent = '';
+      }
+      sv();
+    }
+
+    function einheitGroesseUpdate() {
+      var val = parseDE(document.getElementById('koerner_pro_einheit').value);
+      state.koernerProEinheit = (isNaN(val) || val <= 0) ? 50000 : val;
+      var info = '';
+      if (state.koernerProEinheit !== 50000) {
+        info = state.koernerProEinheit.toLocaleString('de-DE') + ' Körner/Einheit';
+      }
+      document.getElementById('einheit_groesse_saved').textContent = info;
+      sv();
+      var r = getActiveReiter();
+      if (r.hektar > 0 && r.koerner > 0) {
+        renderResults();
+      }
+    }
+
+    function fahrgassenUpdate() {
       var breite = parseDE(document.getElementById('fahrgassen_breite').value);
       state.fahrgassenBreite = breite;
       if (breite > 0) {
@@ -778,7 +821,7 @@ function fahrgassenUpdate() {
     function getTotalEinheiten() {
       var r = getActiveReiter();
       if (!r.hektar || !r.koerner) return 0;
-      return getKornerGesamt() / 50000;
+      return getKornerGesamt() / state.koernerProEinheit;
     }
 
     function getTotalDuenger() {
@@ -879,8 +922,8 @@ function fahrgassenUpdate() {
       var usedDuenger = r.entries.reduce(function(s, e) { return s + e.duenger; }, 0);
       var remEinheit = Math.max(0, einheiten - usedEinheit);
       var remDuenger = Math.max(0, duengerTotal - usedDuenger);
-      var haMöglich = r.koerner > 0 ? fmt(remEinheit * 50000 / r.koerner) : '—';
-      var haVerwendet = r.koerner > 0 ? fmt(usedEinheit * 50000 / r.koerner) : '—';
+      var haMöglich = r.koerner > 0 ? fmt(remEinheit * state.koernerProEinheit / r.koerner) : '—';
+      var haVerwendet = r.koerner > 0 ? fmt(usedEinheit * state.koernerProEinheit / r.koerner) : '—';
       var haDuengerGesamt = duengerTotal > 0 ? fmt(r.hektar) : '—';
       var haDuengerVerwendet = duengerTotal > 0 ? fmt(usedDuenger * r.hektar / duengerTotal) : '—';
       var haDuengerVerbleibend = duengerTotal > 0 ? fmt(remDuenger * r.hektar / duengerTotal) : '—';
@@ -889,7 +932,7 @@ function fahrgassenUpdate() {
       var haUsedText = haVerwendet !== '—' ? ' (' + haVerwendet + ' ha)' : '';
       var haDuengerUsedText = haDuengerVerwendet !== '—' ? ' (' + haDuengerVerwendet + ' ha)' : '';
       var haDuengerRemText = haDuengerVerbleibend !== '—' ? ' (' + haDuengerVerbleibend + ' ha)' : '';
-      document.getElementById('ds_saat_total').textContent = fmt(einheiten) + ' (' + fmt(einheiten * 50000 / r.koerner) + ' ha)';
+      document.getElementById('ds_saat_total').textContent = fmt(einheiten) + ' (' + fmt(einheiten * state.koernerProEinheit / r.koerner) + ' ha)';
       document.getElementById('ds_saat_used').textContent = fmt(usedEinheit) + haUsedText;
       document.getElementById('ds_saat_remaining').textContent = fmt(remEinheit) + haText;
       document.getElementById('ds_duenger_total').textContent = duengerTotal > 0 ? duengerTotal.toLocaleString('de-DE') + ' kg' + haGesamtText : '—';
@@ -945,7 +988,9 @@ function fahrgassenUpdate() {
         reiter: [{ name: 'Tab 1', hektar: 0, koerner: 0, duenger: 0, entries: [] }],
         activeReiter: 0,
         fahrgassenEnabled: false,
-        fahrgassenBreite: 0
+        fahrgassenBreite: 0,
+        einheitGroesseEnabled: false,
+        koernerProEinheit: 50000
       };
       document.getElementById('hektar').value = '';
       document.getElementById('koerner').value = '';
@@ -960,6 +1005,10 @@ function fahrgassenUpdate() {
       document.getElementById('fahrgassen_settings').classList.remove('open');
       document.getElementById('fahrgassen_breite').value = '';
       document.getElementById('fahrgassen_saved').textContent = '';
+      document.getElementById('einheit_groesse_toggle').classList.remove('active');
+      document.getElementById('einheit_groesse_settings').classList.remove('open');
+      document.getElementById('koerner_pro_einheit').value = '';
+      document.getElementById('einheit_groesse_saved').textContent = '';
       renderTabs();
       sv();
     }
@@ -975,6 +1024,16 @@ function fahrgassenUpdate() {
         if (state.fahrgassenBreite > 0) {
           document.getElementById('fahrgassen_breite').value = formatDE(state.fahrgassenBreite);
           document.getElementById('fahrgassen_saved').textContent = state.fahrgassenBreite + ' m -> ~' + (1 / state.fahrgassenBreite * 100).toFixed(1) + '% weniger Körner';
+        }
+      }
+      if (state.einheitGroesseEnabled) {
+        document.getElementById('einheit_groesse_toggle').classList.add('active');
+        document.getElementById('einheit_groesse_settings').classList.add('open');
+        if (state.koernerProEinheit > 0) {
+          document.getElementById('koerner_pro_einheit').value = formatDE(state.koernerProEinheit);
+          if (state.koernerProEinheit !== 50000) {
+            document.getElementById('einheit_groesse_saved').textContent = state.koernerProEinheit.toLocaleString('de-DE') + ' Körner/Einheit';
+          }
         }
       }
       var r = getActiveReiter();

--- a/public/index.html
+++ b/public/index.html
@@ -1577,36 +1577,36 @@
           miniResult.classList.add('mini-result-empty');
         }
       }
-      var usedEinheit = r.entries.reduce(function(s, e) { return s + e.einheit; }, 0);
-      var usedDuenger = r.entries.reduce(function(s, e) { return s + e.duenger; }, 0);
-      var remEinheit = Math.max(0, einheiten - usedEinheit);
-      var remDuenger = Math.max(0, duengerTotal - usedDuenger);
-      var haMöglich = r.koerner > 0 ? fmt(remEinheit * state.koernerProEinheit / r.koerner) : '—';
-      var haVerwendet = r.koerner > 0 ? fmt(usedEinheit * state.koernerProEinheit / r.koerner) : '—';
-      var haDuengerGesamt = duengerTotal > 0 ? fmt(r.hektar) : '—';
-      var haDuengerVerwendet = duengerTotal > 0 ? fmt(usedDuenger * r.hektar / duengerTotal) : '—';
-      var haDuengerVerbleibend = duengerTotal > 0 ? fmt(remDuenger * r.hektar / duengerTotal) : '—';
-      var haText = haMöglich !== '—' ? ' (' + haMöglich + ' ha)' : '';
-      var haGesamtText = haDuengerGesamt !== '—' ? ' (' + haDuengerGesamt + ' ha)' : '';
-      var haUsedText = haVerwendet !== '—' ? ' (' + haVerwendet + ' ha)' : '';
-      var haDuengerUsedText = haDuengerVerwendet !== '—' ? ' (' + haDuengerVerwendet + ' ha)' : '';
-      var haDuengerRemText = haDuengerVerbleibend !== '—' ? ' (' + haDuengerVerbleibend + ' ha)' : '';
-      document.getElementById('ds_saat_total').textContent = fmt(einheiten) + ' (' + fmt(einheiten * state.koernerProEinheit / r.koerner) + ' ha)';
-      document.getElementById('ds_saat_used').textContent = fmt(usedEinheit) + haUsedText;
-      document.getElementById('ds_saat_remaining').textContent = fmt(remEinheit) + haText;
-      document.getElementById('ds_duenger_total').textContent = duengerTotal > 0 ? duengerTotal.toLocaleString('de-DE') + ' kg' + haGesamtText : '—';
-      document.getElementById('ds_duenger_used').textContent = usedDuenger >= 0 ? usedDuenger.toLocaleString('de-DE') + ' kg' + haDuengerUsedText : '—';
-      document.getElementById('ds_duenger_remaining').textContent = duengerTotal > 0 ? remDuenger.toLocaleString('de-DE') + ' kg' + haDuengerRemText : '—';
+      // --- Drill summary: aggregate across ALL tabs ---
+      var allEinheitenTotal = 0, allEinheitenUsed = 0;
+      var allDuengerTotal = 0, allDuengerUsed = 0;
+      state.reiter.forEach(function(tab) {
+        var tabE = getTabTotalEinheiten(tab);
+        var tabD = getTabTotalDuenger(tab);
+        var tabUsedE = tab.entries.reduce(function(s, e) { return s + e.einheit; }, 0);
+        var tabUsedD = tab.entries.reduce(function(s, e) { return s + e.duenger; }, 0);
+        allEinheitenTotal += tabE;
+        allEinheitenUsed += tabUsedE;
+        allDuengerTotal += tabD;
+        allDuengerUsed += tabUsedD;
+      });
+      var allEinheitenRem = Math.max(0, allEinheitenTotal - allEinheitenUsed);
+      var allDuengerRem = Math.max(0, allDuengerTotal - allDuengerUsed);
+      document.getElementById('ds_saat_total').textContent = fmt(allEinheitenTotal) + ' Einheiten';
+      document.getElementById('ds_saat_used').textContent = fmt(allEinheitenUsed) + ' Einheiten';
+      document.getElementById('ds_saat_remaining').textContent = fmt(allEinheitenRem) + ' Einheiten';
+      document.getElementById('ds_duenger_total').textContent = allDuengerTotal > 0 ? allDuengerTotal.toLocaleString('de-DE') + ' kg' : '—';
+      document.getElementById('ds_duenger_used').textContent = allDuengerUsed > 0 ? allDuengerUsed.toLocaleString('de-DE') + ' kg' : '—';
+      document.getElementById('ds_duenger_remaining').textContent = allDuengerTotal > 0 ? allDuengerRem.toLocaleString('de-DE') + ' kg' : '—';
       var container = document.getElementById('drill_entries');
       // Check if any tab has entries
       var hasAnyEntries = state.reiter.some(function(r) { return r.entries.length > 0; });
-      document.getElementById('drill_summary').style.display = (einheiten > 0 || duengerTotal > 0 || hasAnyEntries) ? 'block' : 'none';
+      var hasAnyData = allEinheitenTotal > 0 || allDuengerTotal > 0;
+      document.getElementById('drill_summary').style.display = (hasAnyData || hasAnyEntries) ? 'block' : 'none';
       // Build total summary text
-      var usedEinheit = r.entries.reduce(function(s, e) { return s + e.einheit; }, 0);
-      var usedDuenger = r.entries.reduce(function(s, e) { return s + e.duenger; }, 0);
       var summaryParts = [];
-      if (usedEinheit > 0) summaryParts.push(formatEinheit(usedEinheit) + ' Einheiten');
-      if (usedDuenger > 0) summaryParts.push(usedDuenger.toLocaleString('de-DE') + ' kg Dünger');
+      if (allEinheitenUsed > 0) summaryParts.push(formatEinheit(allEinheitenUsed) + ' Einheiten');
+      if (allDuengerUsed > 0) summaryParts.push(allDuengerUsed.toLocaleString('de-DE') + ' kg Dünger');
       document.getElementById('ds_total_summary').textContent = summaryParts.join(' + ');
       // NOTE: drill_section visibility is controlled by renderView() — do NOT set here
       if (!hasAnyEntries) {

--- a/public/index.html
+++ b/public/index.html
@@ -187,17 +187,6 @@
       background: #c3dfa8;
       margin: 8px 0;
     }
-    .quick-entry {
-      margin-top: 8px;
-      padding-top: 8px;
-      border-top: 1px solid #c3dfa8;
-    }
-    .quick-entry .inline-row .field {
-      margin-bottom: 8px;
-    }
-    .quick-entry .btn-add {
-      margin-top: 4px;
-    }
     .drill-entry-inline {
       display: flex;
       justify-content: space-between;
@@ -944,17 +933,6 @@
           <span class="value small" id="r_drill_d_rem">—</span>
         </div>
         <div id="r_drill_entries"></div>
-        <div class="quick-entry" id="quick_entry">
-          <div class="inline-row">
-            <div class="field">
-              <input type="text" inputmode="decimal" id="r_qe_einheit" placeholder="Einheiten" oninput="onInputFormat(this, 'decimal')">
-            </div>
-            <div class="field">
-              <input type="text" inputmode="decimal" id="r_qe_duenger" placeholder="kg Dünger" oninput="onInputFormat(this, 'decimal')">
-            </div>
-          </div>
-          <button class="btn-add" onclick="drillQuickAdd()">+ Einfüllen</button>
-        </div>
       </div>
 
       <div class="info" id="r_info"></div>
@@ -1628,29 +1606,6 @@
 
     function drillRemove(tabIdx, entryIdx) {
       state.reiter[tabIdx].entries.splice(entryIdx, 1);
-      sv();
-      renderResults();
-    }
-
-    function drillQuickAdd() {
-      var r = getActiveReiter();
-      if (!r.hektar || !r.koerner) return;
-
-      var einheit = parseDE(document.getElementById('r_qe_einheit').value) || 0;
-      var duenger = parseDE(document.getElementById('r_qe_duenger').value) || 0;
-
-      if (einheit <= 0 && duenger <= 0) return;
-
-      r.entries.push({
-        einheit: einheit,
-        hektar: 0,
-        duenger: duenger,
-        time: new Date().toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' })
-      });
-
-      document.getElementById('r_qe_einheit').value = '';
-      document.getElementById('r_qe_duenger').value = '';
-
       sv();
       renderResults();
     }

--- a/public/index.html
+++ b/public/index.html
@@ -182,6 +182,40 @@
       margin-top: 8px;
     }
 
+    .drill-separator {
+      height: 1px;
+      background: #c3dfa8;
+      margin: 8px 0;
+    }
+    .quick-entry {
+      margin-top: 8px;
+      padding-top: 8px;
+      border-top: 1px solid #c3dfa8;
+    }
+    .quick-entry .inline-row .field {
+      margin-bottom: 8px;
+    }
+    .quick-entry .btn-add {
+      margin-top: 4px;
+    }
+    .drill-entry-inline {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 6px 0;
+      border-bottom: 1px solid #c3dfa8;
+      font-size: 0.85rem;
+    }
+    .drill-entry-inline:last-of-type {
+      border-bottom: none;
+    }
+    .drill-entry-inline .entry-text {
+      color: #444;
+    }
+    .drill-entry-inline .entry-text span {
+      font-weight: 600;
+      color: #2d5016;
+    }
     /* Tabs */
     .tab-bar {
       display: flex;
@@ -890,6 +924,39 @@
         <span class="label">Dünger</span>
         <span class="value small" id="r_duenger">—</span>
       </div>
+
+      <div id="r_drill_section" style="display:none">
+        <div class="drill-separator"></div>
+        <div class="result-row">
+          <span class="label">🔧 Eingefüllt</span>
+          <span class="value small" id="r_drill_e_used">—</span>
+        </div>
+        <div class="result-row" id="r_drill_e_rem_row">
+          <span class="label">Verbleibend</span>
+          <span class="value small" id="r_drill_e_rem">—</span>
+        </div>
+        <div class="result-row" id="r_drill_d_used_row" style="display:none">
+          <span class="label">Dünger eingefüllt</span>
+          <span class="value small" id="r_drill_d_used">—</span>
+        </div>
+        <div class="result-row" id="r_drill_d_rem_row" style="display:none">
+          <span class="label">Dünger verbleibend</span>
+          <span class="value small" id="r_drill_d_rem">—</span>
+        </div>
+        <div id="r_drill_entries"></div>
+        <div class="quick-entry" id="quick_entry">
+          <div class="inline-row">
+            <div class="field">
+              <input type="text" inputmode="decimal" id="r_qe_einheit" placeholder="Einheiten" oninput="onInputFormat(this, 'decimal')">
+            </div>
+            <div class="field">
+              <input type="text" inputmode="decimal" id="r_qe_duenger" placeholder="kg Dünger" oninput="onInputFormat(this, 'decimal')">
+            </div>
+          </div>
+          <button class="btn-add" onclick="drillQuickAdd()">+ Einfüllen</button>
+        </div>
+      </div>
+
       <div class="info" id="r_info"></div>
     </div><!-- end results card -->
 
@@ -1565,6 +1632,29 @@
       renderResults();
     }
 
+    function drillQuickAdd() {
+      var r = getActiveReiter();
+      if (!r.hektar || !r.koerner) return;
+
+      var einheit = parseDE(document.getElementById('r_qe_einheit').value) || 0;
+      var duenger = parseDE(document.getElementById('r_qe_duenger').value) || 0;
+
+      if (einheit <= 0 && duenger <= 0) return;
+
+      r.entries.push({
+        einheit: einheit,
+        hektar: 0,
+        duenger: duenger,
+        time: new Date().toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' })
+      });
+
+      document.getElementById('r_qe_einheit').value = '';
+      document.getElementById('r_qe_duenger').value = '';
+
+      sv();
+      renderResults();
+    }
+
     function renderResults() {
       var r = getActiveReiter();
       var kornerGesamt = getKornerGesamt();
@@ -1593,7 +1683,67 @@
           miniResult.classList.add('mini-result-empty');
         }
       }
-      // --- Drill summary: aggregate across ALL tabs ---
+
+      // --- Per-tab drill info in result card ---
+      var usedEinheit = r.entries.reduce(function(s, e) { return s + e.einheit; }, 0);
+      var usedDuenger = r.entries.reduce(function(s, e) { return s + e.duenger; }, 0);
+      var remEinheit = Math.max(0, einheiten - usedEinheit);
+      var remDuenger = Math.max(0, duengerTotal - usedDuenger);
+      var drillSection = document.getElementById('r_drill_section');
+      if (drillSection) {
+        var showDrill = einheiten > 0;
+        drillSection.style.display = showDrill ? 'block' : 'none';
+        if (showDrill) {
+          document.getElementById('r_drill_e_used').textContent = formatEinheit(usedEinheit);
+          var eRemRow = document.getElementById('r_drill_e_rem_row');
+          var eRemVal = document.getElementById('r_drill_e_rem');
+          eRemVal.textContent = formatEinheit(remEinheit);
+          eRemRow.className = 'result-row ' + (remEinheit <= 0.05 ? 'done' : 'remaining');
+
+          var dUsedRow = document.getElementById('r_drill_d_used_row');
+          var dRemRow = document.getElementById('r_drill_d_rem_row');
+          if (duengerTotal > 0) {
+            dUsedRow.style.display = '';
+            dRemRow.style.display = '';
+            document.getElementById('r_drill_d_used').textContent = fmt(usedDuenger) + ' kg';
+            document.getElementById('r_drill_d_rem').textContent = fmt(remDuenger) + ' kg';
+            dRemRow.className = 'result-row ' + (remDuenger <= 0.05 ? 'done' : 'remaining');
+          } else {
+            dUsedRow.style.display = 'none';
+            dRemRow.style.display = 'none';
+          }
+
+          // Per-tab entries in result card
+          var rEntriesContainer = document.getElementById('r_drill_entries');
+          if (rEntriesContainer) {
+            rEntriesContainer.innerHTML = '';
+            r.entries.forEach(function(e, entryIdx) {
+              var ds = e.duenger > 0 ? e.duenger.toLocaleString('de-DE') + ' kg' : '';
+              var dl = ds ? ' + ' + ds + ' Dünger' : '';
+              var hl = e.hektar > 0 ? ' @ ' + (Math.round(e.hektar * 10) / 10).toFixed(1).replace('.', ',') + ' ha' : '';
+              var entry = document.createElement('div');
+              entry.className = 'drill-entry-inline';
+              var span = document.createElement('span');
+              span.className = 'entry-text';
+              var hash = document.createElement('span');
+              hash.textContent = '#' + (entryIdx + 1);
+              var txt = (e.time ? e.time + ' – ' : '') + hl + (hl ? ', ' : '') + formatEinheit(e.einheit) + dl;
+              var txtNode = document.createTextNode(txt + ' ');
+              span.appendChild(hash);
+              span.appendChild(txtNode);
+              var btn = document.createElement('button');
+              btn.className = 'btn-danger';
+              btn.textContent = '✕';
+              btn.onclick = (function(ti, ei) { return function() { drillRemove(ti, ei); }; })(state.activeReiter, entryIdx);
+              entry.appendChild(span);
+              entry.appendChild(btn);
+              rEntriesContainer.appendChild(entry);
+            });
+          }
+        }
+      }
+
+      // --- Drill summary: aggregate across ALL tabs (Protokoll view) ---
       var allEinheitenTotal = 0, allEinheitenUsed = 0;
       var allDuengerTotal = 0, allDuengerUsed = 0;
       state.reiter.forEach(function(tab) {
@@ -1614,8 +1764,6 @@
       document.getElementById('ds_duenger_total').textContent = allDuengerTotal > 0 ? allDuengerTotal.toLocaleString('de-DE') + ' kg' : '—';
       document.getElementById('ds_duenger_used').textContent = allDuengerUsed > 0 ? allDuengerUsed.toLocaleString('de-DE') + ' kg' : '—';
       document.getElementById('ds_duenger_remaining').textContent = allDuengerTotal > 0 ? allDuengerRem.toLocaleString('de-DE') + ' kg' : '—';
-      var container = document.getElementById('drill_entries');
-      // Check if any tab has entries
       var hasAnyEntries = state.reiter.some(function(r) { return r.entries.length > 0; });
       var hasAnyData = allEinheitenTotal > 0 || allDuengerTotal > 0;
       document.getElementById('drill_summary').style.display = (hasAnyData || hasAnyEntries) ? 'block' : 'none';
@@ -1624,19 +1772,18 @@
       if (allEinheitenUsed > 0) summaryParts.push(formatEinheit(allEinheitenUsed) + ' Einheiten');
       if (allDuengerUsed > 0) summaryParts.push(allDuengerUsed.toLocaleString('de-DE') + ' kg Dünger');
       document.getElementById('ds_total_summary').textContent = summaryParts.join(' + ');
-      // NOTE: drill_section visibility is controlled by renderView() — do NOT set here
+      // Per-tab entries in Protokoll view (global log)
+      var container = document.getElementById('drill_entries');
+      container.innerHTML = '';
       if (!hasAnyEntries) {
-        container.innerHTML = '';
         var empty = document.createElement('div');
         empty.className = 'drill-empty';
         empty.textContent = 'Noch nichts eingefüllt';
         container.appendChild(empty);
       } else {
-        container.innerHTML = '';
         state.reiter.forEach(function(r, tabIdx) {
           if (r.entries.length === 0) return;
 
-          // Tab header
           var tabHeader = document.createElement('div');
           tabHeader.className = 'drill-entry-tab-header';
           tabHeader.textContent = r.name || ('Tab ' + (tabIdx + 1));

--- a/public/index.html
+++ b/public/index.html
@@ -188,7 +188,6 @@
       gap: 6px;
       margin-bottom: 12px;
       flex-wrap: wrap;
-      min-height: 36px;
       align-items: center;
     }
     .tab-btn {
@@ -198,98 +197,89 @@
       background: #e8f0de;
       border: 2px solid #c3dfa8;
       border-radius: 8px;
-      padding: 6px 8px;
+      padding: 0;
       font-size: 0.8rem;
       cursor: pointer;
-      transition: background 0.15s;
-      max-width: 120px;
+      transition: background 0.15s, border-color 0.15s;
+      max-width: 130px;
+      min-height: 48px;
+      /* Ensure tap area covers entire button */
+      position: relative;
     }
     .tab-btn.field-tab.active {
       background: #4a7c23;
-      border-color: #4a7c23;
+      border: 3px solid #2d5016;
+      box-shadow: 0 0 0 1px #4a7c23 inset;
       color: white;
     }
     .tab-btn.field-tab:not(.active):hover {
       background: #d0e8b8;
     }
-    .protokoll-tab {
-      display: flex;
-      align-items: center;
-      gap: 4px;
-      background: #fff3cd;
-      border: 2px solid #f0c929;
-      border-radius: 8px;
-      padding: 6px 8px;
-      font-size: 0.8rem;
-      cursor: pointer;
-      transition: background 0.15s;
-    }
-    .protokoll-tab.active {
-      background: #e67700;
-      border-color: #e67700;
-      color: white;
-    }
-    .protokoll-tab:hover:not(.active) {
-      background: #ffe066;
-    }
     .tab-name-input {
       background: transparent;
       border: none;
       font-size: 0.8rem;
+      font-weight: 600;
       color: inherit;
-      width: 70px;
-      max-width: 70px;
-      padding: 0;
+      width: 52px;
+      max-width: 52px;
+      padding: 14px 4px 14px 10px;
       outline: none;
-      pointer-events: none;
+      pointer-events: auto;
+      cursor: pointer;
+      min-height: 48px;
     }
     .tab-name-input:focus {
-      pointer-events: auto;
+      cursor: text;
+      background: rgba(255,255,255,0.15);
+    }
+    .tab-btn:not(.active) .tab-name-input:focus {
+      background: #f0f4e8;
     }
     .tab-btn.active .tab-name-input {
       color: white;
     }
-    .tab-name-input:focus {
-      border-bottom: 1px solid currentColor;
-    }
+    /* Remove the separate .tab-edit stift icon — tap input directly to edit */
     .tab-close {
       background: none;
       border: none;
-      font-size: 0.9rem;
       cursor: pointer;
       color: inherit;
-      padding: 0;
-      line-height: 1;
       opacity: 0.6;
       flex-shrink: 0;
+      /* Ensure min 44x44px touch target */
+      width: 44px;
+      height: 44px;
+      min-width: 44px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 8px;
+      font-size: 1rem;
+      transition: opacity 0.15s, background 0.15s;
+      margin: 2px;
     }
     .tab-close:hover {
       opacity: 1;
     }
-    .tab-edit {
-      background: none;
-      border: none;
-      font-size: 0.75rem;
-      cursor: pointer;
-      color: inherit;
-      padding: 0;
-      line-height: 1;
-      opacity: 0.5;
-      flex-shrink: 0;
-    }
-    .tab-edit:hover {
+    .tab-close:active {
+      background: rgba(0,0,0,0.1);
       opacity: 1;
     }
     .tab-add {
       background: #e8f0de;
       border: 2px dashed #b8d4a0;
       border-radius: 8px;
-      padding: 6px 12px;
+      padding: 0 12px;
       font-size: 0.8rem;
       font-weight: 600;
       color: #4a7c23;
       cursor: pointer;
       flex-shrink: 0;
+      min-height: 48px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
     .tab-add:active {
       background: #d0e8b8;
@@ -298,7 +288,6 @@
       display: flex;
       gap: 6px;
       flex-wrap: wrap;
-      min-height: 36px;
       align-items: center;
       flex: 1;
     }
@@ -975,23 +964,12 @@
             else { evt.stopPropagation(); }
           };
 
-          var edit = document.createElement('span');
-          edit.className = 'tab-edit';
-          edit.textContent = '✏️';
-          edit.setAttribute('aria-label', 'Umbenennen');
-          edit.onclick = function(evt) {
-            evt.stopPropagation();
-            input.focus();
-            input.select();
-          };
-
           var close = document.createElement('span');
           close.className = 'tab-close';
           close.setAttribute('onclick', 'event.stopPropagation(); confirmRemoveReiter(' + i + ')');
           close.textContent = '✕';
 
           btn.appendChild(input);
-          btn.appendChild(edit);
           btn.appendChild(close);
           bar.appendChild(btn);
         });

--- a/public/index.html
+++ b/public/index.html
@@ -1982,7 +1982,7 @@
       document.getElementById('drill_summary').style.display = (hasAnyData || hasAnyEntries) ? 'block' : 'none';
       // Build total summary text
       var summaryParts = [];
-      if (allEinheitenUsed > 0) summaryParts.push(formatEinheit(allEinheitenUsed) + ' Einheiten');
+      if (allEinheitenUsed > 0) summaryParts.push(formatEinheit(allEinheitenUsed));
       if (allDuengerUsed > 0) summaryParts.push(allDuengerUsed.toLocaleString('de-DE') + ' kg Dünger');
       document.getElementById('ds_total_summary').textContent = summaryParts.join(' + ');
       // Machine log (raw fills into machine, independent of tab distribution)

--- a/public/index.html
+++ b/public/index.html
@@ -1633,6 +1633,13 @@
       renderResults();
     }
 
+    function drillMachineRemove(idx) {
+      if (!state.machineLog || idx < 0 || idx >= state.machineLog.length) return;
+      state.machineLog.splice(idx, 1);
+      sv();
+      renderResults();
+    }
+
     function drillRemove(tabIdx, entryIdx) {
       state.reiter[tabIdx].entries.splice(entryIdx, 1);
       sv();
@@ -1779,6 +1786,11 @@
           span.appendChild(hash);
           span.appendChild(txtNode);
           row.appendChild(span);
+          var btn = document.createElement('button');
+          btn.className = 'btn-danger';
+          btn.textContent = '✕';
+          btn.onclick = (function(idx) { return function() { drillMachineRemove(idx); }; })(mi);
+          row.appendChild(btn);
           mlContainer.appendChild(row);
         });
       }

--- a/public/index.html
+++ b/public/index.html
@@ -951,6 +951,10 @@
             <input type="text" inputmode="decimal" id="drill_duenger" placeholder="z.B. 200" oninput="drillCalcAll(); onInputFormat(this, 'decimal')">
           </div>
         </div>
+        <div class="field">
+          <label for="drill_hektar">Hektar-Zählerstand</label>
+          <input type="text" inputmode="decimal" id="drill_hektar" placeholder="z.B. 5,2" oninput="onInputFormat(this, 'decimal')">
+        </div>
         <div class="drill-tabs-section">
           <div class="drill-tabs-header">Aufteilen auf (Klick = Prio: 1 → 2 → 3 → aus):</div>
           <div id="drill_tab_list"></div>
@@ -1541,6 +1545,7 @@
     function drillAdd() {
       var gesamtEinheit = parseDE(document.getElementById('drill_einheit').value) || 0;
       var gesamtDuenger = parseDE(document.getElementById('drill_duenger').value) || 0;
+      var hektarStand = parseDE(document.getElementById('drill_hektar').value) || 0;
 
       // If no tab list rendered (e.g. in tests), fall back to single-tab mode
       var hasTabList = document.getElementById('dtl_prio_0') !== null;
@@ -1552,7 +1557,7 @@
         if (gesamtEinheit <= 0 && gesamtDuenger <= 0) return;
         r.entries.push({
           einheit: gesamtEinheit,
-          hektar: 0,
+          hektar: hektarStand,
           duenger: gesamtDuenger,
           time: new Date().toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' })
         });
@@ -1576,7 +1581,7 @@
         if (einheit > 0 || duenger > 0) {
           r.entries.push({
             einheit: einheit,
-            hektar: 0,
+            hektar: hektarStand,
             duenger: duenger,
             time: new Date().toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' })
           });
@@ -1589,6 +1594,7 @@
       // Clear inputs
       document.getElementById('drill_einheit').value = '';
       document.getElementById('drill_duenger').value = '';
+      document.getElementById('drill_hektar').value = '';
       state.reiter.forEach(function(r, i) {
         var eInput = document.getElementById('dtl_e_' + i);
         var dInput = document.getElementById('dtl_d_' + i);

--- a/public/index.html
+++ b/public/index.html
@@ -1993,6 +1993,16 @@
         mlTitle.className = 'drill-entry-tab-header';
         mlTitle.textContent = 'Maschinen-Protokoll';
         mlContainer.appendChild(mlTitle);
+        // Verbrauchsraten einmal berechnen
+        var fgFactor = 1;
+        if (state.fahrgassenEnabled && state.fahrgassenBreite > 0) {
+          fgFactor = (state.fahrgassenBreite - 1) / state.fahrgassenBreite;
+        }
+        var unitsPerHa = r.koerner * fgFactor / state.koernerProEinheit;
+        var duengerPerHa = r.duenger || 0;
+        // Kumulativ: Restmenge im Tank + neu eingefuellt
+        var cumEinheit = 0, cumDuenger = 0;
+
         state.machineLog.forEach(function(m, mi) {
           var ds = m.duenger > 0 ? m.duenger.toLocaleString('de-DE') + ' kg' : '';
           var dl = ds ? ' + ' + ds + ' Dünger' : '';
@@ -2015,22 +2025,24 @@
           row.appendChild(btn);
           mlContainer.appendChild(row);
 
-          // Prognose: bei welchem ha-Zaehlerstand ist Saat/Duenger leer?
-          if (r.koerner > 0 && (m.einheit > 0 || m.duenger > 0)) {
-            var fgFactor = 1;
-            if (state.fahrgassenEnabled && state.fahrgassenBreite > 0) {
-              fgFactor = (state.fahrgassenBreite - 1) / state.fahrgassenBreite;
+          // Prognose: Rest aus vorheriger Befuellung + neu eingefuellt
+          if (r.koerner > 0 && (m.einheit > 0 || m.duenger > 0 || cumEinheit > 0 || cumDuenger > 0)) {
+            if (mi === 0) {
+              cumEinheit = m.einheit;
+              cumDuenger = m.duenger;
+            } else {
+              var prevM = state.machineLog[mi - 1];
+              var haDriven = Math.max(0, (m.hektar || 0) - (prevM.hektar || 0));
+              cumEinheit = Math.max(0, cumEinheit - haDriven * unitsPerHa) + m.einheit;
+              cumDuenger = Math.max(0, cumDuenger - haDriven * duengerPerHa) + m.duenger;
             }
-            var unitsPerHa = r.koerner * fgFactor / state.koernerProEinheit;
             var prognoseParts = [];
-            if (m.einheit > 0 && unitsPerHa > 0) {
-              var haSaat = m.einheit / unitsPerHa;
-              var prognoseSaat = (m.hektar || 0) + haSaat;
+            if (cumEinheit > 0 && unitsPerHa > 0) {
+              var prognoseSaat = (m.hektar || 0) + cumEinheit / unitsPerHa;
               prognoseParts.push('<span><span class="prog-label">Saat leer bei</span> <span class="prog-val">~' + fmt(prognoseSaat) + ' ha</span></span>');
             }
-            if (m.duenger > 0 && r.duenger > 0) {
-              var haDuenger = m.duenger / r.duenger;
-              var prognoseDuenger = (m.hektar || 0) + haDuenger;
+            if (cumDuenger > 0 && duengerPerHa > 0) {
+              var prognoseDuenger = (m.hektar || 0) + cumDuenger / duengerPerHa;
               prognoseParts.push('<span><span class="prog-label">Dünger leer bei</span> <span class="prog-val">~' + fmt(prognoseDuenger) + ' ha</span></span>');
             }
             if (prognoseParts.length > 0) {

--- a/public/index.html
+++ b/public/index.html
@@ -402,6 +402,13 @@
       margin-top: 8px;
       text-align: center;
     }
+    .version-footer {
+      text-align: center;
+      color: #888;
+      font-size: 0.75rem;
+      margin-top: 24px;
+      padding-bottom: 8px;
+    }
   </style>
 </head>
 <body>
@@ -983,5 +990,6 @@ function fahrgassenUpdate() {
 
     document.addEventListener('DOMContentLoaded', initUI);
   </script>
+  <div class="version-footer">v0.0.1</div>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -648,9 +648,6 @@
       <div class="tab-bar-left" id="tab_bar_left"><button class="tab-add" onclick="addReiter()">+ Tab</button></div>
       <div class="tab-separator"></div>
       <button class="protokoll-tab" id="protokoll_tab_btn" onclick="switchToProtokoll()">🔧 Protokoll</button>
-      <div class="tab-separator"></div>
-      <button class="btn" onclick="berechne()" id="berechnen_btn">Berechnen</button>
-      <button class="btn btn-secondary" onclick="confirmResetAll()" id="reset_btn">Zurücksetzen</button>
     </div>
 
     <div class="card card-input" id="card_input">
@@ -701,6 +698,9 @@
         <div class="fahrgassen-info">Die Körnerzahl wird um ca. 1/Fahrgassenbreite × 100 % reduziert.</div>
       </div>
     </div>
+
+    <button class="btn" onclick="berechne()" id="berechnen_btn">Berechnen</button>
+    <button class="btn btn-secondary" onclick="confirmResetAll()" id="reset_btn">Zurücksetzen</button>
 
     <div class="card result" id="results" style="display:none">
       <h2>📊 Ergebnis</h2>

--- a/public/index.html
+++ b/public/index.html
@@ -356,6 +356,11 @@
       align-items: center;
       padding: 10px 0;
     }
+    #drill_machine_log {
+      margin-bottom: 12px;
+      padding-bottom: 8px;
+      border-bottom: 2px solid #c8dcc0;
+    }
     .drill-entry-tab-header {
       font-size: 13px;
       font-weight: bold;
@@ -988,6 +993,7 @@
           <span id="ds_duenger_remaining">—</span>
         </div>
       </div>
+      <div id="drill_machine_log"></div>
       <div id="drill_entries"></div>
     </div>
 
@@ -1018,7 +1024,8 @@
       fahrgassenEnabled: false,
       fahrgassenBreite: 0,
       einheitGroesseEnabled: false,
-      koernerProEinheit: 50000
+      koernerProEinheit: 50000,
+      machineLog: []
     };
 
     // --- Storage ---
@@ -1058,6 +1065,8 @@
               if (!reiter.entries) reiter.entries = [];
             });
           }
+          // Ensure machineLog exists (migration from older state)
+          if (!parsed.machineLog) parsed.machineLog = [];
           state = parsed;
         }
       } catch(e) {}
@@ -1555,6 +1564,13 @@
         var r = getActiveReiter();
         if (!r.hektar || !r.koerner) return;
         if (gesamtEinheit <= 0 && gesamtDuenger <= 0) return;
+        // Log machine fill
+        state.machineLog.push({
+          einheit: gesamtEinheit,
+          hektar: hektarStand,
+          duenger: gesamtDuenger,
+          time: new Date().toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' })
+        });
         r.entries.push({
           einheit: gesamtEinheit,
           hektar: hektarStand,
@@ -1569,6 +1585,13 @@
       }
 
       var addedAny = false;
+      // Log machine fill first
+      state.machineLog.push({
+        einheit: gesamtEinheit,
+        hektar: hektarStand,
+        duenger: gesamtDuenger,
+        time: new Date().toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' })
+      });
       state.reiter.forEach(function(r, i) {
         var prio = drillPriorities[i] || 0;
         if (prio <= 0) return;
@@ -1733,6 +1756,32 @@
       if (allEinheitenUsed > 0) summaryParts.push(formatEinheit(allEinheitenUsed) + ' Einheiten');
       if (allDuengerUsed > 0) summaryParts.push(allDuengerUsed.toLocaleString('de-DE') + ' kg Dünger');
       document.getElementById('ds_total_summary').textContent = summaryParts.join(' + ');
+      // Machine log (raw fills into machine, independent of tab distribution)
+      var mlContainer = document.getElementById('drill_machine_log');
+      mlContainer.innerHTML = '';
+      if (state.machineLog && state.machineLog.length > 0) {
+        var mlTitle = document.createElement('div');
+        mlTitle.className = 'drill-entry-tab-header';
+        mlTitle.textContent = 'Maschinen-Protokoll';
+        mlContainer.appendChild(mlTitle);
+        state.machineLog.forEach(function(m, mi) {
+          var ds = m.duenger > 0 ? m.duenger.toLocaleString('de-DE') + ' kg' : '';
+          var dl = ds ? ' + ' + ds + ' Dünger' : '';
+          var hl = m.hektar > 0 ? ' @ ' + (Math.round(m.hektar * 10) / 10).toFixed(1).replace('.', ',') + ' ha' : '';
+          var row = document.createElement('div');
+          row.className = 'drill-entry';
+          var span = document.createElement('span');
+          span.className = 'entry-text';
+          var hash = document.createElement('span');
+          hash.textContent = '#' + (mi + 1);
+          var txt = (m.time ? m.time + ' – ' : '') + hl + (hl ? ', ' : '') + formatEinheit(m.einheit) + dl;
+          var txtNode = document.createTextNode(txt + ' ');
+          span.appendChild(hash);
+          span.appendChild(txtNode);
+          row.appendChild(span);
+          mlContainer.appendChild(row);
+        });
+      }
       // Per-tab entries in Protokoll view (global log)
       var container = document.getElementById('drill_entries');
       container.innerHTML = '';
@@ -1794,7 +1843,8 @@
         fahrgassenEnabled: false,
         fahrgassenBreite: 0,
         einheitGroesseEnabled: false,
-        koernerProEinheit: 50000
+        koernerProEinheit: 50000,
+        machineLog: []
       };
       document.getElementById('hektar').value = '';
       document.getElementById('koerner').value = '';

--- a/public/index.html
+++ b/public/index.html
@@ -970,7 +970,7 @@
       if (results) results.style.display = (hasData && !isProtokoll) ? 'block' : 'none';
 
       var drillSection = document.getElementById('drill_section');
-      if (drillSection) drillSection.style.display = (hasData && !isProtokoll) ? 'block' : 'none';
+      if (drillSection) drillSection.style.display = isProtokoll ? 'block' : 'none';
 
       var drillMask = document.getElementById('drill_mask');
       if (drillMask) drillMask.style.display = isProtokoll ? '' : 'none';

--- a/public/index.html
+++ b/public/index.html
@@ -1102,6 +1102,7 @@
       syncInputsFromState();
       renderTabs();
       sv();
+      renderResults();
       renderView();
     }
 

--- a/public/index.html
+++ b/public/index.html
@@ -1249,6 +1249,9 @@
       duengerEl.value = '';
       sv();
       renderResults();
+      // Ensure drill_section is visible when there are entries
+      var drillSection = document.getElementById('drill_section');
+      if (drillSection) drillSection.style.display = 'block';
     }
 
     function drillRemove(idx) {

--- a/public/index.html
+++ b/public/index.html
@@ -465,6 +465,10 @@
       color: #999;
       margin-top: 1px;
     }
+    .drill-tab-row .drill-tab-need.done {
+      color: #4a7c23;
+      font-weight: 600;
+    }
     .drill-tab-row .drill-tab-values {
       display: flex;
       gap: 6px;
@@ -1388,15 +1392,27 @@
         label.className = 'drill-tab-name';
         label.textContent = r.name || ('Tab ' + (i + 1));
         nameWrap.appendChild(label);
-        // Show remaining need
+        // Show remaining need or done status
         if (r.hektar > 0 && r.koerner > 0) {
           var totalE = getTabTotalEinheiten(r);
           var usedE = r.entries.reduce(function(s, e) { return s + e.einheit; }, 0);
           var remE = Math.max(0, totalE - usedE);
+          var totalD = getTabTotalDuenger(r);
+          var usedD = r.entries.reduce(function(s, e) { return s + e.duenger; }, 0);
+          var remD = Math.max(0, totalD - usedD);
           var needDiv = document.createElement('div');
           needDiv.className = 'drill-tab-need';
           needDiv.id = 'dtl_need_' + i;
-          needDiv.textContent = 'braucht ' + fmt(remE) + ' Einheiten';
+          var saatDone = remE <= 0.05;
+          var duengerDone = totalD <= 0 || remD <= 0.05;
+          if (saatDone && duengerDone) {
+            needDiv.classList.add('done');
+            needDiv.textContent = '✓ fertig';
+          } else {
+            var text = 'braucht ' + fmt(remE) + ' Einheiten';
+            if (totalD > 0 && remD > 0.05) text += ', ' + fmt(remD) + ' kg Dünger';
+            needDiv.textContent = text;
+          }
           nameWrap.appendChild(needDiv);
         }
 

--- a/public/index.html
+++ b/public/index.html
@@ -204,13 +204,33 @@
       transition: background 0.15s;
       max-width: 120px;
     }
-    .tab-btn.active {
+    .tab-btn.field-tab.active {
       background: #4a7c23;
       border-color: #4a7c23;
       color: white;
     }
-    .tab-btn:not(.active):hover {
+    .tab-btn.field-tab:not(.active):hover {
       background: #d0e8b8;
+    }
+    .protokoll-tab {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      background: #fff3cd;
+      border: 2px solid #f0c929;
+      border-radius: 8px;
+      padding: 6px 8px;
+      font-size: 0.8rem;
+      cursor: pointer;
+      transition: background 0.15s;
+    }
+    .protokoll-tab.active {
+      background: #e67700;
+      border-color: #e67700;
+      color: white;
+    }
+    .protokoll-tab:hover:not(.active) {
+      background: #ffe066;
     }
     .tab-name-input {
       background: transparent;
@@ -273,6 +293,48 @@
     }
     .tab-add:active {
       background: #d0e8b8;
+    }
+    .tab-bar-left {
+      display: flex;
+      gap: 6px;
+      flex-wrap: wrap;
+      min-height: 36px;
+      align-items: center;
+      flex: 1;
+    }
+    .tab-separator {
+      width: 1px;
+      height: 24px;
+      background: #c3dfa8;
+      margin: 0 4px;
+      flex-shrink: 0;
+    }
+    .tab-btn.protokoll-tab {
+      background: #e8f4dc;
+      border: 2px solid #4a7c23;
+      color: #2d5016;
+      flex-shrink: 0;
+    }
+    .tab-btn.protokoll-tab.active {
+      background: #4a7c23;
+      border-color: #4a7c23;
+      color: white;
+    }
+    .tab-btn.protokoll-tab:not(.active):hover {
+      background: #d0e8b8;
+    }
+    .tab-bar {
+      display: flex;
+      gap: 0;
+      margin-bottom: 12px;
+      align-items: center;
+    }
+    .tab-bar > .tab-bar-left {
+      display: flex;
+      gap: 6px;
+      flex-wrap: wrap;
+      min-height: 36px;
+      align-items: center;
     }
 
     /* Drill log */
@@ -582,7 +644,11 @@
     </div>
 
     <!-- Tabs -->
-    <div class="tab-bar" id="tab_bar"><button class="tab-add" onclick="addReiter()">+ Tab</button></div>
+    <div class="tab-bar" id="tab_bar">
+      <div class="tab-bar-left" id="tab_bar_left"><button class="tab-add" onclick="addReiter()">+ Tab</button></div>
+      <div class="tab-separator"></div>
+      <button class="protokoll-tab" id="protokoll_tab_btn" onclick="switchToProtokoll()">🔧 Protokoll</button>
+    </div>
 
     <div class="card">
       <h2>📐 Fläche & Aussaatstärke</h2>
@@ -706,6 +772,7 @@
     var state = {
       reiter: [{ name: 'Tab 1', hektar: 0, koerner: 0, duenger: 0, entries: [] }],
       activeReiter: 0,
+      activeView: null, // null='field', 'protokoll'
       fahrgassenEnabled: false,
       fahrgassenBreite: 0,
       einheitGroesseEnabled: false,
@@ -781,13 +848,13 @@
 
     // --- Tab management ---
     function renderTabs() {
-      var bar = document.getElementById('tab_bar');
+      var bar = document.getElementById('tab_bar_left');
       bar.innerHTML = '';
       if (state.reiter.length > 1) {
         state.reiter.forEach(function(r, i) {
-          var isActive = i === state.activeReiter;
+          var isActive = i === state.activeReiter && state.activeView !== 'protokoll';
           var btn = document.createElement('button');
-          btn.className = 'tab-btn' + (isActive ? ' active' : '');
+          btn.className = 'tab-btn field-tab' + (isActive ? ' active' : '');
           btn.setAttribute('aria-label', 'Tab ' + (i+1));
           btn.onclick = function() { switchReiter(i); };
 
@@ -830,6 +897,10 @@
       addBtn.textContent = '+ Tab';
       addBtn.onclick = function() { addReiter(); };
       bar.appendChild(addBtn);
+
+      // Protokoll tab button
+      var protokollBtn = document.getElementById('protokoll_tab_btn');
+      protokollBtn.classList.toggle('active', state.activeView === 'protokoll');
     }
 
     function addReiter() {
@@ -861,20 +932,43 @@
     }
 
     function switchReiter(idx) {
-      if (idx === state.activeReiter) return;
+      if (idx === state.activeReiter && state.activeView !== 'protokoll') return;
       syncStateFromInputs();
       state.activeReiter = idx;
+      state.activeView = null;
       syncInputsFromState();
       renderTabs();
       sv();
-      var r = getActiveReiter();
-      if (r.hektar > 0 && r.koerner > 0) {
-        renderResults();
-        document.getElementById('results').style.display = 'block';
+      renderView();
+    }
+
+    function switchToProtokoll() {
+      if (state.activeView === 'protokoll') {
+        state.activeView = null;
       } else {
-        document.getElementById('results').style.display = 'none';
-        document.getElementById('drill_section').style.display = 'none';
+        syncStateFromInputs();
+        state.activeView = 'protokoll';
       }
+      renderTabs();
+      sv();
+      renderView();
+    }
+
+    function renderView() {
+      var r = getActiveReiter();
+      var hasData = r.hektar > 0 && r.koerner > 0;
+      var isProtokoll = state.activeView === 'protokoll';
+
+      var cards = document.querySelectorAll('.card');
+      cards.forEach(function(c) {
+        c.style.display = isProtokoll ? 'none' : '';
+      });
+
+      var results = document.getElementById('results');
+      if (results) results.style.display = (hasData && !isProtokoll) ? 'block' : 'none';
+
+      var drillSection = document.getElementById('drill_section');
+      if (drillSection) drillSection.style.display = (hasData && !isProtokoll) ? 'block' : 'none';
     }
 
     function renameReiter(idx, name) {
@@ -1152,6 +1246,7 @@
       state = {
         reiter: [{ name: 'Tab 1', hektar: 0, koerner: 0, duenger: 0, entries: [] }],
         activeReiter: 0,
+        activeView: null,
         fahrgassenEnabled: false,
         fahrgassenBreite: 0,
         einheitGroesseEnabled: false,
@@ -1204,7 +1299,9 @@
       var r = getActiveReiter();
       if (r.hektar > 0 && r.koerner > 0) {
         renderResults();
-        document.getElementById('results').style.display = 'block';
+        if (state.activeView !== 'protokoll') {
+          document.getElementById('results').style.display = 'block';
+        }
       }
     }
 

--- a/public/index.html
+++ b/public/index.html
@@ -1717,7 +1717,7 @@
               var span = document.createElement('span');
               span.className = 'entry-text';
               var hash = document.createElement('span');
-              hash.textContent = '#' + (entryIdx + 1);
+              hash.textContent = '#' + (entryIdx + 1) + ' ';
               var txt = (e.time ? e.time + ' – ' : '') + hl + (hl ? ', ' : '') + formatEinheit(e.einheit) + dl;
               var txtNode = document.createTextNode(txt + ' ');
               span.appendChild(hash);
@@ -1780,7 +1780,7 @@
           var span = document.createElement('span');
           span.className = 'entry-text';
           var hash = document.createElement('span');
-          hash.textContent = '#' + (mi + 1);
+          hash.textContent = '#' + (mi + 1) + ' ';
           var txt = (m.time ? m.time + ' – ' : '') + hl + (hl ? ', ' : '') + formatEinheit(m.einheit) + dl;
           var txtNode = document.createTextNode(txt + ' ');
           span.appendChild(hash);
@@ -1822,7 +1822,7 @@
             var span = document.createElement('span');
             span.className = 'entry-text';
             var hash = document.createElement('span');
-            hash.textContent = '#' + (entryIdx + 1);
+            hash.textContent = '#' + (entryIdx + 1) + ' ';
             var txt = (e.time ? e.time + ' – ' : '') + hl + (hl ? ', ' : '') + formatEinheit(e.einheit) + dl;
             var txtNode = document.createTextNode(txt + ' ');
             span.appendChild(hash);

--- a/public/index.html
+++ b/public/index.html
@@ -648,9 +648,12 @@
       <div class="tab-bar-left" id="tab_bar_left"><button class="tab-add" onclick="addReiter()">+ Tab</button></div>
       <div class="tab-separator"></div>
       <button class="protokoll-tab" id="protokoll_tab_btn" onclick="switchToProtokoll()">🔧 Protokoll</button>
+      <div class="tab-separator"></div>
+      <button class="btn" onclick="berechne()" id="berechnen_btn">Berechnen</button>
+      <button class="btn btn-secondary" onclick="confirmResetAll()" id="reset_btn">Zurücksetzen</button>
     </div>
 
-    <div class="card">
+    <div class="card card-input" id="card_input">
       <h2>📐 Fläche & Aussaatstärke</h2>
       <div class="field">
         <label for="hektar">Hektar</label>
@@ -699,9 +702,6 @@
       </div>
     </div>
 
-    <button class="btn" onclick="berechne()">Berechnen</button>
-    <button class="btn btn-secondary" onclick="confirmResetAll()">Zurücksetzen</button>
-
     <div class="card result" id="results" style="display:none">
       <h2>📊 Ergebnis</h2>
       <div class="result-row">
@@ -721,21 +721,23 @@
 
     <div class="card" id="drill_section" style="display:none">
       <h2>🔧 Drill-Protokoll</h2>
-      <div class="inline-row">
-        <div class="field">
-          <label for="drill_einheit">Einheiten eingefüllt</label>
-          <input type="text" inputmode="decimal" id="drill_einheit" placeholder="z.B. 1,5" oninput="onInputFormat(this, 'decimal')">
+      <div id="drill_mask">
+        <div class="inline-row">
+          <div class="field">
+            <label for="drill_einheit">Einheiten eingefüllt</label>
+            <input type="text" inputmode="decimal" id="drill_einheit" placeholder="z.B. 1,5" oninput="onInputFormat(this, 'decimal')">
+          </div>
+          <div class="field">
+            <label for="drill_hektar">Hektar-Zähler</label>
+            <input type="text" inputmode="decimal" id="drill_hektar" placeholder="z.B. 5,2" oninput="onInputFormat(this, 'decimal')">
+          </div>
         </div>
         <div class="field">
-          <label for="drill_hektar">Hektar-Zähler</label>
-          <input type="text" inputmode="decimal" id="drill_hektar" placeholder="z.B. 5,2" oninput="onInputFormat(this, 'decimal')">
+          <label for="drill_duenger">Dünger (kg)</label>
+          <input type="text" inputmode="decimal" id="drill_duenger" placeholder="z.B. 500" oninput="onInputFormat(this, 'decimal')">
         </div>
+        <button class="btn-add" onclick="drillAdd()">+ Einfüllen</button>
       </div>
-      <div class="field">
-        <label for="drill_duenger">Dünger (kg)</label>
-        <input type="text" inputmode="decimal" id="drill_duenger" placeholder="z.B. 500" oninput="onInputFormat(this, 'decimal')">
-      </div>
-      <button class="btn-add" onclick="drillAdd()">+ Einfüllen</button>
 
       <div class="drill-summary" id="drill_summary" style="display:none">
         <div class="drill-summary-row">
@@ -969,6 +971,14 @@
 
       var drillSection = document.getElementById('drill_section');
       if (drillSection) drillSection.style.display = (hasData && !isProtokoll) ? 'block' : 'none';
+
+      var drillMask = document.getElementById('drill_mask');
+      if (drillMask) drillMask.style.display = isProtokoll ? '' : 'none';
+
+      var berechnenBtn = document.getElementById('berechnen_btn');
+      if (berechnenBtn) berechnenBtn.style.display = isProtokoll ? 'none' : '';
+      var resetBtn = document.getElementById('reset_btn');
+      if (resetBtn) resetBtn.style.display = isProtokoll ? 'none' : '';
     }
 
     function renameReiter(idx, name) {
@@ -1278,6 +1288,7 @@
       lv();
       syncInputsFromState();
       renderTabs();
+      renderView();
       if (state.fahrgassenEnabled) {
         document.getElementById('fahrgassen_toggle').classList.add('active');
         document.getElementById('fahrgassen_settings').classList.add('open');

--- a/public/index.html
+++ b/public/index.html
@@ -792,7 +792,7 @@
         <span class="value small" id="r_duenger">—</span>
       </div>
       <div class="info" id="r_info"></div>
-    </div>
+    </div><!-- end results card -->
 
     <div class="card" id="drill_section" style="display:none">
       <h2>🔧 Drill-Protokoll</h2>
@@ -813,8 +813,7 @@
         </div>
         <button class="btn-add" onclick="drillAdd()">+ Einfüllen</button>
       </div>
-
-      <div class="drill-summary" id="drill_summary" style="display:none">
+      <div id="drill_summary" class="drill-summary" style="display:none">
         <div class="drill-summary-row">
           <span>Einheiten gesamt</span>
           <span id="ds_saat_total">—</span>
@@ -842,6 +841,7 @@
       </div>
       <div id="drill_entries"></div>
     </div>
+
     </div><!-- end .container -->
 
     <!-- Sticky footer -->
@@ -1157,6 +1157,7 @@
       sv();
       renderTabs();
       renderResults();
+      renderView();
       document.getElementById('results').style.display = 'block';
     }
 
@@ -1307,7 +1308,7 @@
       document.getElementById('ds_duenger_remaining').textContent = duengerTotal > 0 ? remDuenger.toLocaleString('de-DE') + ' kg' + haDuengerRemText : '—';
       var container = document.getElementById('drill_entries');
       document.getElementById('drill_summary').style.display = (einheiten > 0 || duengerTotal > 0 || r.entries.length > 0) ? 'block' : 'none';
-      document.getElementById('drill_section').style.display = 'block';
+      // NOTE: drill_section visibility is controlled by renderView() — do NOT set here
       if (r.entries.length === 0) {
         container.innerHTML = '';
         var empty = document.createElement('div');

--- a/public/index.html
+++ b/public/index.html
@@ -2104,9 +2104,34 @@
     function confirmResetAll() {
       var tabName = state.reiter[state.activeReiter].name;
       if (!confirm('Wirklich zurücksetzen?\n\nAlle Eingaben für "' + tabName + '" werden gelöscht.')) return;
-      resetAll();
+      resetActiveTab();
     }
 
+    // Reset only the active tab's data (preserves other tabs, global settings, machineLog)
+    function resetActiveTab() {
+      var active = state.activeReiter;
+      state.reiter[active] = {
+        name: state.reiter[active].name,
+        hektar: 0,
+        koerner: 0,
+        duenger: 0,
+        entries: []
+      };
+      document.getElementById('hektar').value = '';
+      document.getElementById('koerner').value = '';
+      document.getElementById('duenger').value = '';
+      document.getElementById('err_hektar').textContent = '';
+      document.getElementById('err_koerner').textContent = '';
+      document.getElementById('hektar').style.borderColor = '';
+      document.getElementById('koerner').style.borderColor = '';
+      document.getElementById('results').style.display = 'none';
+      document.getElementById('drill_section').style.display = 'none';
+      syncInputsFromState();
+      renderTabs();
+      sv();
+    }
+
+    // Full reset - clears everything (used for extreme cases, not via UI button)
     function resetAll() {
       state = {
         reiter: [{ name: 'Tab 1', hektar: 0, koerner: 0, duenger: 0, entries: [] }],

--- a/public/index.html
+++ b/public/index.html
@@ -480,11 +480,60 @@
       margin-top: 8px;
       text-align: center;
     }
+    /* Sticky footer */
+    .app-layout {
+      display: flex;
+      flex-direction: column;
+      min-height: calc(100vh - max(20px, env(safe-area-inset-top)) - max(20px, env(safe-area-inset-bottom)));
+    }
+    .scrollable-content {
+      flex: 1;
+      overflow-y: auto;
+      -webkit-overflow-scrolling: touch;
+    }
+    .sticky-footer {
+      position: sticky;
+      top: 100%;
+      background: white;
+      border-top: 2px solid #e8f0de;
+      padding: 12px 0 max(12px, env(safe-area-inset-bottom));
+      box-shadow: 0 -2px 8px rgba(0,0,0,0.08);
+      z-index: 10;
+    }
+    .mini-result {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      font-size: 0.9rem;
+      color: #2d5016;
+      font-weight: 600;
+      padding: 0 4px 8px;
+      min-height: 28px;
+    }
+    .mini-result-empty {
+      color: #aaa;
+      font-weight: 400;
+    }
+    .mini-result .mr-einheiten { color: #2d5016; }
+    .mini-result .mr-duenger { color: #4a7c23; font-size: 0.85rem; }
+    .footer-btn-row {
+      display: flex;
+      gap: 8px;
+    }
+    .footer-btn-row .btn {
+      flex: 1;
+    }
+    .footer-btn-row .btn-secondary {
+      flex: 0 0 auto;
+      width: auto;
+      min-width: 110px;
+    }
+
     .version-footer {
       text-align: center;
       color: #888;
       font-size: 0.75rem;
-      margin-top: 24px;
+      margin-top: 16px;
       padding-bottom: 8px;
     }
 
@@ -665,6 +714,8 @@
   </style>
 </head>
 <body>
+  <div class="app-layout">
+    <div class="scrollable-content">
   <div class="container">
     <div class="header-row">
       <div class="header-titles">
@@ -728,10 +779,7 @@
         <div class="fahrgassen-saved" id="fahrgassen_saved"></div>
         <div class="fahrgassen-info">Die Körnerzahl wird um ca. 1/Fahrgassenbreite × 100 % reduziert.</div>
       </div>
-    </div>
-
-    <button class="btn" onclick="berechne()" id="berechnen_btn">Berechnen</button>
-    <button class="btn btn-secondary" onclick="confirmResetAll()" id="reset_btn">Zurücksetzen</button>
+    </div><!-- Dünger card -->
 
     <div class="card result" id="results" style="display:none">
       <h2>📊 Ergebnis</h2>
@@ -798,7 +846,23 @@
       </div>
       <div id="drill_entries"></div>
     </div>
-  </div>
+    </div><!-- end .container -->
+
+    <!-- Sticky footer -->
+    <div class="sticky-footer" id="sticky_footer">
+      <div class="container">
+        <div id="mini_result" class="mini-result mini-result-empty">
+          Bitte Hektar und Körner eingeben
+        </div>
+        <div class="footer-btn-row">
+          <button class="btn" onclick="berechne()" id="berechnen_btn">Berechnen</button>
+          <button class="btn btn-secondary" onclick="confirmResetAll()" id="reset_btn">Zurücksetzen</button>
+        </div>
+      </div>
+    </div>
+
+    </div><!-- end .scrollable-content -->
+  </div><!-- end .app-layout -->
 
   <script>
     // --- State ---
@@ -1010,6 +1074,9 @@
       if (berechnenBtn) berechnenBtn.style.display = isProtokoll ? 'none' : '';
       var resetBtn = document.getElementById('reset_btn');
       if (resetBtn) resetBtn.style.display = isProtokoll ? 'none' : '';
+
+      var stickyFooter = document.getElementById('sticky_footer');
+      if (stickyFooter) stickyFooter.style.display = isProtokoll ? 'none' : '';
     }
 
     function renameReiter(idx, name) {
@@ -1217,6 +1284,21 @@
         document.getElementById('r_info').textContent = duengerTotal.toLocaleString('de-DE') + ' kg Dünger, ' + formatEinheit(einheiten) + ' Saat';
       } else {
         document.getElementById('r_info').textContent = formatEinheit(einheiten) + ' Saat (ohne Dünger)';
+      }
+
+      // Update mini-result in sticky footer
+      var miniResult = document.getElementById('mini_result');
+      if (miniResult) {
+        if (r.hektar > 0 && r.koerner > 0) {
+          var parts = [formatEinheit(einheiten)];
+          if (duengerTotal > 0) parts.push(duengerTotal.toLocaleString('de-DE') + ' kg');
+          miniResult.innerHTML = '<span class="mr-einheiten">' + parts[0] + '</span>' +
+            (parts[1] ? ' <span class="mr-duenger">| ' + parts[1] + '</span>' : '');
+          miniResult.classList.remove('mini-result-empty');
+        } else {
+          miniResult.textContent = 'Bitte Hektar und Körner eingeben';
+          miniResult.classList.add('mini-result-empty');
+        }
       }
       var usedEinheit = r.entries.reduce(function(s, e) { return s + e.einheit; }, 0);
       var usedDuenger = r.entries.reduce(function(s, e) { return s + e.duenger; }, 0);

--- a/public/index.html
+++ b/public/index.html
@@ -388,6 +388,67 @@
       flex: 1;
       margin-bottom: 8px;
     }
+    .drill-machine-row {
+      display: flex;
+      gap: 8px;
+    }
+    .drill-machine-row .field {
+      flex: 1;
+      margin-bottom: 8px;
+    }
+    .drill-tabs-section {
+      margin: 12px 0;
+      border: 1px solid #c3dfa8;
+      border-radius: 8px;
+      padding: 8px;
+      background: #f8faf4;
+    }
+    .drill-tabs-header {
+      font-size: 0.85rem;
+      color: #555;
+      margin-bottom: 8px;
+      font-weight: 600;
+    }
+    .drill-tab-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 6px;
+      padding: 4px;
+      border-radius: 6px;
+    }
+    .drill-tab-row:hover {
+      background: rgba(0,0,0,0.03);
+    }
+    .drill-tab-row input[type="checkbox"] {
+      width: 20px;
+      height: 20px;
+      cursor: pointer;
+      accent-color: #4a7c23;
+    }
+    .drill-tab-row .drill-tab-name {
+      flex: 1;
+      font-size: 0.9rem;
+      font-weight: 500;
+    }
+    .drill-tab-row .drill-tab-values {
+      display: flex;
+      gap: 6px;
+      font-size: 0.85rem;
+      color: #666;
+    }
+    .drill-tab-row .drill-tab-values input {
+      width: 55px;
+      padding: 4px 6px;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      font-size: 0.85rem;
+      text-align: right;
+    }
+    .drill-tab-row .drill-tab-values input:focus {
+      border-color: #4a7c23;
+      outline: none;
+    }
     .btn-add {
       width: 100%;
       padding: 12px;
@@ -797,23 +858,24 @@
     <div class="card" id="drill_section" style="display:none">
       <h2>🔧 Drill-Protokoll</h2>
       <div id="drill_mask">
-        <div class="inline-row">
+        <div class="drill-machine-row">
           <div class="field">
-            <label for="drill_einheit">Einheiten eingefüllt</label>
-            <input type="text" inputmode="decimal" id="drill_einheit" placeholder="z.B. 1,5" oninput="onInputFormat(this, 'decimal')">
+            <label for="drill_einheit">Maschine eingefüllt (Einheiten)</label>
+            <input type="text" inputmode="decimal" id="drill_einheit" placeholder="z.B. 4" oninput="drillCalcAll(); onInputFormat(this, 'decimal')">
           </div>
           <div class="field">
-            <label for="drill_hektar">Hektar-Zähler</label>
-            <input type="text" inputmode="decimal" id="drill_hektar" placeholder="z.B. 5,2" oninput="onInputFormat(this, 'decimal')">
+            <label for="drill_duenger">Maschine eingefüllt (Dünger kg)</label>
+            <input type="text" inputmode="decimal" id="drill_duenger" placeholder="z.B. 200" oninput="drillCalcAll(); onInputFormat(this, 'decimal')">
           </div>
         </div>
-        <div class="field">
-          <label for="drill_duenger">Dünger (kg)</label>
-          <input type="text" inputmode="decimal" id="drill_duenger" placeholder="z.B. 500" oninput="onInputFormat(this, 'decimal')">
+        <div class="drill-tabs-section">
+          <div class="drill-tabs-header">Aufteilen auf (nach Hektar):</div>
+          <div id="drill_tab_list"></div>
         </div>
         <button class="btn-add" onclick="drillAdd()">+ Einfüllen</button>
       </div>
       <div id="drill_summary" class="drill-summary" style="display:none">
+        <div id="ds_total_summary" class="drill-total-summary" style="margin-bottom:8px;font-weight:bold;"></div>
         <div class="drill-summary-row">
           <span>Einheiten gesamt</span>
           <span id="ds_saat_total">—</span>
@@ -1039,6 +1101,7 @@
       } else {
         syncStateFromInputs();
         state.activeView = 'protokoll';
+        renderDrillTabList();
       }
       renderTabs();
       sv();
@@ -1242,25 +1305,145 @@
     }
 
     // --- Drill log ---
+    function renderDrillTabList() {
+      var container = document.getElementById('drill_tab_list');
+      if (!container) return;
+      container.innerHTML = '';
+      state.reiter.forEach(function(r, i) {
+        var row = document.createElement('div');
+        row.className = 'drill-tab-row';
+
+        var cb = document.createElement('input');
+        cb.type = 'checkbox';
+        cb.id = 'dtl_cb_' + i;
+        cb.checked = (i === state.activeReiter); // Default: only active tab
+        cb.onchange = function() { drillCalcAll(); };
+
+        var label = document.createElement('label');
+        label.htmlFor = 'dtl_cb_' + i;
+        label.className = 'drill-tab-name';
+        label.textContent = r.name || ('Tab ' + (i + 1));
+
+        var values = document.createElement('div');
+        values.className = 'drill-tab-values';
+
+        var eInput = document.createElement('input');
+        eInput.type = 'text';
+        eInput.id = 'dtl_e_' + i;
+        eInput.placeholder = 'Einheiten';
+        eInput.inputMode = 'decimal';
+        eInput.oninput = function() { onInputFormat(eInput, 'decimal'); };
+
+        var dInput = document.createElement('input');
+        dInput.type = 'text';
+        dInput.id = 'dtl_d_' + i;
+        dInput.placeholder = 'kg Dünger';
+        dInput.inputMode = 'decimal';
+        dInput.oninput = function() { onInputFormat(dInput, 'decimal'); };
+
+        values.appendChild(eInput);
+        values.appendChild(dInput);
+
+        row.appendChild(cb);
+        row.appendChild(label);
+        row.appendChild(values);
+        container.appendChild(row);
+      });
+    }
+
+    function drillCalcAll() {
+      var gesamtEinheit = parseDE(document.getElementById('drill_einheit').value) || 0;
+      var gesamtDuenger = parseDE(document.getElementById('drill_duenger').value) || 0;
+
+      // Calculate total hectares of selected tabs
+      var selectedTotalHa = 0;
+      var selectedIndices = [];
+      state.reiter.forEach(function(r, i) {
+        var cb = document.getElementById('dtl_cb_' + i);
+        if (cb && cb.checked) {
+          selectedTotalHa += r.hektar || 0;
+          selectedIndices.push(i);
+        }
+      });
+
+      // Distribute by hectare ratio
+      state.reiter.forEach(function(r, i) {
+        var eInput = document.getElementById('dtl_e_' + i);
+        var dInput = document.getElementById('dtl_d_' + i);
+        if (!eInput || !dInput) return;
+
+        var cb = document.getElementById('dtl_cb_' + i);
+        if (cb && cb.checked && selectedTotalHa > 0 && r.hektar > 0) {
+          var ratio = r.hektar / selectedTotalHa;
+          eInput.value = fmt(gesamtEinheit * ratio);
+          dInput.value = fmt(gesamtDuenger * ratio);
+        } else {
+          eInput.value = '';
+          dInput.value = '';
+        }
+      });
+    }
+
     function drillAdd() {
-      var r = getActiveReiter();
-      if (!r.hektar || !r.koerner) return;
-      var einheitEl = document.getElementById('drill_einheit');
-      var hektarEl = document.getElementById('drill_hektar');
-      var duengerEl = document.getElementById('drill_duenger');
-      var einheit = parseDE(einheitEl.value) || 0;
-      var hektar = parseDE(hektarEl.value) || 0;
-      var duenger = parseDE(duengerEl.value) || 0;
-      if (einheit <= 0 && duenger <= 0) return;
-      r.entries.push({ einheit: einheit, hektar: hektar, duenger: duenger, time: new Date().toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' }) });
-      einheitEl.value = '';
-      hektarEl.value = '';
-      duengerEl.value = '';
+      var gesamtEinheit = parseDE(document.getElementById('drill_einheit').value) || 0;
+      var gesamtDuenger = parseDE(document.getElementById('drill_duenger').value) || 0;
+
+      // If no tab list rendered (e.g. in tests), fall back to single-tab mode
+      var hasTabList = document.getElementById('dtl_cb_0') !== null;
+
+      if (!hasTabList) {
+        // Single-tab fallback: add entry directly to active tab
+        var r = getActiveReiter();
+        if (!r.hektar || !r.koerner) return;
+        if (gesamtEinheit <= 0 && gesamtDuenger <= 0) return;
+        r.entries.push({
+          einheit: gesamtEinheit,
+          hektar: 0,
+          duenger: gesamtDuenger,
+          time: new Date().toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' })
+        });
+        document.getElementById('drill_einheit').value = '';
+        document.getElementById('drill_duenger').value = '';
+        sv();
+        renderResults();
+        return;
+      }
+
+      var addedAny = false;
+      state.reiter.forEach(function(r, i) {
+        var cb = document.getElementById('dtl_cb_' + i);
+        if (!cb || !cb.checked) return;
+
+        var eInput = document.getElementById('dtl_e_' + i);
+        var dInput = document.getElementById('dtl_d_' + i);
+        var einheit = parseDE(eInput ? eInput.value : '') || 0;
+        var duenger = parseDE(dInput ? dInput.value : '') || 0;
+
+        if (einheit > 0 || duenger > 0) {
+          r.entries.push({
+            einheit: einheit,
+            hektar: 0,
+            duenger: duenger,
+            time: new Date().toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' })
+          });
+          addedAny = true;
+        }
+      });
+
+      if (!addedAny) return;
+
+      // Clear inputs
+      document.getElementById('drill_einheit').value = '';
+      document.getElementById('drill_duenger').value = '';
+      state.reiter.forEach(function(r, i) {
+        var eInput = document.getElementById('dtl_e_' + i);
+        var dInput = document.getElementById('dtl_d_' + i);
+        if (eInput) eInput.value = '';
+        if (dInput) dInput.value = '';
+      });
+
       sv();
       renderResults();
-      // Ensure drill_section is visible when there are entries
-      var drillSection = document.getElementById('drill_section');
-      if (drillSection) drillSection.style.display = 'block';
     }
 
     function drillRemove(idx) {
@@ -1320,6 +1503,13 @@
       document.getElementById('ds_duenger_remaining').textContent = duengerTotal > 0 ? remDuenger.toLocaleString('de-DE') + ' kg' + haDuengerRemText : '—';
       var container = document.getElementById('drill_entries');
       document.getElementById('drill_summary').style.display = (einheiten > 0 || duengerTotal > 0 || r.entries.length > 0) ? 'block' : 'none';
+      // Build total summary text
+      var usedEinheit = r.entries.reduce(function(s, e) { return s + e.einheit; }, 0);
+      var usedDuenger = r.entries.reduce(function(s, e) { return s + e.duenger; }, 0);
+      var summaryParts = [];
+      if (usedEinheit > 0) summaryParts.push(formatEinheit(usedEinheit) + ' Einheiten');
+      if (usedDuenger > 0) summaryParts.push(usedDuenger.toLocaleString('de-DE') + ' kg Dünger');
+      document.getElementById('ds_total_summary').textContent = summaryParts.join(' + ');
       // NOTE: drill_section visibility is controlled by renderView() — do NOT set here
       if (r.entries.length === 0) {
         container.innerHTML = '';

--- a/public/index.html
+++ b/public/index.html
@@ -983,11 +983,6 @@
 
       // Protokoll tab button
       var protokollBtn = document.getElementById('protokoll_tab_btn');
-      if (state.activeView === 'protokoll') {
-        protokollBtn.textContent = '← Zurück';
-      } else {
-        protokollBtn.textContent = '🔧 Protokoll';
-      }
       protokollBtn.classList.toggle('active', state.activeView === 'protokoll');
     }
 

--- a/public/index.html
+++ b/public/index.html
@@ -332,6 +332,16 @@
       justify-content: space-between;
       align-items: center;
       padding: 10px 0;
+    }
+    .drill-entry-tab-header {
+      font-size: 13px;
+      font-weight: bold;
+      color: #666;
+      padding: 8px 0 4px 0;
+      border-bottom: 1px solid #eee;
+      margin-bottom: 4px;
+    }
+    .drill-entry {
       border-bottom: 1px solid #e8f0de;
       font-size: 0.9rem;
     }
@@ -1446,9 +1456,8 @@
       renderResults();
     }
 
-    function drillRemove(idx) {
-      var r = getActiveReiter();
-      r.entries.splice(idx, 1);
+    function drillRemove(tabIdx, entryIdx) {
+      state.reiter[tabIdx].entries.splice(entryIdx, 1);
       sv();
       renderResults();
     }
@@ -1502,7 +1511,9 @@
       document.getElementById('ds_duenger_used').textContent = usedDuenger >= 0 ? usedDuenger.toLocaleString('de-DE') + ' kg' + haDuengerUsedText : '—';
       document.getElementById('ds_duenger_remaining').textContent = duengerTotal > 0 ? remDuenger.toLocaleString('de-DE') + ' kg' + haDuengerRemText : '—';
       var container = document.getElementById('drill_entries');
-      document.getElementById('drill_summary').style.display = (einheiten > 0 || duengerTotal > 0 || r.entries.length > 0) ? 'block' : 'none';
+      // Check if any tab has entries
+      var hasAnyEntries = state.reiter.some(function(r) { return r.entries.length > 0; });
+      document.getElementById('drill_summary').style.display = (einheiten > 0 || duengerTotal > 0 || hasAnyEntries) ? 'block' : 'none';
       // Build total summary text
       var usedEinheit = r.entries.reduce(function(s, e) { return s + e.einheit; }, 0);
       var usedDuenger = r.entries.reduce(function(s, e) { return s + e.duenger; }, 0);
@@ -1511,7 +1522,7 @@
       if (usedDuenger > 0) summaryParts.push(usedDuenger.toLocaleString('de-DE') + ' kg Dünger');
       document.getElementById('ds_total_summary').textContent = summaryParts.join(' + ');
       // NOTE: drill_section visibility is controlled by renderView() — do NOT set here
-      if (r.entries.length === 0) {
+      if (!hasAnyEntries) {
         container.innerHTML = '';
         var empty = document.createElement('div');
         empty.className = 'drill-empty';
@@ -1519,31 +1530,41 @@
         container.appendChild(empty);
       } else {
         container.innerHTML = '';
-        r.entries.forEach(function(e, i) {
-          var ds = e.duenger > 0 ? e.duenger.toLocaleString('de-DE') + ' kg' : '';
-          var dl = ds ? ' + ' + ds + ' Dünger' : '';
-          var hl = e.hektar > 0 ? ' @ ' + (Math.round(e.hektar * 10) / 10).toFixed(1).replace('.', ',') + ' ha' : '';
+        state.reiter.forEach(function(r, tabIdx) {
+          if (r.entries.length === 0) return;
 
-          var entry = document.createElement('div');
-          entry.className = 'drill-entry';
+          // Tab header
+          var tabHeader = document.createElement('div');
+          tabHeader.className = 'drill-entry-tab-header';
+          tabHeader.textContent = r.name || ('Tab ' + (tabIdx + 1));
+          container.appendChild(tabHeader);
 
-          var span = document.createElement('span');
-          span.className = 'entry-text';
-          var hash = document.createElement('span');
-          hash.textContent = '#' + (i+1);
-          var txt = (e.time ? e.time + ' – ' : '') + hl + (hl ? ', ' : '') + formatEinheit(e.einheit) + dl;
-          var txtNode = document.createTextNode(txt + ' ');
-          span.appendChild(hash);
-          span.appendChild(txtNode);
+          r.entries.forEach(function(e, entryIdx) {
+            var ds = e.duenger > 0 ? e.duenger.toLocaleString('de-DE') + ' kg' : '';
+            var dl = ds ? ' + ' + ds + ' Dünger' : '';
+            var hl = e.hektar > 0 ? ' @ ' + (Math.round(e.hektar * 10) / 10).toFixed(1).replace('.', ',') + ' ha' : '';
 
-          var btn = document.createElement('button');
-          btn.className = 'btn-danger';
-          btn.textContent = '✕';
-          btn.onclick = function() { drillRemove(i); };
+            var entry = document.createElement('div');
+            entry.className = 'drill-entry';
 
-          entry.appendChild(span);
-          entry.appendChild(btn);
-          container.appendChild(entry);
+            var span = document.createElement('span');
+            span.className = 'entry-text';
+            var hash = document.createElement('span');
+            hash.textContent = '#' + (entryIdx + 1);
+            var txt = (e.time ? e.time + ' – ' : '') + hl + (hl ? ', ' : '') + formatEinheit(e.einheit) + dl;
+            var txtNode = document.createTextNode(txt + ' ');
+            span.appendChild(hash);
+            span.appendChild(txtNode);
+
+            var btn = document.createElement('button');
+            btn.className = 'btn-danger';
+            btn.textContent = '✕';
+            btn.onclick = (function(ti, ei) { return function() { drillRemove(ti, ei); }; })(tabIdx, entryIdx);
+
+            entry.appendChild(span);
+            entry.appendChild(btn);
+            container.appendChild(entry);
+          });
         });
       }
     }

--- a/public/index.html
+++ b/public/index.html
@@ -36,6 +36,22 @@
       font-size: 0.85rem;
       margin-bottom: 24px;
     }
+    .header-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      margin-bottom: 16px;
+    }
+    .header-titles {
+      flex: 1;
+    }
+    .header-titles h1 {
+      margin-bottom: 2px;
+    }
+    .header-titles .subtitle {
+      text-align: left;
+      margin-bottom: 0;
+    }
     .card {
       background: white;
       border-radius: 16px;
@@ -409,12 +425,161 @@
       margin-top: 24px;
       padding-bottom: 8px;
     }
+
+    /* Dashboard */
+    .dashboard-overlay {
+      display: none;
+      position: fixed;
+      inset: 0;
+      background: rgba(0,0,0,0.4);
+      z-index: 100;
+    }
+    .dashboard-overlay.open {
+      display: block;
+    }
+    .dashboard-sheet {
+      display: none;
+      position: fixed;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      background: white;
+      border-radius: 20px 20px 0 0;
+      max-height: 80vh;
+      overflow-y: auto;
+      z-index: 101;
+      padding: 0 0 max(20px, env(safe-area-inset-bottom));
+    }
+    .dashboard-sheet.open {
+      display: block;
+    }
+    .dashboard-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 20px 20px 16px;
+      border-bottom: 2px solid #e8f0de;
+      position: sticky;
+      top: 0;
+      background: white;
+      border-radius: 20px 20px 0 0;
+    }
+    .dashboard-header h2 {
+      margin: 0;
+      padding: 0;
+      border: none;
+      font-size: 1.1rem;
+      color: #2d5016;
+    }
+    .dashboard-close {
+      background: #e8f0de;
+      border: none;
+      border-radius: 50%;
+      width: 36px;
+      height: 36px;
+      font-size: 1.2rem;
+      cursor: pointer;
+      color: #4a7c23;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .dashboard-close:active {
+      background: #d0e8b8;
+    }
+    .dashboard-open-btn {
+      background: #2d5016;
+      color: white;
+      border: none;
+      border-radius: 8px;
+      padding: 6px 14px;
+      font-size: 0.85rem;
+      font-weight: 600;
+      cursor: pointer;
+      margin-left: 8px;
+      flex-shrink: 0;
+    }
+    .dashboard-open-btn:active {
+      background: #1e3410;
+    }
+    .dashboard-tabs-header {
+      display: flex;
+      align-items: center;
+      padding: 12px 20px 0;
+    }
+    .dashboard-empty {
+      text-align: center;
+      color: #888;
+      font-size: 0.9rem;
+      padding: 32px 20px;
+    }
+    .dashboard-reiter-card {
+      margin: 12px 20px;
+      background: #fafef5;
+      border: 2px solid #e8f0de;
+      border-radius: 12px;
+      padding: 14px;
+    }
+    .dashboard-reiter-name {
+      font-weight: 700;
+      color: #2d5016;
+      font-size: 0.95rem;
+      margin-bottom: 10px;
+    }
+    .dashboard-reiter-stats {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 8px;
+    }
+    .dashboard-stat {
+      background: white;
+      border-radius: 8px;
+      padding: 8px 10px;
+    }
+    .dashboard-stat-label {
+      font-size: 0.75rem;
+      color: #888;
+      margin-bottom: 2px;
+    }
+    .dashboard-stat-value {
+      font-size: 0.95rem;
+      font-weight: 600;
+      color: #1a1a1a;
+    }
+    .dashboard-stat-value.remaining {
+      color: #d32f2f;
+    }
+    .dashboard-stat-value.done {
+      color: #4a7c23;
+    }
+    .dashboard-stat-value.na {
+      color: #aaa;
+    }
+    .dashboard-progress-bar {
+      grid-column: 1 / -1;
+      height: 6px;
+      background: #e8f0de;
+      border-radius: 3px;
+      overflow: hidden;
+      margin-top: 4px;
+    }
+    .dashboard-progress-fill {
+      height: 100%;
+      background: #4a7c23;
+      border-radius: 3px;
+      transition: width 0.3s;
+    }
   </style>
 </head>
 <body>
   <div class="container">
-    <h1>🌾 Mais-Rechner</h1>
-    <p class="subtitle">Einheiten & Dünger für Aussaat</p>
+    <div class="header-row">
+      <div class="header-titles">
+        <h1>🌾 Mais-Rechner</h1>
+        <p class="subtitle">Einheiten & Dünger für Aussaat</p>
+      </div>
+      <button class="dashboard-open-btn" onclick="openDashboard()">📊 Dashboard</button>
+    </div>
 
     <!-- Tabs -->
     <div class="tab-bar" id="tab_bar"><button class="tab-add" onclick="addReiter()">+ Tab</button></div>
@@ -1048,7 +1213,143 @@
     }
 
     document.addEventListener('DOMContentLoaded', initUI);
+
+    // --- Dashboard ---
+    function openDashboard() {
+      renderDashboard();
+      document.getElementById('dashboard_overlay').classList.add('open');
+      document.getElementById('dashboard_sheet').classList.add('open');
+      document.body.style.overflow = 'hidden';
+    }
+
+    function closeDashboard() {
+      document.getElementById('dashboard_overlay').classList.remove('open');
+      document.getElementById('dashboard_sheet').classList.remove('open');
+      document.body.style.overflow = '';
+    }
+
+    function renderDashboard() {
+      var container = document.getElementById('dashboard_content');
+      var reiter = state.reiter;
+      if (reiter.length === 0) {
+        container.innerHTML = '<div class="dashboard-empty">Keine Reiter vorhanden</div>';
+        return;
+      }
+      container.innerHTML = '';
+      reiter.forEach(function(r, idx) {
+        var card = document.createElement('div');
+        card.className = 'dashboard-reiter-card';
+
+        var nameEl = document.createElement('div');
+        nameEl.className = 'dashboard-reiter-name';
+        nameEl.textContent = r.name || ('Reiter ' + (idx + 1));
+        if (idx === state.activeReiter) {
+          nameEl.textContent += ' (aktiv)';
+        }
+        card.appendChild(nameEl);
+
+        var stats = document.createElement('div');
+        stats.className = 'dashboard-reiter-stats';
+
+        // Hektar
+        var haDiv = document.createElement('div');
+        haDiv.className = 'dashboard-stat';
+        var haDivLabel = document.createElement('div');
+        haDivLabel.className = 'dashboard-stat-label';
+        haDivLabel.textContent = 'Hektar';
+        var haDivVal = document.createElement('div');
+        haDivVal.className = 'dashboard-stat-value';
+        haDivVal.textContent = r.hektar > 0 ? fmt(r.hektar) + ' ha' : '—';
+        haDiv.appendChild(haDivLabel);
+        haDiv.appendChild(haDivVal);
+        stats.appendChild(haDiv);
+
+        // Körner/ha
+        var kDiv = document.createElement('div');
+        kDiv.className = 'dashboard-stat';
+        var kDivLabel = document.createElement('div');
+        kDivLabel.className = 'dashboard-stat-label';
+        kDivLabel.textContent = 'Körner/ha';
+        var kDivVal = document.createElement('div');
+        kDivVal.className = 'dashboard-stat-value';
+        kDivVal.textContent = r.koerner > 0 ? r.koerner.toLocaleString('de-DE') : '—';
+        kDiv.appendChild(kDivLabel);
+        kDiv.appendChild(kDivVal);
+        stats.appendChild(kDiv);
+
+        // Calculate progress
+        var einheiten = 0;
+        var usedEinheit = 0;
+        var duengerTotal = 0;
+        var usedDuenger = 0;
+        var pct = 0;
+        var statusClass = 'na';
+        if (r.hektar > 0 && r.koerner > 0) {
+          einheiten = r.hektar * r.koerner / state.koernerProEinheit;
+          usedEinheit = r.entries.reduce(function(s, e) { return s + e.einheit; }, 0);
+          duengerTotal = r.hektar * r.duenger;
+          usedDuenger = r.entries.reduce(function(s, e) { return s + e.duenger; }, 0);
+          var maxUsed = Math.max(
+            einheiten > 0 ? usedEinheit / einheiten : 0,
+            duengerTotal > 0 ? usedDuenger / duengerTotal : 0
+          );
+          pct = Math.min(100, Math.round(maxUsed * 100));
+          if (pct >= 100) statusClass = 'done';
+          else if (pct > 0) statusClass = 'remaining';
+        }
+
+        // Einheiten verbleibend
+        var einheitRem = Math.max(0, einheiten - usedEinheit);
+        var eStat = document.createElement('div');
+        eStat.className = 'dashboard-stat';
+        var eStatLabel = document.createElement('div');
+        eStatLabel.className = 'dashboard-stat-label';
+        eStatLabel.textContent = 'Einheiten verbl.';
+        var eStatVal = document.createElement('div');
+        eStatVal.className = 'dashboard-stat-value ' + statusClass;
+        eStatVal.textContent = r.hektar > 0 && r.koerner > 0 ? fmt(einheitRem) : '—';
+        eStat.appendChild(eStatLabel);
+        eStat.appendChild(eStatVal);
+        stats.appendChild(eStat);
+
+        // Dünger verbleibend
+        var duengerRem = Math.max(0, duengerTotal - usedDuenger);
+        var dStat = document.createElement('div');
+        dStat.className = 'dashboard-stat';
+        var dStatLabel = document.createElement('div');
+        dStatLabel.className = 'dashboard-stat-label';
+        dStatLabel.textContent = 'Dünger verbl.';
+        var dStatVal = document.createElement('div');
+        dStatVal.className = 'dashboard-stat-value ' + statusClass;
+        dStatVal.textContent = duengerTotal > 0 ? duengerRem.toLocaleString('de-DE') + ' kg' : '—';
+        dStat.appendChild(dStatLabel);
+        dStat.appendChild(dStatVal);
+        stats.appendChild(dStat);
+
+        // Progress bar
+        var progressWrap = document.createElement('div');
+        progressWrap.className = 'dashboard-progress-bar';
+        var progressFill = document.createElement('div');
+        progressFill.className = 'dashboard-progress-fill';
+        progressFill.style.width = (r.hektar > 0 && r.koerner > 0) ? pct + '%' : '0%';
+        progressWrap.appendChild(progressFill);
+        stats.appendChild(progressWrap);
+
+        card.appendChild(stats);
+        container.appendChild(card);
+      });
+    }
   </script>
   <div class="version-footer">v0.0.1</div>
+
+  <!-- Dashboard overlay + sheet -->
+  <div class="dashboard-overlay" id="dashboard_overlay" onclick="closeDashboard()"></div>
+  <div class="dashboard-sheet" id="dashboard_sheet">
+    <div class="dashboard-header">
+      <h2>📊 Alle Reiter</h2>
+      <button class="dashboard-close" onclick="closeDashboard()" aria-label="Schließen">✕</button>
+    </div>
+    <div class="dashboard-content" id="dashboard_content"></div>
+  </div>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -943,37 +943,38 @@
     function renderTabs() {
       var bar = document.getElementById('tab_bar_left');
       bar.innerHTML = '';
-      if (state.reiter.length > 1) {
-        state.reiter.forEach(function(r, i) {
-          var isActive = i === state.activeReiter && state.activeView !== 'protokoll';
-          var btn = document.createElement('button');
-          btn.className = 'tab-btn field-tab' + (isActive ? ' active' : '');
-          btn.setAttribute('aria-label', 'Tab ' + (i+1));
-          btn.onclick = function() { switchReiter(i); };
+      state.reiter.forEach(function(r, i) {
+        var isActive = i === state.activeReiter && state.activeView !== 'protokoll';
+        var btn = document.createElement('button');
+        btn.className = 'tab-btn field-tab' + (isActive ? ' active' : '');
+        btn.setAttribute('aria-label', 'Tab ' + (i+1));
+        btn.onclick = function() { switchReiter(i); };
 
-          var input = document.createElement('input');
-          input.className = 'tab-name-input';
-          input.type = 'text';
-          input.value = r.name;
-          input.setAttribute('aria-label', 'Tab-Name');
-          input.onfocus = function() { this.select(); };
-          input.onchange = function() { renameReiter(i, input.value); };
-          input.onblur = function() { renameReiter(i, input.value); };
-          input.onkeydown = function(evt) {
-            if (evt.key === 'Enter') { input.blur(); }
-            else { evt.stopPropagation(); }
-          };
+        var input = document.createElement('input');
+        input.className = 'tab-name-input';
+        input.type = 'text';
+        input.value = r.name;
+        input.setAttribute('aria-label', 'Tab-Name');
+        input.onfocus = function() { this.select(); };
+        input.onchange = function() { renameReiter(i, input.value); };
+        input.onblur = function() { renameReiter(i, input.value); };
+        input.onkeydown = function(evt) {
+          if (evt.key === 'Enter') { input.blur(); }
+          else { evt.stopPropagation(); }
+        };
 
+        // Only show close button if more than 1 tab
+        if (state.reiter.length > 1) {
           var close = document.createElement('span');
           close.className = 'tab-close';
           close.setAttribute('onclick', 'event.stopPropagation(); confirmRemoveReiter(' + i + ')');
           close.textContent = '✕';
-
-          btn.appendChild(input);
           btn.appendChild(close);
-          bar.appendChild(btn);
-        });
-      }
+        }
+
+        btn.appendChild(input);
+        bar.appendChild(btn);
+      });
       var addBtn = document.createElement('button');
       addBtn.className = 'tab-add';
       addBtn.textContent = '+ Tab';
@@ -982,6 +983,11 @@
 
       // Protokoll tab button
       var protokollBtn = document.getElementById('protokoll_tab_btn');
+      if (state.activeView === 'protokoll') {
+        protokollBtn.textContent = '← Zurück';
+      } else {
+        protokollBtn.textContent = '🔧 Protokoll';
+      }
       protokollBtn.classList.toggle('active', state.activeView === 'protokoll');
     }
 

--- a/public/index.html
+++ b/public/index.html
@@ -430,16 +430,40 @@
     .drill-tab-row:hover {
       background: rgba(0,0,0,0.03);
     }
-    .drill-tab-row input[type="checkbox"] {
-      width: 20px;
-      height: 20px;
+    .drill-prio-btn {
+      width: 32px;
+      height: 32px;
+      border-radius: 50%;
+      border: 2px solid #c3dfa8;
+      background: #f0f4e8;
+      font-size: 0.85rem;
+      font-weight: 700;
+      color: #888;
       cursor: pointer;
-      accent-color: #4a7c23;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+      transition: background 0.15s, border-color 0.15s, color 0.15s;
+      touch-action: manipulation;
+    }
+    .drill-prio-btn.active {
+      background: #4a7c23;
+      border-color: #2d5016;
+      color: white;
+    }
+    .drill-prio-btn:active {
+      transform: scale(0.92);
     }
     .drill-tab-row .drill-tab-name {
       flex: 1;
       font-size: 0.9rem;
       font-weight: 500;
+    }
+    .drill-tab-row .drill-tab-need {
+      font-size: 0.75rem;
+      color: #999;
+      margin-top: 1px;
     }
     .drill-tab-row .drill-tab-values {
       display: flex;
@@ -879,7 +903,7 @@
           </div>
         </div>
         <div class="drill-tabs-section">
-          <div class="drill-tabs-header">Aufteilen auf (nach Hektar):</div>
+          <div class="drill-tabs-header">Aufteilen auf (Klick = Prio: 1 → 2 → 3 → aus):</div>
           <div id="drill_tab_list"></div>
         </div>
         <button class="btn-add" onclick="drillAdd()">+ Einfüllen</button>
@@ -1245,7 +1269,20 @@
     }
 
     function getKornerGesamt() {
+      return getTabKornerGesamt(getActiveReiter());
+    }
+
+    function getTotalEinheiten() {
       var r = getActiveReiter();
+      return getTabTotalEinheiten(r);
+    }
+
+    function getTabTotalEinheiten(r) {
+      if (!r.hektar || !r.koerner) return 0;
+      return getTabKornerGesamt(r) / state.koernerProEinheit;
+    }
+
+    function getTabKornerGesamt(r) {
       if (!r.hektar || !r.koerner) return 0;
       var k = r.hektar * r.koerner;
       if (state.fahrgassenEnabled && state.fahrgassenBreite > 0) {
@@ -1254,14 +1291,12 @@
       return k;
     }
 
-    function getTotalEinheiten() {
-      var r = getActiveReiter();
-      if (!r.hektar || !r.koerner) return 0;
-      return getKornerGesamt() / state.koernerProEinheit;
-    }
-
     function getTotalDuenger() {
       var r = getActiveReiter();
+      return getTabTotalDuenger(r);
+    }
+
+    function getTabTotalDuenger(r) {
       if (!r.hektar) return 0;
       return r.hektar * r.duenger;
     }
@@ -1316,24 +1351,54 @@
     }
 
     // --- Drill log ---
+    // Priority state for drill tab list
+    var drillPriorities = {};
+
     function renderDrillTabList() {
       var container = document.getElementById('drill_tab_list');
       if (!container) return;
       container.innerHTML = '';
+      drillPriorities = {};
       state.reiter.forEach(function(r, i) {
         var row = document.createElement('div');
         row.className = 'drill-tab-row';
 
-        var cb = document.createElement('input');
-        cb.type = 'checkbox';
-        cb.id = 'dtl_cb_' + i;
-        cb.checked = (i === state.activeReiter); // Default: only active tab
-        cb.onchange = function() { drillCalcAll(); };
+        // Priority button: click cycles — (off) → 1 → 2 → … → — (off)
+        var prioBtn = document.createElement('button');
+        prioBtn.className = 'drill-prio-btn';
+        prioBtn.id = 'dtl_prio_' + i;
+        prioBtn.textContent = '—';
+        prioBtn.setAttribute('data-prio', '0');
+        prioBtn.onclick = function() {
+          var current = parseInt(prioBtn.getAttribute('data-prio')) || 0;
+          var maxPrio = state.reiter.length;
+          var next = current >= maxPrio ? 0 : current + 1;
+          prioBtn.setAttribute('data-prio', String(next));
+          prioBtn.textContent = next === 0 ? '—' : String(next);
+          prioBtn.classList.toggle('active', next > 0);
+          drillPriorities[i] = next;
+          drillCalcAll();
+        };
 
-        var label = document.createElement('label');
-        label.htmlFor = 'dtl_cb_' + i;
+        // Tab name + remaining need
+        var nameWrap = document.createElement('div');
+        nameWrap.style.flex = '1';
+        nameWrap.style.minWidth = '0';
+        var label = document.createElement('div');
         label.className = 'drill-tab-name';
         label.textContent = r.name || ('Tab ' + (i + 1));
+        nameWrap.appendChild(label);
+        // Show remaining need
+        if (r.hektar > 0 && r.koerner > 0) {
+          var totalE = getTabTotalEinheiten(r);
+          var usedE = r.entries.reduce(function(s, e) { return s + e.einheit; }, 0);
+          var remE = Math.max(0, totalE - usedE);
+          var needDiv = document.createElement('div');
+          needDiv.className = 'drill-tab-need';
+          needDiv.id = 'dtl_need_' + i;
+          needDiv.textContent = 'braucht ' + fmt(remE) + ' Einheiten';
+          nameWrap.appendChild(needDiv);
+        }
 
         var values = document.createElement('div');
         values.className = 'drill-tab-values';
@@ -1355,8 +1420,8 @@
         values.appendChild(eInput);
         values.appendChild(dInput);
 
-        row.appendChild(cb);
-        row.appendChild(label);
+        row.appendChild(prioBtn);
+        row.appendChild(nameWrap);
         row.appendChild(values);
         container.appendChild(row);
       });
@@ -1366,28 +1431,45 @@
       var gesamtEinheit = parseDE(document.getElementById('drill_einheit').value) || 0;
       var gesamtDuenger = parseDE(document.getElementById('drill_duenger').value) || 0;
 
-      // Calculate total hectares of selected tabs
-      var selectedTotalHa = 0;
-      var selectedIndices = [];
+      // Collect tabs with priority > 0, sort by priority descending
+      var prioritized = [];
       state.reiter.forEach(function(r, i) {
-        var cb = document.getElementById('dtl_cb_' + i);
-        if (cb && cb.checked) {
-          selectedTotalHa += r.hektar || 0;
-          selectedIndices.push(i);
+        var prio = drillPriorities[i] || 0;
+        if (prio > 0) {
+          prioritized.push({ idx: i, prio: prio, reiter: r });
         }
       });
+      prioritized.sort(function(a, b) { return b.prio - a.prio; });
 
-      // Distribute by hectare ratio
+      // Distribute: highest priority first, give what they need, remainder to next
+      var remEinheit = gesamtEinheit;
+      var remDuenger = gesamtDuenger;
+      var distribution = {};
+      prioritized.forEach(function(item) {
+        var r = item.reiter;
+        var totalE = getTabTotalEinheiten(r);
+        var usedE = r.entries.reduce(function(s, e) { return s + e.einheit; }, 0);
+        var needE = Math.max(0, totalE - usedE);
+
+        var totalD = getTabTotalDuenger(r);
+        var usedD = r.entries.reduce(function(s, e) { return s + e.duenger; }, 0);
+        var needD = Math.max(0, totalD - usedD);
+
+        var giveE = Math.min(needE, remEinheit);
+        var giveD = Math.min(needD, remDuenger);
+        distribution[item.idx] = { einheit: giveE, duenger: giveD };
+        remEinheit -= giveE;
+        remDuenger -= giveD;
+      });
+
+      // Write values to inputs
       state.reiter.forEach(function(r, i) {
         var eInput = document.getElementById('dtl_e_' + i);
         var dInput = document.getElementById('dtl_d_' + i);
         if (!eInput || !dInput) return;
-
-        var cb = document.getElementById('dtl_cb_' + i);
-        if (cb && cb.checked && selectedTotalHa > 0 && r.hektar > 0) {
-          var ratio = r.hektar / selectedTotalHa;
-          eInput.value = fmt(gesamtEinheit * ratio);
-          dInput.value = fmt(gesamtDuenger * ratio);
+        if (distribution[i]) {
+          eInput.value = distribution[i].einheit > 0 ? fmt(distribution[i].einheit) : '';
+          dInput.value = distribution[i].duenger > 0 ? fmt(distribution[i].duenger) : '';
         } else {
           eInput.value = '';
           dInput.value = '';
@@ -1400,7 +1482,7 @@
       var gesamtDuenger = parseDE(document.getElementById('drill_duenger').value) || 0;
 
       // If no tab list rendered (e.g. in tests), fall back to single-tab mode
-      var hasTabList = document.getElementById('dtl_cb_0') !== null;
+      var hasTabList = document.getElementById('dtl_prio_0') !== null;
 
       if (!hasTabList) {
         // Single-tab fallback: add entry directly to active tab
@@ -1422,8 +1504,8 @@
 
       var addedAny = false;
       state.reiter.forEach(function(r, i) {
-        var cb = document.getElementById('dtl_cb_' + i);
-        if (!cb || !cb.checked) return;
+        var prio = drillPriorities[i] || 0;
+        if (prio <= 0) return;
 
         var eInput = document.getElementById('dtl_e_' + i);
         var dInput = document.getElementById('dtl_d_' + i);
@@ -1452,6 +1534,10 @@
         if (eInput) eInput.value = '';
         if (dInput) dInput.value = '';
       });
+
+      // Reset priorities after fill
+      drillPriorities = {};
+      renderDrillTabList();
 
       sv();
       renderResults();

--- a/public/index.html
+++ b/public/index.html
@@ -1230,6 +1230,7 @@
         <div class="footer-btn-row">
           <button class="btn" onclick="berechne()" id="berechnen_btn">Berechnen</button>
           <button class="btn btn-secondary" onclick="confirmResetAll()" id="reset_btn">Zurücksetzen</button>
+          <button class="btn btn-danger" onclick="confirmResetAll(true)" id="reset_all_btn">Reset All</button>
         </div>
       </div>
     </div>
@@ -1450,6 +1451,8 @@
       if (berechnenBtn) berechnenBtn.style.display = isProtokoll ? 'none' : '';
       var resetBtn = document.getElementById('reset_btn');
       if (resetBtn) resetBtn.style.display = isProtokoll ? 'none' : '';
+      var resetAllBtn = document.getElementById('reset_all_btn');
+      if (resetAllBtn) resetAllBtn.style.display = isProtokoll ? 'none' : '';
 
       var stickyFooter = document.getElementById('sticky_footer');
       if (stickyFooter) stickyFooter.style.display = isProtokoll ? 'none' : '';
@@ -2101,10 +2104,15 @@
       }
     }
 
-    function confirmResetAll() {
+    function confirmResetAll(fullReset) {
       var tabName = state.reiter[state.activeReiter].name;
-      if (!confirm('Wirklich zurücksetzen?\n\nAlle Eingaben für "' + tabName + '" werden gelöscht.')) return;
-      resetActiveTab();
+      if (fullReset) {
+        if (!confirm('Wirklich ALLE Daten zurücksetzen?\n\nAlle Tabs, Einträge und Einstellungen werden gelöscht.')) return;
+        resetAll();
+      } else {
+        if (!confirm('Wirklich zurücksetzen?\n\nAlle Eingaben für "' + tabName + '" werden gelöscht.')) return;
+        resetActiveTab();
+      }
     }
 
     // Reset only the active tab's data (preserves other tabs, global settings, machineLog)

--- a/public/index.html
+++ b/public/index.html
@@ -575,6 +575,37 @@
       font-size: 0.9rem;
       padding: 32px 20px;
     }
+    .dashboard-summary {
+      margin: 0 20px 16px;
+      background: linear-gradient(135deg, #4a7c23, #6aa336);
+      border-radius: 14px;
+      padding: 16px 18px;
+      color: white;
+    }
+    .dashboard-summary-title {
+      font-weight: 700;
+      font-size: 1rem;
+      margin-bottom: 12px;
+    }
+    .dashboard-summary-stats {
+      display: flex;
+      gap: 20px;
+      margin-bottom: 12px;
+    }
+    .dashboard-summary-stat {
+      flex: 1;
+    }
+    .dashboard-summary-label {
+      font-size: 0.7rem;
+      opacity: 0.85;
+      margin-bottom: 2px;
+    }
+    .dashboard-summary-value {
+      font-size: 1.1rem;
+      font-weight: 700;
+    }
+    .dashboard-summary-value.done { color: #ffe066; }
+    .dashboard-summary-value.remaining { color: #ffd700; }
     .dashboard-reiter-card {
       margin: 12px 20px;
       background: #fafef5;
@@ -1343,7 +1374,56 @@
         container.innerHTML = '<div class="dashboard-empty">Keine Reiter vorhanden</div>';
         return;
       }
-      container.innerHTML = '';
+
+      // --- Summary across all tabs ---
+      var totalHa = 0, totalEinheiten = 0, totalUsedEinheit = 0;
+      var totalDuenger = 0, totalUsedDuenger = 0;
+      reiter.forEach(function(r) {
+        if (r.hektar > 0 && r.koerner > 0) {
+          totalHa += r.hektar;
+          totalEinheiten += r.hektar * r.koerner / state.koernerProEinheit;
+          totalDuenger += r.hektar * r.duenger;
+          totalUsedEinheit += r.entries.reduce(function(s, e) { return s + e.einheit; }, 0);
+          totalUsedDuenger += r.entries.reduce(function(s, e) { return s + e.duenger; }, 0);
+        }
+      });
+      var totalEinheitRem = Math.max(0, totalEinheiten - totalUsedEinheit);
+      var totalDuengerRem = Math.max(0, totalDuenger - totalUsedDuenger);
+      var totalPct = totalEinheiten > 0 || totalDuenger > 0
+        ? Math.min(100, Math.round(Math.max(
+            totalEinheiten > 0 ? totalUsedEinheit / totalEinheiten : 0,
+            totalDuenger > 0 ? totalUsedDuenger / totalDuenger : 0
+          ) * 100))
+        : 0;
+
+      var summaryCard = document.createElement('div');
+      summaryCard.className = 'dashboard-summary';
+      summaryCard.innerHTML =
+        '<div class="dashboard-summary-title">📊 Zusammenfassung</div>' +
+        '<div class="dashboard-summary-stats">' +
+          '<div class="dashboard-summary-stat">' +
+            '<div class="dashboard-summary-label">Fläche</div>' +
+            '<div class="dashboard-summary-value">' + (totalHa > 0 ? fmt(totalHa) + ' ha' : '—') + '</div>' +
+          '</div>' +
+          '<div class="dashboard-summary-stat">' +
+            '<div class="dashboard-summary-label">Einheiten verbl.</div>' +
+            '<div class="dashboard-summary-value ' + (totalPct >= 100 ? 'done' : totalPct > 0 ? 'remaining' : '') + '">' +
+              (totalEinheiten > 0 ? fmt(totalEinheitRem) : '—') +
+            '</div>' +
+          '</div>' +
+          '<div class="dashboard-summary-stat">' +
+            '<div class="dashboard-summary-label">Dünger verbl.</div>' +
+            '<div class="dashboard-summary-value ' + (totalPct >= 100 ? 'done' : totalPct > 0 ? 'remaining' : '') + '">' +
+              (totalDuenger > 0 ? totalDuengerRem.toLocaleString('de-DE') + ' kg' : '—') +
+            '</div>' +
+          '</div>' +
+        '</div>' +
+        '<div class="dashboard-progress-bar">' +
+          '<div class="dashboard-progress-fill" style="width:' + totalPct + '%"></div>' +
+        '</div>';
+      container.appendChild(summaryCard);
+
+      // --- Per-tab cards ---
       reiter.forEach(function(r, idx) {
         var card = document.createElement('div');
         card.className = 'dashboard-reiter-card';

--- a/public/index.html
+++ b/public/index.html
@@ -490,15 +490,22 @@
       flex: 1;
       overflow-y: auto;
       -webkit-overflow-scrolling: touch;
+      padding-bottom: max(80px, env(safe-area-inset-bottom));
     }
     .sticky-footer {
-      position: sticky;
-      top: 100%;
+      position: fixed;
+      bottom: 0;
+      left: 0;
+      right: 0;
       background: white;
       border-top: 2px solid #e8f0de;
-      padding: 12px 0 max(12px, env(safe-area-inset-bottom));
+      padding: 12px max(20px, env(safe-area-inset-right)) max(12px, env(safe-area-inset-bottom)) max(20px, env(safe-area-inset-left));
       box-shadow: 0 -2px 8px rgba(0,0,0,0.08);
       z-index: 10;
+    }
+    .sticky-footer .container {
+      max-width: 420px;
+      margin: 0 auto;
     }
     .mini-result {
       display: flex;

--- a/public/index.html
+++ b/public/index.html
@@ -332,16 +332,6 @@
       justify-content: space-between;
       align-items: center;
       padding: 10px 0;
-    }
-    .drill-entry-tab-header {
-      font-size: 13px;
-      font-weight: bold;
-      color: #666;
-      padding: 8px 0 4px 0;
-      border-bottom: 1px solid #eee;
-      margin-bottom: 4px;
-    }
-    .drill-entry {
       border-bottom: 1px solid #e8f0de;
       font-size: 0.9rem;
     }
@@ -1456,8 +1446,9 @@
       renderResults();
     }
 
-    function drillRemove(tabIdx, entryIdx) {
-      state.reiter[tabIdx].entries.splice(entryIdx, 1);
+    function drillRemove(idx) {
+      var r = getActiveReiter();
+      r.entries.splice(idx, 1);
       sv();
       renderResults();
     }
@@ -1511,9 +1502,7 @@
       document.getElementById('ds_duenger_used').textContent = usedDuenger >= 0 ? usedDuenger.toLocaleString('de-DE') + ' kg' + haDuengerUsedText : '—';
       document.getElementById('ds_duenger_remaining').textContent = duengerTotal > 0 ? remDuenger.toLocaleString('de-DE') + ' kg' + haDuengerRemText : '—';
       var container = document.getElementById('drill_entries');
-      // Check if any tab has entries
-      var hasAnyEntries = state.reiter.some(function(r) { return r.entries.length > 0; });
-      document.getElementById('drill_summary').style.display = (einheiten > 0 || duengerTotal > 0 || hasAnyEntries) ? 'block' : 'none';
+      document.getElementById('drill_summary').style.display = (einheiten > 0 || duengerTotal > 0 || r.entries.length > 0) ? 'block' : 'none';
       // Build total summary text
       var usedEinheit = r.entries.reduce(function(s, e) { return s + e.einheit; }, 0);
       var usedDuenger = r.entries.reduce(function(s, e) { return s + e.duenger; }, 0);
@@ -1522,7 +1511,7 @@
       if (usedDuenger > 0) summaryParts.push(usedDuenger.toLocaleString('de-DE') + ' kg Dünger');
       document.getElementById('ds_total_summary').textContent = summaryParts.join(' + ');
       // NOTE: drill_section visibility is controlled by renderView() — do NOT set here
-      if (!hasAnyEntries) {
+      if (r.entries.length === 0) {
         container.innerHTML = '';
         var empty = document.createElement('div');
         empty.className = 'drill-empty';
@@ -1530,41 +1519,31 @@
         container.appendChild(empty);
       } else {
         container.innerHTML = '';
-        state.reiter.forEach(function(r, tabIdx) {
-          if (r.entries.length === 0) return;
+        r.entries.forEach(function(e, i) {
+          var ds = e.duenger > 0 ? e.duenger.toLocaleString('de-DE') + ' kg' : '';
+          var dl = ds ? ' + ' + ds + ' Dünger' : '';
+          var hl = e.hektar > 0 ? ' @ ' + (Math.round(e.hektar * 10) / 10).toFixed(1).replace('.', ',') + ' ha' : '';
 
-          // Tab header
-          var tabHeader = document.createElement('div');
-          tabHeader.className = 'drill-entry-tab-header';
-          tabHeader.textContent = r.name || ('Tab ' + (tabIdx + 1));
-          container.appendChild(tabHeader);
+          var entry = document.createElement('div');
+          entry.className = 'drill-entry';
 
-          r.entries.forEach(function(e, entryIdx) {
-            var ds = e.duenger > 0 ? e.duenger.toLocaleString('de-DE') + ' kg' : '';
-            var dl = ds ? ' + ' + ds + ' Dünger' : '';
-            var hl = e.hektar > 0 ? ' @ ' + (Math.round(e.hektar * 10) / 10).toFixed(1).replace('.', ',') + ' ha' : '';
+          var span = document.createElement('span');
+          span.className = 'entry-text';
+          var hash = document.createElement('span');
+          hash.textContent = '#' + (i+1);
+          var txt = (e.time ? e.time + ' – ' : '') + hl + (hl ? ', ' : '') + formatEinheit(e.einheit) + dl;
+          var txtNode = document.createTextNode(txt + ' ');
+          span.appendChild(hash);
+          span.appendChild(txtNode);
 
-            var entry = document.createElement('div');
-            entry.className = 'drill-entry';
+          var btn = document.createElement('button');
+          btn.className = 'btn-danger';
+          btn.textContent = '✕';
+          btn.onclick = function() { drillRemove(i); };
 
-            var span = document.createElement('span');
-            span.className = 'entry-text';
-            var hash = document.createElement('span');
-            hash.textContent = '#' + (entryIdx + 1);
-            var txt = (e.time ? e.time + ' – ' : '') + hl + (hl ? ', ' : '') + formatEinheit(e.einheit) + dl;
-            var txtNode = document.createTextNode(txt + ' ');
-            span.appendChild(hash);
-            span.appendChild(txtNode);
-
-            var btn = document.createElement('button');
-            btn.className = 'btn-danger';
-            btn.textContent = '✕';
-            btn.onclick = (function(ti, ei) { return function() { drillRemove(ti, ei); }; })(tabIdx, entryIdx);
-
-            entry.appendChild(span);
-            entry.appendChild(btn);
-            container.appendChild(entry);
-          });
+          entry.appendChild(span);
+          entry.appendChild(btn);
+          container.appendChild(entry);
         });
       }
     }

--- a/public/index.html
+++ b/public/index.html
@@ -996,7 +996,15 @@
     }
 
     function confirmRemoveReiter(idx) {
-      if (!confirm('Tab wirklich löschen?')) return;
+      var tab = state.reiter[idx];
+      var hasData = tab.hektar > 0 || tab.koerner > 0 || tab.duenger > 0 || tab.entries.length > 0;
+      var msg = 'Tab "' + tab.name + '" schließen?\n\n';
+      if (hasData) {
+        msg += 'Achtung: Es sind Daten vorhanden, die gelöscht werden.';
+      } else {
+        msg += 'Alle Eingaben gehen verloren.';
+      }
+      if (!confirm(msg)) return;
       removeReiter(idx);
     }
 
@@ -1350,7 +1358,8 @@
     }
 
     function confirmResetAll() {
-      if (!confirm('Wirklich alles zurücksetzen?')) return;
+      var tabName = state.reiter[state.activeReiter].name;
+      if (!confirm('Wirklich zurücksetzen?\n\nAlle Eingaben für "' + tabName + '" werden gelöscht.')) return;
       resetAll();
     }
 

--- a/public/index.html
+++ b/public/index.html
@@ -1374,6 +1374,7 @@
         container.innerHTML = '<div class="dashboard-empty">Keine Reiter vorhanden</div>';
         return;
       }
+      container.innerHTML = '';
 
       // --- Summary across all tabs ---
       var totalHa = 0, totalEinheiten = 0, totalUsedEinheit = 0;

--- a/public/index.html
+++ b/public/index.html
@@ -834,6 +834,204 @@
       border-radius: 3px;
       transition: width 0.3s;
     }
+
+    /* Dark mode toggle */
+    .theme-toggle {
+      background: #e8f0de;
+      border: 2px solid #c3dfa8;
+      border-radius: 8px;
+      width: 40px;
+      height: 40px;
+      font-size: 1.15rem;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+      transition: background 0.2s, border-color 0.2s;
+      touch-action: manipulation;
+    }
+    .theme-toggle:active {
+      transform: scale(0.92);
+    }
+
+    /* ===== Dark mode ===== */
+    html.dark body {
+      background: #1a1f16;
+      color: #e0e8d6;
+    }
+    html.dark h1 { color: #8bc34a; }
+    html.dark .subtitle { color: #9aa88a; }
+    html.dark .card {
+      background: #252b20;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+    }
+    html.dark .card h2 {
+      color: #8bc34a;
+      border-bottom-color: #3a4030;
+    }
+    html.dark label { color: #c8d0b8; }
+    html.dark input {
+      background: #1e241a;
+      border-color: #3a4030;
+      color: #e0e8d6;
+    }
+    html.dark input:focus { border-color: #6aa336; }
+    html.dark input::placeholder { color: #5a6050; }
+    html.dark .error-msg { color: #ef5350; }
+    html.dark .unit { color: #7a8470; }
+
+    html.dark .btn { background: #5a9a2a; }
+    html.dark .btn:active { background: #4a7c23; }
+    html.dark .btn-secondary { background: #4a7c23; }
+    html.dark .btn-danger { background: #c62828; }
+    html.dark .btn-danger:active { background: #b71c1c; }
+
+    html.dark .result {
+      background: #2a3320;
+      border-color: #4a7c23;
+    }
+    html.dark .result h2 { border-bottom-color: #3a4030; }
+    html.dark .result-row { border-bottom-color: #3a4030; }
+    html.dark .result-row .label { color: #9aa88a; }
+    html.dark .result-row .value { color: #8bc34a; }
+    html.dark .result-row.remaining .value { color: #ef5350; }
+    html.dark .result-row.done .value { color: #66bb6a; }
+    html.dark .info { color: #7a8470; }
+
+    html.dark .drill-separator { background: #3a4030; }
+    html.dark .drill-entry-inline { border-bottom-color: #3a4030; }
+    html.dark .drill-entry-inline .entry-text { color: #9aa88a; }
+    html.dark .drill-entry-inline .entry-text span { color: #8bc34a; }
+
+    /* Tabs dark */
+    html.dark .tab-btn {
+      background: #2a3320;
+      border-color: #3a4030;
+    }
+    html.dark .tab-btn.field-tab.active {
+      background: #4a7c23;
+      border-color: #5a9a2a;
+      color: white;
+    }
+    html.dark .tab-btn.field-tab:not(.active):hover { background: #333d28; }
+    html.dark .tab-btn:not(.active) .tab-name-input:focus { background: #333d28; }
+    html.dark .tab-add {
+      background: #2a3320;
+      border-color: #3a4030;
+      color: #8bc34a;
+    }
+    html.dark .tab-add:active { background: #333d28; }
+    html.dark .tab-separator { background: #3a4030; }
+    html.dark .tab-btn.protokoll-tab {
+      background: #2a3320;
+      border-color: #4a7c23;
+      color: #8bc34a;
+    }
+    html.dark .tab-btn.protokoll-tab.active {
+      background: #4a7c23;
+      border-color: #4a7c23;
+      color: white;
+    }
+
+    /* Toggle dark */
+    html.dark .toggle-btn { background: #3a4030; }
+    html.dark .toggle-btn.active { background: #4a7c23; }
+    html.dark .fahrgassen-settings { background: #1e241a; }
+    html.dark .fahrgassen-saved { color: #66bb6a; }
+    html.dark .fahrgassen-info { color: #7a8470; }
+
+    /* Sticky footer dark */
+    html.dark .sticky-footer {
+      background: #252b20;
+      border-top-color: #3a4030;
+      box-shadow: 0 -2px 8px rgba(0,0,0,0.3);
+    }
+    html.dark .mini-result { color: #8bc34a; }
+    html.dark .mini-result-empty { color: #5a6050; }
+    html.dark .mini-result .mr-einheiten { color: #8bc34a; }
+    html.dark .mini-result .mr-duenger { color: #66bb6a; }
+
+    /* Dashboard dark */
+    html.dark .dashboard-overlay { background: rgba(0,0,0,0.6); }
+    html.dark .dashboard-sheet { background: #252b20; }
+    html.dark .dashboard-header {
+      background: #252b20;
+      border-bottom-color: #3a4030;
+    }
+    html.dark .dashboard-header h2 { color: #8bc34a; }
+    html.dark .dashboard-close {
+      background: #2a3320;
+      color: #8bc34a;
+    }
+    html.dark .dashboard-close:active { background: #333d28; }
+    html.dark .dashboard-open-btn {
+      background: #4a7c23;
+      color: white;
+    }
+    html.dark .dashboard-open-btn:active { background: #3a6318; }
+    html.dark .dashboard-empty { color: #7a8470; }
+    html.dark .dashboard-reiter-card {
+      background: #1e241a;
+      border-color: #3a4030;
+    }
+    html.dark .dashboard-reiter-name { color: #8bc34a; }
+    html.dark .dashboard-stat {
+      background: #252b20;
+    }
+    html.dark .dashboard-stat-label { color: #7a8470; }
+    html.dark .dashboard-stat-value { color: #e0e8d6; }
+    html.dark .dashboard-stat-value.remaining { color: #ef5350; }
+    html.dark .dashboard-stat-value.done { color: #66bb6a; }
+    html.dark .dashboard-stat-value.na { color: #5a6050; }
+    html.dark .dashboard-progress-bar { background: #3a4030; }
+    html.dark .dashboard-progress-fill { background: #4a7c23; }
+
+    /* Drill section dark */
+    html.dark .drill-tabs-section {
+      border-color: #3a4030;
+      background: #1e241a;
+    }
+    html.dark .drill-tabs-header { color: #9aa88a; }
+    html.dark .drill-prio-btn {
+      background: #2a3320;
+      border-color: #3a4030;
+      color: #7a8470;
+    }
+    html.dark .drill-prio-btn.active {
+      background: #4a7c23;
+      border-color: #5a9a2a;
+      color: white;
+    }
+    html.dark .drill-tab-row:hover { background: rgba(255,255,255,0.03); }
+    html.dark .drill-tab-row .drill-tab-name { color: #c8d0b8; }
+    html.dark .drill-tab-row .drill-tab-need { color: #7a8470; }
+    html.dark .drill-tab-row .drill-tab-need.done { color: #66bb6a; }
+    html.dark .drill-tab-row .drill-tab-values input {
+      background: #1e241a;
+      border-color: #3a4030;
+      color: #e0e8d6;
+    }
+    html.dark .drill-tab-row .drill-tab-values input:focus { border-color: #6aa336; }
+
+    html.dark .drill-summary { background: #1e241a; }
+    html.dark .drill-summary-row { color: #c8d0b8; }
+    html.dark .drill-summary-row.remaining { color: #ef5350; }
+    html.dark .drill-summary-total { color: #8bc34a; border-top-color: #4a7c23; }
+    html.dark #drill_machine_log { border-bottom-color: #3a4030; }
+    html.dark .drill-entry-tab-header { color: #9aa88a; border-bottom-color: #3a4030; }
+    html.dark .drill-entry { border-bottom-color: #3a4030; }
+    html.dark .drill-entry .entry-text { color: #9aa88a; }
+    html.dark .drill-entry .entry-text span { color: #8bc34a; }
+    html.dark .drill-empty { color: #7a8470; }
+
+    html.dark .version-footer { color: #5a6050; }
+
+    /* Dark mode toggle button dark state */
+    html.dark .theme-toggle {
+      background: #2a3320;
+      border-color: #3a4030;
+    }
   </style>
 </head>
 <body>
@@ -845,7 +1043,10 @@
         <h1>🌾 Mais-Rechner</h1>
         <p class="subtitle">Einheiten & Dünger für Aussaat</p>
       </div>
-      <button class="dashboard-open-btn" onclick="openDashboard()">📊 Dashboard</button>
+      <div style="display:flex;gap:8px;align-items:flex-start;">
+        <button class="theme-toggle" onclick="toggleTheme()" id="theme_toggle" aria-label="Dark Mode umschalten">🌙</button>
+        <button class="dashboard-open-btn" onclick="openDashboard()">📊 Dashboard</button>
+      </div>
     </div>
 
     <!-- Tabs -->
@@ -1912,10 +2113,40 @@
       }
     }
 
+    // --- Dark Mode ---
+    function getStoredTheme() {
+      try { return localStorage.getItem('mais_rechner_theme'); } catch(e) { return null; }
+    }
+    function setStoredTheme(theme) {
+      try { localStorage.setItem('mais_rechner_theme', theme); } catch(e) {}
+    }
+    function applyTheme(dark) {
+      document.documentElement.classList.toggle('dark', dark);
+      var btn = document.getElementById('theme_toggle');
+      if (btn) btn.textContent = dark ? '☀️' : '🌙';
+      var meta = document.querySelector('meta[name="theme-color"]');
+      if (meta) meta.setAttribute('content', dark ? '#1a1f16' : '#2d5016');
+    }
+    function toggleTheme() {
+      var isDark = document.documentElement.classList.contains('dark');
+      var next = !isDark;
+      setStoredTheme(next ? 'dark' : 'light');
+      applyTheme(next);
+    }
+    function initTheme() {
+      var stored = getStoredTheme();
+      if (stored === 'dark') { applyTheme(true); return; }
+      if (stored === 'light') { applyTheme(false); return; }
+      // No stored preference: follow system
+      var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+      applyTheme(prefersDark);
+    }
+
     if ('serviceWorker' in navigator) {
       navigator.serviceWorker.register('sw.js');
     }
 
+    initTheme();
     document.addEventListener('DOMContentLoaded', initUI);
 
     // --- Dashboard ---

--- a/public/index.html
+++ b/public/index.html
@@ -383,6 +383,23 @@
       font-weight: 600;
       color: #2d5016;
     }
+    .drill-prognose {
+      font-size: 0.78rem;
+      color: #666;
+      padding: 2px 0 6px 4px;
+    }
+    .drill-prognose span {
+      display: inline-block;
+      margin-right: 10px;
+    }
+    .drill-prognose .prog-label {
+      font-weight: 600;
+      color: #555;
+    }
+    .drill-prognose .prog-val {
+      color: #2d5016;
+      font-weight: 700;
+    }
     .drill-empty {
       text-align: center;
       color: #888;
@@ -1024,6 +1041,10 @@
     html.dark .drill-entry .entry-text { color: #9aa88a; }
     html.dark .drill-entry .entry-text span { color: #8bc34a; }
     html.dark .drill-empty { color: #7a8470; }
+
+    html.dark .drill-prognose { color: #7a8470; }
+    html.dark .drill-prognose .prog-label { color: #9aa88a; }
+    html.dark .drill-prognose .prog-val { color: #8bc34a; }
 
     html.dark .version-footer { color: #5a6050; }
 
@@ -1993,6 +2014,32 @@
           btn.onclick = (function(idx) { return function() { drillMachineRemove(idx); }; })(mi);
           row.appendChild(btn);
           mlContainer.appendChild(row);
+
+          // Prognose: bei welchem ha-Zaehlerstand ist Saat/Duenger leer?
+          if (r.koerner > 0 && (m.einheit > 0 || m.duenger > 0)) {
+            var fgFactor = 1;
+            if (state.fahrgassenEnabled && state.fahrgassenBreite > 0) {
+              fgFactor = (state.fahrgassenBreite - 1) / state.fahrgassenBreite;
+            }
+            var unitsPerHa = r.koerner * fgFactor / state.koernerProEinheit;
+            var prognoseParts = [];
+            if (m.einheit > 0 && unitsPerHa > 0) {
+              var haSaat = m.einheit / unitsPerHa;
+              var prognoseSaat = (m.hektar || 0) + haSaat;
+              prognoseParts.push('<span><span class="prog-label">Saat leer bei</span> <span class="prog-val">~' + fmt(prognoseSaat) + ' ha</span></span>');
+            }
+            if (m.duenger > 0 && r.duenger > 0) {
+              var haDuenger = m.duenger / r.duenger;
+              var prognoseDuenger = (m.hektar || 0) + haDuenger;
+              prognoseParts.push('<span><span class="prog-label">Dünger leer bei</span> <span class="prog-val">~' + fmt(prognoseDuenger) + ' ha</span></span>');
+            }
+            if (prognoseParts.length > 0) {
+              var progRow = document.createElement('div');
+              progRow.className = 'drill-prognose';
+              progRow.innerHTML = prognoseParts.join(' ');
+              mlContainer.appendChild(progRow);
+            }
+          }
         });
       }
       // Per-tab entries in Protokoll view (global log)

--- a/tests/03-berechne.test.js
+++ b/tests/03-berechne.test.js
@@ -125,7 +125,8 @@ describe('berechne()', () => {
     doc.getElementById('hektar').value = '10';
     doc.getElementById('koerner').value = '90000';
     w.berechne();
-    expect(doc.getElementById('drill_section').style.display).toBe('block');
+    // drill_section is shown ONLY in protokoll mode, not after berechne()
+    expect(doc.getElementById('drill_section').style.display).toBe('none');
   });
 
   it('negative duenger is treated as 0', () => {

--- a/tests/05-drill-protocol.test.js
+++ b/tests/05-drill-protocol.test.js
@@ -122,28 +122,26 @@ describe('Drill-Protokoll', () => {
   });
 
   describe('drillRemove()', () => {
-    it('removes an entry by index', () => {
-      doc.getElementById('drill_einheit').value = '2';
-      doc.getElementById('drill_duenger').value = '100';
+    it('removes an entry by tab+index', () => {
+      doc.getElementById('drill_einheit').value = '1';
+      doc.getElementById('drill_duenger').value = '0';
       w.drillAdd();
-
-      doc.getElementById('drill_einheit').value = '3';
-      doc.getElementById('drill_duenger').value = '200';
+      doc.getElementById('drill_einheit').value = '2';
       w.drillAdd();
 
       expect(w.getActiveReiter().entries.length).toBe(2);
 
-      w.drillRemove(0);
+      // Remove first entry: tabIdx=0, entryIdx=0
+      w.drillRemove(0, 0);
       expect(w.getActiveReiter().entries.length).toBe(1);
-      expect(w.getActiveReiter().entries[0].einheit).toBe(3);
+      expect(w.getActiveReiter().entries[0].einheit).toBe(2);
     });
 
     it('removes the last entry', () => {
-      doc.getElementById('drill_einheit').value = '2';
-      doc.getElementById('drill_duenger').value = '100';
+      doc.getElementById('drill_einheit').value = '1';
       w.drillAdd();
 
-      w.drillRemove(0);
+      w.drillRemove(0, 0);
       expect(w.getActiveReiter().entries.length).toBe(0);
     });
   });
@@ -189,7 +187,6 @@ describe('Drill-Protokoll', () => {
 
     it('shows total summary in drill_entries after adding entry', () => {
       doc.getElementById('drill_einheit').value = '5';
-      doc.getElementById('drill_hektar').value = '3,5';
       doc.getElementById('drill_duenger').value = '500';
       w.drillAdd();
 

--- a/tests/05-drill-protocol.test.js
+++ b/tests/05-drill-protocol.test.js
@@ -122,26 +122,28 @@ describe('Drill-Protokoll', () => {
   });
 
   describe('drillRemove()', () => {
-    it('removes an entry by tab+index', () => {
-      doc.getElementById('drill_einheit').value = '1';
-      doc.getElementById('drill_duenger').value = '0';
-      w.drillAdd();
+    it('removes an entry by index', () => {
       doc.getElementById('drill_einheit').value = '2';
+      doc.getElementById('drill_duenger').value = '100';
+      w.drillAdd();
+
+      doc.getElementById('drill_einheit').value = '3';
+      doc.getElementById('drill_duenger').value = '200';
       w.drillAdd();
 
       expect(w.getActiveReiter().entries.length).toBe(2);
 
-      // Remove first entry: tabIdx=0, entryIdx=0
-      w.drillRemove(0, 0);
+      w.drillRemove(0);
       expect(w.getActiveReiter().entries.length).toBe(1);
-      expect(w.getActiveReiter().entries[0].einheit).toBe(2);
+      expect(w.getActiveReiter().entries[0].einheit).toBe(3);
     });
 
     it('removes the last entry', () => {
-      doc.getElementById('drill_einheit').value = '1';
+      doc.getElementById('drill_einheit').value = '2';
+      doc.getElementById('drill_duenger').value = '100';
       w.drillAdd();
 
-      w.drillRemove(0, 0);
+      w.drillRemove(0);
       expect(w.getActiveReiter().entries.length).toBe(0);
     });
   });
@@ -187,6 +189,7 @@ describe('Drill-Protokoll', () => {
 
     it('shows total summary in drill_entries after adding entry', () => {
       doc.getElementById('drill_einheit').value = '5';
+      doc.getElementById('drill_hektar').value = '3,5';
       doc.getElementById('drill_duenger').value = '500';
       w.drillAdd();
 

--- a/tests/05-drill-protocol.test.js
+++ b/tests/05-drill-protocol.test.js
@@ -152,13 +152,13 @@ describe('Drill-Protokoll', () => {
       doc.getElementById('drill_duenger').value = '500';
       w.drillAdd();
 
-      // Check drill summary
-      // Total einheiten = 18 (10ha * 90000 / 50000) — ha shown in brackets
-      expect(doc.getElementById('ds_saat_total').textContent).toBe('18,0 (10,0 ha)');
+      // Check drill summary (aggregated across all tabs)
+      // Total einheiten = 18 (10ha * 90000 / 50000)
+      expect(doc.getElementById('ds_saat_total').textContent).toBe('18,0 Einheiten');
       // Used einheit = 5
       expect(doc.getElementById('ds_saat_used').textContent).toContain('5,0');
-      // Remaining = 18 - 5 = 13, ha in brackets
-      expect(doc.getElementById('ds_saat_remaining').textContent).toBe('13,0 (7,2 ha)');
+      // Remaining = 18 - 5 = 13
+      expect(doc.getElementById('ds_saat_remaining').textContent).toBe('13,0 Einheiten');
       // Duenger total = 1500
       expect(doc.getElementById('ds_duenger_total').textContent).toContain('1.500');
       // Duenger used = 500
@@ -209,7 +209,7 @@ describe('Drill-Protokoll', () => {
 
       const rem = doc.getElementById('ds_saat_remaining').textContent;
       // Math.max(0, 18 - 20) = 0
-      expect(rem).toBe('0,0 (0,0 ha)');
+      expect(rem).toBe('0,0 Einheiten');
     });
 
     it('remaining duenger is clamped to 0 (no negative)', () => {

--- a/tests/05-drill-protocol.test.js
+++ b/tests/05-drill-protocol.test.js
@@ -194,22 +194,22 @@ describe('Drill-Protokoll', () => {
       expect(entries.length).toBe(1);
     });
 
-    it('shows total summary line', () => {
+    it('shows total summary in drill_entries after adding entry', () => {
       doc.getElementById('drill_einheit').value = '5';
       doc.getElementById('drill_hektar').value = '3,5';
       doc.getElementById('drill_duenger').value = '500';
       w.drillAdd();
 
-      const summary = doc.getElementById('ds_total_summary').textContent;
-      expect(summary).toContain('3,5 ha');
-      expect(summary).toContain('5,0 Einheiten');
-      expect(summary).toContain('500');
-      expect(summary).toContain('Dünger');
-      expect(summary).toContain('eingefüllt');
+      const entries = doc.getElementById('drill_entries').querySelectorAll('.drill-entry');
+      expect(entries.length).toBe(1);
+      expect(entries[0].textContent).toContain('5,0 Einheiten');
+      expect(entries[0].textContent).toContain('500 kg');
     });
 
-    it('shows "—" total summary when no entries', () => {
-      expect(doc.getElementById('ds_total_summary').textContent).toBe('—');
+    it('shows empty state when no entries', () => {
+      const empty = doc.getElementById('drill_entries').querySelector('.drill-empty');
+      expect(empty).not.toBeNull();
+      expect(empty.textContent).toBe('Noch nichts eingefüllt');
     });
 
     it('remaining duenger is clamped to 0 (no negative)', () => {

--- a/tests/05-drill-protocol.test.js
+++ b/tests/05-drill-protocol.test.js
@@ -20,17 +20,16 @@ describe('Drill-Protokoll', () => {
   });
 
   describe('drillAdd()', () => {
-    it('adds an entry with einheit and hektar', () => {
+    it('adds an entry with einheit and duenger', () => {
       doc.getElementById('drill_einheit').value = '1,5';
-      doc.getElementById('drill_hektar').value = '5,0';
       doc.getElementById('drill_duenger').value = '200';
       w.drillAdd();
 
       const entries = w.getActiveReiter().entries;
       expect(entries.length).toBe(1);
       expect(entries[0].einheit).toBeCloseTo(1.5);
-      expect(entries[0].hektar).toBeCloseTo(5.0);
       expect(entries[0].duenger).toBe(200);
+      expect(entries[0].hektar).toBe(0); // Hektar not tracked per entry anymore
       expect(entries[0].time).toBeTruthy();
     });
 
@@ -79,12 +78,10 @@ describe('Drill-Protokoll', () => {
 
     it('clears input fields after adding', () => {
       doc.getElementById('drill_einheit').value = '2';
-      doc.getElementById('drill_hektar').value = '5';
       doc.getElementById('drill_duenger').value = '300';
       w.drillAdd();
 
       expect(doc.getElementById('drill_einheit').value).toBe('');
-      expect(doc.getElementById('drill_hektar').value).toBe('');
       expect(doc.getElementById('drill_duenger').value).toBe('');
     });
 
@@ -100,12 +97,10 @@ describe('Drill-Protokoll', () => {
 
     it('adds multiple entries in sequence', () => {
       doc.getElementById('drill_einheit').value = '2';
-      doc.getElementById('drill_hektar').value = '3';
       doc.getElementById('drill_duenger').value = '100';
       w.drillAdd();
 
       doc.getElementById('drill_einheit').value = '3';
-      doc.getElementById('drill_hektar').value = '4';
       doc.getElementById('drill_duenger').value = '200';
       w.drillAdd();
 
@@ -156,18 +151,16 @@ describe('Drill-Protokoll', () => {
   describe('renderResults() — drill summary', () => {
     it('shows correct summary after adding entries', () => {
       doc.getElementById('drill_einheit').value = '5';
-      doc.getElementById('drill_hektar').value = '3,5';
       doc.getElementById('drill_duenger').value = '500';
       w.drillAdd();
 
       // Check drill summary
-      // Total einheiten = 18 (10ha * 90000 / 50000)
-      expect(doc.getElementById('ds_saat_total').textContent).toBe('18,0 Einheiten');
+      // Total einheiten = 18 (10ha * 90000 / 50000) — ha shown in brackets
+      expect(doc.getElementById('ds_saat_total').textContent).toBe('18,0 (10,0 ha)');
       // Used einheit = 5
-      expect(doc.getElementById('ds_saat_used').textContent).toContain('5,0 Einheiten');
-      expect(doc.getElementById('ds_saat_used').textContent).toContain('3,5 ha');
-      // Remaining = 18 - 5 = 13
-      expect(doc.getElementById('ds_saat_remaining').textContent).toBe('13,0 Einheiten');
+      expect(doc.getElementById('ds_saat_used').textContent).toContain('5,0');
+      // Remaining = 18 - 5 = 13, ha in brackets
+      expect(doc.getElementById('ds_saat_remaining').textContent).toBe('13,0 (7,2 ha)');
       // Duenger total = 1500
       expect(doc.getElementById('ds_duenger_total').textContent).toContain('1.500');
       // Duenger used = 500
@@ -212,6 +205,16 @@ describe('Drill-Protokoll', () => {
       expect(empty.textContent).toBe('Noch nichts eingefüllt');
     });
 
+    it('remaining einheit is clamped to 0 (no negative)', () => {
+      doc.getElementById('drill_einheit').value = '20';
+      doc.getElementById('drill_duenger').value = '0';
+      w.drillAdd();
+
+      const rem = doc.getElementById('ds_saat_remaining').textContent;
+      // Math.max(0, 18 - 20) = 0
+      expect(rem).toBe('0,0 (0,0 ha)');
+    });
+
     it('remaining duenger is clamped to 0 (no negative)', () => {
       // Add more duenger than total
       doc.getElementById('drill_einheit').value = '0';
@@ -221,16 +224,6 @@ describe('Drill-Protokoll', () => {
       const rem = doc.getElementById('ds_duenger_remaining').textContent;
       // Math.max(0, 1500 - 2000) = 0
       expect(rem).toContain('0');
-    });
-
-    it('remaining einheit is clamped to 0 (no negative)', () => {
-      doc.getElementById('drill_einheit').value = '20';
-      doc.getElementById('drill_duenger').value = '0';
-      w.drillAdd();
-
-      const rem = doc.getElementById('ds_saat_remaining').textContent;
-      // Math.max(0, 18 - 20) = 0
-      expect(rem).toBe('0,0 Einheiten');
     });
   });
 });

--- a/tests/06-tab-management.test.js
+++ b/tests/06-tab-management.test.js
@@ -231,6 +231,17 @@ describe('Tab management', () => {
       expect(closes.length).toBe(2);
     });
 
+    it('tab name input is visible and editable with only 1 tab', () => {
+      w.renderTabs();
+      const inputs = doc.querySelectorAll('.tab-name-input');
+      expect(inputs.length).toBe(1);
+      expect(inputs[0].value).toBe('Tab 1');
+      // Simulate renaming
+      inputs[0].value = 'Mein Feld';
+      inputs[0].onblur();
+      expect(w.state.reiter[0].name).toBe('Mein Feld');
+    });
+
     it('tab name input shows correct name', () => {
       w.addReiter();
       w.renameReiter(1, 'Test');

--- a/tests/06-tab-management.test.js
+++ b/tests/06-tab-management.test.js
@@ -189,16 +189,28 @@ describe('Tab management', () => {
   });
 
   describe('renderTabs()', () => {
-    it('shows no tab buttons when only 1 reiter', () => {
+    it('shows single tab button when only 1 reiter (for rename)', () => {
       w.renderTabs();
-    const btns = doc.querySelectorAll('.field-tab');
-    expect(btns.length).toBe(0);
+      const btns = doc.querySelectorAll('.field-tab');
+      expect(btns.length).toBe(1);
     });
 
     it('shows tab buttons when 2+ reiter', () => {
       w.addReiter();
-    const btns = doc.querySelectorAll('.field-tab');
-    expect(btns.length).toBe(2);
+      const btns = doc.querySelectorAll('.field-tab');
+      expect(btns.length).toBe(2);
+    });
+
+    it('hides close button when only 1 tab', () => {
+      w.renderTabs();
+      const closes = doc.querySelectorAll('.tab-close');
+      expect(closes.length).toBe(0);
+    });
+
+    it('shows close buttons when 2+ tabs', () => {
+      w.addReiter();
+      const closes = doc.querySelectorAll('.tab-close');
+      expect(closes.length).toBe(2);
     });
 
     it('marks active tab with "active" class', () => {

--- a/tests/06-tab-management.test.js
+++ b/tests/06-tab-management.test.js
@@ -191,14 +191,14 @@ describe('Tab management', () => {
   describe('renderTabs()', () => {
     it('shows no tab buttons when only 1 reiter', () => {
       w.renderTabs();
-      const btns = doc.querySelectorAll('.tab-btn');
-      expect(btns.length).toBe(0);
+    const btns = doc.querySelectorAll('.field-tab');
+    expect(btns.length).toBe(0);
     });
 
     it('shows tab buttons when 2+ reiter', () => {
       w.addReiter();
-      const btns = doc.querySelectorAll('.tab-btn');
-      expect(btns.length).toBe(2);
+    const btns = doc.querySelectorAll('.field-tab');
+    expect(btns.length).toBe(2);
     });
 
     it('marks active tab with "active" class', () => {

--- a/tests/08-reset-init-sync.test.js
+++ b/tests/08-reset-init-sync.test.js
@@ -168,7 +168,7 @@ describe('initUI()', () => {
     });
     w.initUI();
     // Tab buttons should appear (2 tabs)
-    const btns = doc.querySelectorAll('.tab-btn');
+    const btns = doc.querySelectorAll('.field-tab');
     expect(btns.length).toBe(2);
     // Active should be tab 1
     expect(w.state.activeReiter).toBe(1);

--- a/tests/09-blind-spots.test.js
+++ b/tests/09-blind-spots.test.js
@@ -270,8 +270,8 @@ describe('Blind spots — renderResults edge cases', () => {
     w.renderResults();
 
     const hashes = doc.querySelectorAll('.entry-text span');
-    expect(hashes[0].textContent).toBe('#1');
-    expect(hashes[1].textContent).toBe('#2');
+    expect(hashes[0].textContent).toBe('#1 ');
+    expect(hashes[1].textContent).toBe('#2 ');
   });
 
   it('drill entry delete button has btn-danger class and calls drillRemove', () => {

--- a/tests/09-blind-spots.test.js
+++ b/tests/09-blind-spots.test.js
@@ -283,11 +283,13 @@ describe('Blind spots — renderResults edge cases', () => {
     r.entries.push({ einheit: 2, hektar: 0, duenger: 0, time: '10:00' });
     w.renderResults();
 
+    // Two btn-danger buttons: one in result card inline entries, one in Protokoll view
     const btns = doc.querySelectorAll('.btn-danger');
-    expect(btns.length).toBe(1);
+    expect(btns.length).toBe(2);
     expect(btns[0].textContent).toBe('✕');
+    expect(btns[1].textContent).toBe('✕');
 
-    // Click delete
+    // Click delete on the first one (result card inline entry)
     btns[0].onclick();
     expect(r.entries.length).toBe(0);
   });

--- a/tests/09-blind-spots.test.js
+++ b/tests/09-blind-spots.test.js
@@ -322,8 +322,8 @@ describe('Blind spots — renderResults with duenger-only entry (einheit=0)', ()
     w.renderResults();
 
     const summary = doc.getElementById('ds_total_summary').textContent;
-    expect(summary).toContain('0,0 Einheiten');
     expect(summary).toContain('500 kg Dünger');
+    expect(summary).not.toContain('Einheiten');
     expect(summary).not.toContain('ha');
   });
 });

--- a/tests/09-blind-spots.test.js
+++ b/tests/09-blind-spots.test.js
@@ -363,7 +363,8 @@ describe('Blind spots — switchReiter hides drill_section when no data', () => 
     doc.getElementById('hektar').value = '10';
     doc.getElementById('koerner').value = '90000';
     w.berechne();
-    expect(doc.getElementById('drill_section').style.display).toBe('block');
+    // drill_section should NOT show after berechne() in normal view (only in protokoll mode)
+    expect(doc.getElementById('drill_section').style.display).toBe('none');
 
     // Add empty tab 1 and switch to it
     w.addReiter();

--- a/tests/09-blind-spots.test.js
+++ b/tests/09-blind-spots.test.js
@@ -18,7 +18,7 @@ describe('Blind spots — renderTabs callbacks', () => {
     // Tab 0 button should switch to reiter 0
     expect(w.state.activeReiter).toBe(1); // currently on tab 1
 
-    const btns = doc.querySelectorAll('.tab-btn');
+    const btns = doc.querySelectorAll('.field-tab');
     btns[0].onclick(); // click tab 0
     expect(w.state.activeReiter).toBe(0);
   });

--- a/tests/10-regression-session-fixes.test.js
+++ b/tests/10-regression-session-fixes.test.js
@@ -136,7 +136,7 @@ describe('Regression: renderTabs creates tab-add button fresh', () => {
   it('renderTabs survives adding and removing tabs repeatedly', () => {
     w.addReiter(); // 2 tabs
     w.addReiter(); // 3 tabs
-    expect(doc.querySelectorAll('.tab-btn').length).toBe(3);
+    expect(doc.querySelectorAll('.field-tab').length).toBe(3);
     expect(doc.querySelector('.tab-add')).not.toBeNull();
 
     w.removeReiter(2);

--- a/tests/11-dashboard.test.js
+++ b/tests/11-dashboard.test.js
@@ -1,0 +1,187 @@
+/**
+ * Tests for Dashboard feature: openDashboard, closeDashboard, renderDashboard
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createDom } from './helpers.js';
+
+describe('Dashboard', () => {
+  let w, doc, store;
+
+  beforeEach(() => {
+    const result = createDom();
+    w = result.window;
+    doc = w.document;
+    store = result.store;
+  });
+
+  describe('openDashboard() / closeDashboard()', () => {
+    it('opens the dashboard sheet and overlay', () => {
+      w.openDashboard();
+      expect(doc.getElementById('dashboard_sheet').classList.contains('open')).toBe(true);
+      expect(doc.getElementById('dashboard_overlay').classList.contains('open')).toBe(true);
+    });
+
+    it('sets body overflow to hidden when open', () => {
+      w.openDashboard();
+      expect(doc.body.style.overflow).toBe('hidden');
+    });
+
+    it('closes the dashboard sheet and overlay', () => {
+      w.openDashboard();
+      w.closeDashboard();
+      expect(doc.getElementById('dashboard_sheet').classList.contains('open')).toBe(false);
+      expect(doc.getElementById('dashboard_overlay').classList.contains('open')).toBe(false);
+    });
+
+    it('restores body overflow on close', () => {
+      w.openDashboard();
+      w.closeDashboard();
+      expect(doc.body.style.overflow).toBe('');
+    });
+
+    it('renderDashboard is called when opening', () => {
+      // Setup state with one tab that has data
+      w.state.reiter[0].hektar = 10;
+      w.state.reiter[0].koerner = 90000;
+      w.state.reiter[0].duenger = 150;
+      w.openDashboard();
+      // Should have a card in the content
+      const cards = doc.getElementById('dashboard_content').querySelectorAll('.dashboard-reiter-card');
+      expect(cards.length).toBe(1);
+    });
+
+    it('shows empty state when no reiter', () => {
+      w.state.reiter = [];
+      w.openDashboard();
+      const empty = doc.getElementById('dashboard_content').querySelector('.dashboard-empty');
+      expect(empty).toBeTruthy();
+    });
+  });
+
+  describe('renderDashboard() — single tab', () => {
+    it('shows tab name', () => {
+      w.state.reiter[0].name = 'Feld A';
+      w.state.reiter[0].hektar = 10;
+      w.state.reiter[0].koerner = 90000;
+      w.openDashboard();
+      const nameEl = doc.querySelector('.dashboard-reiter-name');
+      expect(nameEl.textContent).toContain('Feld A');
+    });
+
+    it('marks active tab with "(aktiv)"', () => {
+      w.addReiter();
+      // addReiter already sets activeReiter=1, so tab 1 is active
+      w.openDashboard();
+      const names = doc.querySelectorAll('.dashboard-reiter-name');
+      expect(names[1].textContent).toContain('(aktiv)');
+    });
+
+    it('shows hektar value', () => {
+      w.state.reiter[0].hektar = 12.5;
+      w.state.reiter[0].koerner = 90000;
+      w.openDashboard();
+      const values = doc.querySelectorAll('.dashboard-stat-value');
+      expect(values[0].textContent).toContain('12,5');
+    });
+
+    it('shows koerner value with DE formatting', () => {
+      w.state.reiter[0].hektar = 10;
+      w.state.reiter[0].koerner = 90000;
+      w.openDashboard();
+      const values = doc.querySelectorAll('.dashboard-stat-value');
+      expect(values[1].textContent).toBe('90.000');
+    });
+
+    it('shows — when hektar is 0', () => {
+      w.state.reiter[0].hektar = 0;
+      w.state.reiter[0].koerner = 90000;
+      w.openDashboard();
+      const values = doc.querySelectorAll('.dashboard-stat-value');
+      expect(values[0].textContent).toBe('—');
+    });
+
+    it('shows — when koerner is 0', () => {
+      w.state.reiter[0].hektar = 10;
+      w.state.reiter[0].koerner = 0;
+      w.openDashboard();
+      const values = doc.querySelectorAll('.dashboard-stat-value');
+      expect(values[1].textContent).toBe('—');
+    });
+
+    it('shows remaining einheiten with remaining class when partially filled', () => {
+      w.state.reiter[0].hektar = 10;
+      w.state.reiter[0].koerner = 50000; // 10 units
+      w.state.reiter[0].entries = [{ einheit: 5, hektar: 0, duenger: 0, time: '08:00' }];
+      w.openDashboard();
+      // The einheiten remaining stat is at index 2
+      const values = doc.querySelectorAll('.dashboard-stat-value');
+      expect(values[2].textContent).toContain('5,0');
+      expect(values[2].classList.contains('remaining')).toBe(true);
+    });
+
+    it('shows remaining duenger with remaining class when partially filled', () => {
+      w.state.reiter[0].hektar = 10;
+      w.state.reiter[0].koerner = 90000;
+      w.state.reiter[0].duenger = 150;
+      w.state.reiter[0].entries = [{ einheit: 0, hektar: 0, duenger: 75, time: '08:00' }];
+      w.openDashboard();
+      const values = doc.querySelectorAll('.dashboard-stat-value');
+      // Find duenger remaining (should be 750 kg)
+      const duengerRem = Array.from(values).find(v => v.textContent.includes('kg'));
+      expect(duengerRem.classList.contains('remaining')).toBe(true);
+    });
+
+    it('shows done class when fully filled', () => {
+      w.state.reiter[0].hektar = 10;
+      w.state.reiter[0].koerner = 50000;
+      w.state.reiter[0].entries = [{ einheit: 10, hektar: 0, duenger: 0, time: '08:00' }];
+      w.openDashboard();
+      const values = doc.querySelectorAll('.dashboard-stat-value');
+      // First remaining stat
+      expect(values[2].classList.contains('done')).toBe(true);
+    });
+
+    it('progress bar shows 0% when no calculation', () => {
+      w.state.reiter[0].hektar = 0;
+      w.state.reiter[0].koerner = 0;
+      w.openDashboard();
+      const fill = doc.querySelector('.dashboard-progress-fill');
+      expect(fill.style.width).toBe('0%');
+    });
+
+    it('progress bar shows correct percentage', () => {
+      w.state.reiter[0].hektar = 10;
+      w.state.reiter[0].koerner = 50000;
+      w.state.reiter[0].entries = [{ einheit: 5, hektar: 0, duenger: 0, time: '08:00' }]; // 50%
+      w.openDashboard();
+      const fill = doc.querySelector('.dashboard-progress-fill');
+      expect(fill.style.width).toBe('50%');
+    });
+  });
+
+  describe('renderDashboard() — multiple tabs', () => {
+    it('renders one card per tab', () => {
+      w.addReiter();
+      w.addReiter();
+      w.openDashboard();
+      const cards = doc.querySelectorAll('.dashboard-reiter-card');
+      expect(cards.length).toBe(3);
+    });
+
+    it('each card shows its respective values', () => {
+      w.state.reiter[0].hektar = 10;
+      w.state.reiter[0].koerner = 90000;
+      w.addReiter();
+      w.state.reiter[1].hektar = 20;
+      w.state.reiter[1].koerner = 80000;
+      w.openDashboard();
+      const cards = doc.querySelectorAll('.dashboard-reiter-card');
+      // First card: 10 ha
+      const firstHa = cards[0].querySelectorAll('.dashboard-stat-value')[0];
+      expect(firstHa.textContent).toContain('10');
+      // Second card: 20 ha
+      const secondHa = cards[1].querySelectorAll('.dashboard-stat-value')[0];
+      expect(secondHa.textContent).toContain('20');
+    });
+  });
+});

--- a/tests/17-edge-cases.test.js
+++ b/tests/17-edge-cases.test.js
@@ -175,7 +175,7 @@ describe('confirmResetAll', () => {
   let w;
   beforeEach(() => { w = createDom().window; });
 
-  it('calls resetActiveTab when confirmed', () => {
+  it('calls resetActiveTab when confirmed (partial reset)', () => {
     // Mock confirm to return true
     var originalConfirm = w.confirm;
     w.confirm = () => true;
@@ -185,6 +185,22 @@ describe('confirmResetAll', () => {
 
     expect(w.state.reiter[0].hektar).toBe(0);
     expect(w.state.reiter[0].koerner).toBe(0);
+
+    w.confirm = originalConfirm;
+  });
+
+  it('calls resetAll when fullReset=true', () => {
+    var originalConfirm = w.confirm;
+    w.confirm = () => true;
+
+    w.addReiter();
+    w.state.reiter[0] = { ...w.state.reiter[0], hektar: 10, koerner: 90000 };
+    w.state.reiter[1] = { ...w.state.reiter[1], hektar: 5, koerner: 45000 };
+    w.state.machineLog = [{ einheit: 5, hektar: 3, duenger: 100, time: '10:00' }];
+    w.confirmResetAll(true);  // full reset
+
+    expect(w.state.reiter.length).toBe(1);  // all tabs cleared
+    expect(w.state.machineLog).toEqual([]);   // machineLog cleared
 
     w.confirm = originalConfirm;
   });

--- a/tests/17-edge-cases.test.js
+++ b/tests/17-edge-cases.test.js
@@ -1,0 +1,396 @@
+/**
+ * Tests for remaining edge cases and utility functions:
+ * - fmt() formatting
+ * - formatDE() number to string
+ * - getTabKornerGesamt / getTabTotalDuenger with various inputs
+ * - getTabTotalEinheiten with fahrgassen
+ * - lv() migration edge cases
+ * - confirmResetAll / confirmRemoveReiter (confirm mock)
+ * - resetAll clears machineLog
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createDom } from './helpers.js';
+
+describe('fmt()', () => {
+  let w;
+  beforeEach(() => { w = createDom().window; });
+
+  it('formats integer with one decimal', () => {
+    expect(w.fmt(5)).toBe('5,0');
+  });
+
+  it('formats decimal correctly', () => {
+    expect(w.fmt(3.7)).toBe('3,7');
+  });
+
+  it('rounds to one decimal place', () => {
+    expect(w.fmt(3.14159)).toBe('3,1');
+  });
+
+  it('rounds 0.05 to 0,1 (round half up)', () => {
+    expect(w.fmt(0.05)).toBe('0,1');
+  });
+
+  it('rounds 0.04 to 0,0', () => {
+    expect(w.fmt(0.04)).toBe('0,0');
+  });
+
+  it('formats 0 correctly', () => {
+    expect(w.fmt(0)).toBe('0,0');
+  });
+
+  it('formats large numbers', () => {
+    expect(w.fmt(12345.6)).toBe('12345,6');
+  });
+
+  it('handles negative numbers', () => {
+    expect(w.fmt(-3.5)).toBe('-3,5');
+  });
+});
+
+describe('formatDE()', () => {
+  let w;
+  beforeEach(() => { w = createDom().window; });
+
+  it('replaces dot with comma', () => {
+    expect(w.formatDE(3.5)).toBe('3,5');
+  });
+
+  it('integer stays integer (no comma)', () => {
+    expect(w.formatDE(10)).toBe('10');
+  });
+
+  it('0 stays 0', () => {
+    expect(w.formatDE(0)).toBe('0');
+  });
+
+  it('works with very small decimals', () => {
+    expect(w.formatDE(0.1)).toBe('0,1');
+  });
+});
+
+describe('getTabKornerGesamt cross-tab', () => {
+  let w;
+  beforeEach(() => { w = createDom().window; });
+
+  it('works for a specific tab, not activeReiter', () => {
+    w.state.reiter = [
+      { name: 'A', hektar: 10, koerner: 90000, entries: [] },
+      { name: 'B', hektar: 5, koerner: 80000, entries: [] },
+    ];
+    expect(w.getTabKornerGesamt(w.state.reiter[0])).toBe(900000);
+    expect(w.getTabKornerGesamt(w.state.reiter[1])).toBe(400000);
+  });
+
+  it('respects fahrgassen for specific tab', () => {
+    var tab = { name: 'X', hektar: 10, koerner: 100000, entries: [] };
+    w.state.fahrgassenEnabled = true;
+    w.state.fahrgassenBreite = 4;
+    // (4-1)/4 = 0.75
+    expect(w.getTabKornerGesamt(tab)).toBe(750000);
+  });
+});
+
+describe('getTabTotalDuenger cross-tab', () => {
+  let w;
+  beforeEach(() => { w = createDom().window; });
+
+  it('works for a specific tab', () => {
+    var tab = { name: 'X', hektar: 10, duenger: 200, entries: [] };
+    expect(w.getTabTotalDuenger(tab)).toBe(2000);
+  });
+
+  it('returns 0 when hektar is 0', () => {
+    var tab = { name: 'X', hektar: 0, duenger: 200, entries: [] };
+    expect(w.getTabTotalDuenger(tab)).toBe(0);
+  });
+
+  it('returns 0 when duenger is 0', () => {
+    var tab = { name: 'X', hektar: 10, duenger: 0, entries: [] };
+    expect(w.getTabTotalDuenger(tab)).toBe(0);
+  });
+});
+
+describe('lv() migration edge cases', () => {
+  let w;
+  beforeEach(() => { w = createDom().window; });
+
+  it('migrates old flat state with entries to tabbed', () => {
+    var oldState = {
+      hektar: 10,
+      koerner: 90000,
+      duenger: 150,
+      entries: [{ einheit: 5, duenger: 100 }]
+    };
+    w.localStorage.setItem('mais_rechner', JSON.stringify(oldState));
+    w.lv();
+    expect(w.state.reiter).toBeTruthy();
+    expect(w.state.reiter.length).toBe(1);
+    expect(w.state.reiter[0].hektar).toBe(10);
+    expect(w.state.reiter[0].koerner).toBe(90000);
+    expect(w.state.reiter[0].entries.length).toBe(1);
+  });
+
+  it('migrates state with global entries to first tab entries', () => {
+    var oldState = {
+      reiter: [{ name: 'Tab 1', hektar: 5, koerner: 80000 }],
+      entries: [{ einheit: 3, duenger: 50 }]
+    };
+    w.localStorage.setItem('mais_rechner', JSON.stringify(oldState));
+    w.lv();
+    expect(w.state.reiter[0].entries.length).toBe(1);
+    // Global entries should be removed
+    expect(w.state.entries).toBeUndefined();
+  });
+
+  it('does not overwrite existing tab entries during migration', () => {
+    var oldState = {
+      reiter: [
+        { name: 'Tab 1', hektar: 5, koerner: 80000, entries: [{ einheit: 2 }] },
+        { name: 'Tab 2', hektar: 3, koerner: 70000 }
+      ],
+      entries: [{ einheit: 3 }]
+    };
+    w.localStorage.setItem('mais_rechner', JSON.stringify(oldState));
+    w.lv();
+    // Tab 1 already has entries, should keep them
+    expect(w.state.reiter[0].entries.length).toBe(1);
+    expect(w.state.reiter[0].entries[0].einheit).toBe(2);
+    // Tab 2 should get entries array
+    expect(w.state.reiter[1].entries).toEqual([]);
+  });
+
+  it('ensures machineLog exists after migration', () => {
+    var oldState = {
+      reiter: [{ name: 'Tab 1', hektar: 5, koerner: 80000, entries: [] }]
+    };
+    delete oldState.machineLog;
+    w.localStorage.setItem('mais_rechner', JSON.stringify(oldState));
+    w.lv();
+    expect(w.state.machineLog).toEqual([]);
+  });
+});
+
+describe('confirmResetAll', () => {
+  let w;
+  beforeEach(() => { w = createDom().window; });
+
+  it('calls resetActiveTab when confirmed', () => {
+    // Mock confirm to return true
+    var originalConfirm = w.confirm;
+    w.confirm = () => true;
+
+    w.state.reiter[0] = { ...w.state.reiter[0], hektar: 10, koerner: 90000 };
+    w.confirmResetAll();
+
+    expect(w.state.reiter[0].hektar).toBe(0);
+    expect(w.state.reiter[0].koerner).toBe(0);
+
+    w.confirm = originalConfirm;
+  });
+
+  it('does nothing when cancelled', () => {
+    var originalConfirm = w.confirm;
+    w.confirm = () => false;
+
+    w.state.reiter[0] = { ...w.state.reiter[0], hektar: 10, koerner: 90000 };
+    w.confirmResetAll();
+
+    expect(w.state.reiter[0].hektar).toBe(10);
+
+    w.confirm = originalConfirm;
+  });
+
+  it('includes tab name in confirm message', () => {
+    var lastMsg = '';
+    var originalConfirm = w.confirm;
+    w.confirm = (msg) => { lastMsg = msg; return false; };
+
+    w.state.reiter[0].name = 'Feld A';
+    w.confirmResetAll();
+
+    expect(lastMsg).toContain('Feld A');
+
+    w.confirm = originalConfirm;
+  });
+});
+
+describe('resetActiveTab', () => {
+  let w;
+  beforeEach(() => { w = createDom().window; });
+
+  it('resets only active tab data', () => {
+    w.state.reiter[0] = { ...w.state.reiter[0], hektar: 10, koerner: 90000, duenger: 500, entries: [{ einheit: 5 }] };
+    w.resetActiveTab();
+
+    expect(w.state.reiter[0].hektar).toBe(0);
+    expect(w.state.reiter[0].koerner).toBe(0);
+    expect(w.state.reiter[0].duenger).toBe(0);
+    expect(w.state.reiter[0].entries).toEqual([]);
+  });
+
+  it('preserves other tabs when multi-tab', () => {
+    w.addReiter();
+    w.state.reiter[0] = { ...w.state.reiter[0], hektar: 10, koerner: 90000 };
+    w.state.reiter[1] = { ...w.state.reiter[1], hektar: 5, koerner: 45000 };
+    w.state.activeReiter = 0;
+    w.resetActiveTab();
+
+    expect(w.state.reiter[0].hektar).toBe(0);
+    expect(w.state.reiter[1].hektar).toBe(5);  // preserved
+    expect(w.state.reiter.length).toBe(2);      // no tabs removed
+  });
+
+  it('preserves tab name', () => {
+    w.state.reiter[0].name = 'Mein Feld';
+    w.state.reiter[0].hektar = 10;
+    w.resetActiveTab();
+
+    expect(w.state.reiter[0].name).toBe('Mein Feld');
+    expect(w.state.reiter[0].hektar).toBe(0);
+  });
+
+  it('preserves machineLog', () => {
+    w.state.machineLog = [{ einheit: 5, hektar: 3, duenger: 100, time: '10:00' }];
+    w.state.reiter[0].hektar = 10;
+    w.resetActiveTab();
+
+    expect(w.state.machineLog).toEqual([{ einheit: 5, hektar: 3, duenger: 100, time: '10:00' }]);
+  });
+
+  it('preserves global settings (fahrgassenEnabled, koernerProEinheit)', () => {
+    w.state.fahrgassenEnabled = true;
+    w.state.fahrgassenBreite = 1.5;
+    w.state.koernerProEinheit = 80000;
+    w.state.einheitGroesseEnabled = true;
+    w.state.reiter[0].hektar = 10;
+    w.resetActiveTab();
+
+    expect(w.state.fahrgassenEnabled).toBe(true);
+    expect(w.state.fahrgassenBreite).toBe(1.5);
+    expect(w.state.koernerProEinheit).toBe(80000);
+    expect(w.state.einheitGroesseEnabled).toBe(true);
+  });
+});
+
+describe('confirmRemoveReiter', () => {
+  let w;
+  beforeEach(() => { w = createDom().window; });
+
+  it('removes tab when confirmed', () => {
+    var originalConfirm = w.confirm;
+    w.confirm = () => true;
+
+    w.addReiter();
+    expect(w.state.reiter.length).toBe(2);
+    w.confirmRemoveReiter(1);
+    expect(w.state.reiter.length).toBe(1);
+
+    w.confirm = originalConfirm;
+  });
+
+  it('keeps tab when cancelled', () => {
+    var originalConfirm = w.confirm;
+    w.confirm = () => false;
+
+    w.addReiter();
+    expect(w.state.reiter.length).toBe(2);
+    w.confirmRemoveReiter(1);
+    expect(w.state.reiter.length).toBe(2);
+
+    w.confirm = originalConfirm;
+  });
+
+  it('shows data warning when tab has data', () => {
+    var lastMsg = '';
+    var originalConfirm = w.confirm;
+    w.confirm = (msg) => { lastMsg = msg; return false; };
+
+    w.addReiter();
+    w.state.reiter[1].hektar = 10;
+    w.state.reiter[1].koerner = 90000;
+    w.confirmRemoveReiter(1);
+
+    expect(lastMsg).toContain('Daten vorhanden');
+
+    w.confirm = originalConfirm;
+  });
+
+  it('shows basic message when tab has no data', () => {
+    var lastMsg = '';
+    var originalConfirm = w.confirm;
+    w.confirm = (msg) => { lastMsg = msg; return false; };
+
+    w.addReiter();
+    w.confirmRemoveReiter(1);
+
+    expect(lastMsg).toContain('Alle Eingaben gehen verloren');
+
+    w.confirm = originalConfirm;
+  });
+});
+
+describe('resetAll clears machineLog', () => {
+  let w;
+  beforeEach(() => { w = createDom().window; });
+
+  it('clears machineLog on reset', () => {
+    w.state.machineLog = [
+      { einheit: 5, hektar: 3, duenger: 100, time: '10:00' },
+    ];
+    w.resetAll();
+    expect(w.state.machineLog).toEqual([]);
+  });
+
+  it('clears all entries across tabs', () => {
+    w.addReiter();
+    w.state.reiter[0].entries = [{ einheit: 5 }];
+    w.state.reiter[1].entries = [{ einheit: 3 }];
+    w.resetAll();
+    // After resetAll, only 1 tab remains
+    expect(w.state.reiter.length).toBe(1);
+    expect(w.state.reiter[0].entries).toEqual([]);
+  });
+
+  it('resets koernerProEinheit to 50000', () => {
+    w.state.koernerProEinheit = 80000;
+    w.resetAll();
+    expect(w.state.koernerProEinheit).toBe(50000);
+  });
+
+  it('resets einheitGroesseEnabled to false', () => {
+    w.state.einheitGroesseEnabled = true;
+    w.resetAll();
+    expect(w.state.einheitGroesseEnabled).toBe(false);
+  });
+});
+
+describe('drillRemove cross-tab', () => {
+  let w;
+  beforeEach(() => { w = createDom().window; });
+
+  it('removes entry from specified tab', () => {
+    w.state.reiter[0].entries = [
+      { einheit: 5, duenger: 100 },
+      { einheit: 3, duenger: 50 },
+    ];
+    w.drillRemove(0, 0);
+    expect(w.state.reiter[0].entries.length).toBe(1);
+    expect(w.state.reiter[0].entries[0].einheit).toBeCloseTo(3);
+  });
+
+  it('removes entry from different tab', () => {
+    w.state.reiter.push({ name: 'B', hektar: 5, koerner: 80000, duenger: 0, entries: [
+      { einheit: 2, duenger: 30 },
+    ]});
+    w.drillRemove(1, 0);
+    expect(w.state.reiter[1].entries.length).toBe(0);
+  });
+
+  it('saves state after removal', () => {
+    w.state.reiter[0].entries = [{ einheit: 5, duenger: 100 }];
+    w.drillRemove(0, 0);
+    var stored = JSON.parse(w.localStorage.getItem('mais_rechner'));
+    expect(stored.reiter[0].entries.length).toBe(0);
+  });
+});

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -11,7 +11,11 @@ const htmlPath = resolve(__dirname, '../public/index.html');
 const htmlContent = readFileSync(htmlPath, 'utf-8');
 
 const DOM_TEMPLATE = `<!DOCTYPE html><html><body>
-  <div id="tab_bar"></div>
+  <div id="tab_bar">
+    <div id="tab_bar_left"></div>
+    <div class="tab-separator"></div>
+    <button class="protokoll-tab" id="protokoll_tab_btn" onclick="switchToProtokoll()">🔧 Protokoll</button>
+  </div>
   <input id="hektar" value="">
   <input id="koerner" value="">
   <input id="duenger" value="">

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -21,11 +21,27 @@ const DOM_TEMPLATE = `<!DOCTYPE html><html><body>
   <input id="duenger" value="">
   <div id="err_hektar"></div>
   <div id="err_koerner"></div>
-  <div id="results" style="display:none"></div>
-  <div id="r_korner"></div>
-  <div id="r_einheiten"></div>
-  <div id="r_duenger"></div>
-  <div id="r_info"></div>
+  <div id="results" style="display:none">
+    <div id="r_korner"></div>
+    <div id="r_einheiten"></div>
+    <div id="r_duenger"></div>
+    <div id="r_drill_section" style="display:none">
+      <div class="drill-separator"></div>
+      <div class="result-row"><span class="label">🔧 Eingefüllt</span><span class="value small" id="r_drill_e_used">—</span></div>
+      <div class="result-row" id="r_drill_e_rem_row"><span class="label">Verbleibend</span><span class="value small" id="r_drill_e_rem">—</span></div>
+      <div class="result-row" id="r_drill_d_used_row" style="display:none"><span class="label">Dünger eingefüllt</span><span class="value small" id="r_drill_d_used">—</span></div>
+      <div class="result-row" id="r_drill_d_rem_row" style="display:none"><span class="label">Dünger verbleibend</span><span class="value small" id="r_drill_d_rem">—</span></div>
+      <div id="r_drill_entries"></div>
+      <div class="quick-entry" id="quick_entry">
+        <div class="inline-row">
+          <div class="field"><input type="text" inputmode="decimal" id="r_qe_einheit" placeholder="Einheiten"></div>
+          <div class="field"><input type="text" inputmode="decimal" id="r_qe_duenger" placeholder="kg Dünger"></div>
+        </div>
+        <button class="btn-add" onclick="drillQuickAdd()">+ Einfüllen</button>
+      </div>
+    </div>
+    <div id="r_info"></div>
+  </div>
   <div id="drill_section" style="display:none"></div>
   <input id="drill_einheit" value="">
   <input id="drill_hektar" value="">

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -48,6 +48,7 @@ const DOM_TEMPLATE = `<!DOCTYPE html><html><body>
   <div id="ds_duenger_used"></div>
   <div id="ds_duenger_remaining"></div>
   <div id="ds_total_summary"></div>
+  <div id="drill_machine_log"></div>
   <div id="drill_entries"></div>
   <button id="fahrgassen_toggle"></button>
   <div id="fahrgassen_settings"></div>

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -32,13 +32,6 @@ const DOM_TEMPLATE = `<!DOCTYPE html><html><body>
       <div class="result-row" id="r_drill_d_used_row" style="display:none"><span class="label">Dünger eingefüllt</span><span class="value small" id="r_drill_d_used">—</span></div>
       <div class="result-row" id="r_drill_d_rem_row" style="display:none"><span class="label">Dünger verbleibend</span><span class="value small" id="r_drill_d_rem">—</span></div>
       <div id="r_drill_entries"></div>
-      <div class="quick-entry" id="quick_entry">
-        <div class="inline-row">
-          <div class="field"><input type="text" inputmode="decimal" id="r_qe_einheit" placeholder="Einheiten"></div>
-          <div class="field"><input type="text" inputmode="decimal" id="r_qe_duenger" placeholder="kg Dünger"></div>
-        </div>
-        <button class="btn-add" onclick="drillQuickAdd()">+ Einfüllen</button>
-      </div>
     </div>
     <div id="r_info"></div>
   </div>

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -40,6 +40,18 @@ const DOM_TEMPLATE = `<!DOCTYPE html><html><body>
   <div id="fahrgassen_settings"></div>
   <input id="fahrgassen_breite" value="">
   <div id="fahrgassen_saved"></div>
+  <div id="einheit_groesse_toggle"></div>
+  <div id="einheit_groesse_settings"></div>
+  <input id="koerner_pro_einheit" value="">
+  <div id="einheit_groesse_saved"></div>
+  <div class="dashboard-overlay" id="dashboard_overlay"></div>
+  <div class="dashboard-sheet" id="dashboard_sheet">
+    <div class="dashboard-header">
+      <h2>📊 Alle Reiter</h2>
+      <button class="dashboard-close" onclick="closeDashboard()">✕</button>
+    </div>
+    <div class="dashboard-content" id="dashboard_content"></div>
+  </div>
 </body></html>`;
 
 /**


### PR DESCRIPTION
## Problem
Der "Zuruecksetzen"-Button loescht versehentlich alle Daten (alle Tabs, machineLog, globale Einstellungen), nicht nur den aktiven Tab.

## Loesung
- Neue  Funktion die nur die Daten des aktiven Tabs zuruecksetzt
- Andere Tabs, machineLog und globale Einstellungen bleiben erhalten
-  ruft jetzt  statt  auf

## Getestet
- 389 Tests bestanden (5 neue Tests fuer )

## Akzeptanzkriterien erfuellt
- [x] "Zuruecksetzen" zeigt Bestaetigungsdialog vor dem Loeschen
- [x] Dialog zeigt Tab-Namen und beschreibt was geloescht wird
- [x] "Abbrechen" ist der Default-Button (Browser confirm)
- [x] Tab-Schliessen bestaetigt wenn Daten vorhanden (bereits vorhanden)
- [x] Kein Datenverlust ohne explizite Nutzerbestaetigung