### PR TITLE
fix(drill-protocol): correct priority sort direction (Prio 1 = first) #62

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1808,7 +1808,7 @@
       var gesamtEinheit = parseDE(document.getElementById('drill_einheit').value) || 0;
       var gesamtDuenger = parseDE(document.getElementById('drill_duenger').value) || 0;
 
-      // Collect tabs with priority > 0, sort by priority descending
+      // Collect tabs with priority > 0, sort by priority ascending (1 = highest = first)
       var prioritized = [];
       state.reiter.forEach(function(r, i) {
         var prio = drillPriorities[i] || 0;
@@ -1816,7 +1816,7 @@
           prioritized.push({ idx: i, prio: prio, reiter: r });
         }
       });
-      prioritized.sort(function(a, b) { return b.prio - a.prio; });
+      prioritized.sort(function(a, b) { return a.prio - b.prio; });
 
       // Distribute: highest priority first, give what they need, remainder to next
       var remEinheit = gesamtEinheit;


### PR DESCRIPTION
## Bug

The UI shows `Prio: 1 → 2 → 3 → aus`, meaning Prio 1 = highest priority = served first. But the code sorted descending (`b.prio - a.prio`), so Prio 3 was served first — opposite of user expectation.

## Fix

Changed the sort from descending to ascending:

```diff
- prioritized.sort(function(a, b) { return b.prio - a.prio; });
+ prioritized.sort(function(a, b) { return a.prio - b.prio; });
```

Also fixed the misleading comment above the sort.

## Verification

- Logic tests: 66 passed (all pass, same as before my change)
- The 107 failing tests are pre-existing infrastructure issues with the DOM test helper (unrelated to this bug)