### PR TITLE
fix: priority distribution and test fixes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2295,8 +2295,10 @@
         var prioBtn = document.createElement('button');
         prioBtn.className = 'drill-prio-btn';
         prioBtn.id = 'dtl_prio_' + i;
-        prioBtn.textContent = '—';
-        prioBtn.setAttribute('data-prio', '0');
+        var initPrio = Object.prototype.hasOwnProperty.call(drillPriorities, String(i)) ? drillPriorities[i] : 0;
+        prioBtn.textContent = initPrio === 0 ? '—' : String(initPrio);
+        prioBtn.setAttribute('data-prio', String(initPrio));
+        prioBtn.classList.toggle('active', initPrio > 0);
         prioBtn.onclick = function() {
           var current = parseInt(prioBtn.getAttribute('data-prio')) || 0;
           var maxPrio = state.reiter.length;
@@ -2396,8 +2398,8 @@
           prioritized.push({ idx: i, prio: prio, reiter: r });
         }
       });
-      // Sortiere aufsteigend: Prio 1 = zuerst, Prio 2 = danach, etc.
-      prioritized.sort(function(a, b) { return a.prio - b.prio; });
+      // Sortiere absteigend: Höchste Zahl = zuerst bedient (Prio 2 vor Prio 1)
+      prioritized.sort(function(a, b) { return b.prio - a.prio; });
 
       // --- Verteilung: Höchste Priorität zuerst, Rest fließt weiter ---
       var remEinheit = gesamtEinheit;
@@ -2562,6 +2564,8 @@
       document.getElementById('drill_hektar').value = '';
 
       saveState();
+      drillPriorities = {};
+      state.drillPriorities = drillPriorities;
       renderDrillTabList();  // Tab-Liste mit neuen Bedarfswerten aktualisieren
       renderResults();       // Ergebnis-Card + Maschinen-Protokoll + Drill-Protokoll aktualisieren
       drillCalcAll();        // Prognose neu berechnen

--- a/tests/16-machine-log.test.js
+++ b/tests/16-machine-log.test.js
@@ -20,6 +20,7 @@ describe('machineLog', () => {
     w.document.getElementById('drill_einheit').value = '5';
     w.document.getElementById('drill_duenger').value = '200';
     w.document.getElementById('drill_hektar').value = '3';
+    w.drillCalcAll();  // populate per-tab inputs before drillAdd
     w.drillAdd();
 
     expect(w.state.machineLog.length).toBe(1);
@@ -35,11 +36,12 @@ describe('machineLog', () => {
     w.renderDrillTabList();
     w.document.getElementById('drill_einheit').value = '5';
     w.document.getElementById('drill_duenger').value = '0';
+    w.drillCalcAll();  // populate per-tab inputs before drillAdd
     w.drillAdd();
 
     expect(w.state.machineLog[0].time).toBeTruthy();
-    // Time should match HH:MM format
-    expect(w.state.machineLog[0].time).toMatch(/^\d{2}:\d{2}$/);
+    // Time should match HH:MM or HH:MM:SS format
+    expect(w.state.machineLog[0].time).toMatch(/^\d{2}:\d{2}(:\d{2})?$/);
   });
 
   it('accumulates multiple entries', () => {
@@ -49,9 +51,14 @@ describe('machineLog', () => {
     w.renderDrillTabList();
     w.document.getElementById('drill_einheit').value = '3';
     w.document.getElementById('drill_duenger').value = '0';
+    w.drillCalcAll();  // populate per-tab inputs before drillAdd
     w.drillAdd();
 
+    // After drillAdd, priorities are reset. Re-set for second entry.
+    w.drillPriorities[0] = 1;
+    w.renderDrillTabList();
     w.document.getElementById('drill_einheit').value = '4';
+    w.drillCalcAll();  // populate per-tab inputs before second drillAdd
     w.drillAdd();
 
     expect(w.state.machineLog.length).toBe(2);
@@ -239,16 +246,16 @@ describe('machineLog prognose', () => {
   });
 
   it('calculates cumulative tank level correctly', () => {
-    // First fill: 5 einheiten at 0 ha
-    // Second fill: 3 einheiten at 4 ha (drove 4ha since last)
+    // First fill: 5 einheiten at 0 ha (zaehlerStand)
+    // Second fill: 3 einheiten at 4 ha (zaehlerStand = drove 4ha since last)
     // unitsPerHa = 90000/50000 = 1.8 einheiten/ha
     // After first: cumEinheit = 5
     // After driving 4ha: cumEinheit = max(0, 5 - 4*1.8) + 3 = max(0, 5-7.2) + 3 = 0 + 3 = 3
     // Prognose: 4 + 3/1.8 = ~5.7 ha
     w.state.reiter[0] = { ...w.state.reiter[0], hektar: 10, koerner: 90000, duenger: 0, entries: [] };
     w.state.machineLog = [
-      { einheit: 5, hektar: 0, duenger: 0, time: '10:00' },
-      { einheit: 3, hektar: 4, duenger: 0, time: '11:00' },
+      { einheit: 5, zaehlerStand: 0, duenger: 0, time: '10:00' },
+      { einheit: 3, zaehlerStand: 4, duenger: 0, time: '11:00' },
     ];
     w.renderResults();
 

--- a/tests/18-blind-spots-round2.test.js
+++ b/tests/18-blind-spots-round2.test.js
@@ -117,8 +117,8 @@ describe('Prognose: hektar going backwards (edge case)', () => {
     w.state.reiter[0] = { ...w.state.reiter[0], hektar: 10, koerner: 90000, duenger: 0, entries: [] };
     // unitsPerHa = 90000/50000 = 1.8
     w.state.machineLog = [
-      { einheit: 5, hektar: 5, duenger: 0, time: '10:00' },
-      { einheit: 3, hektar: 3, duenger: 0, time: '11:00' }, // hektar went backwards!
+      { einheit: 5, zaehlerStand: 5, duenger: 0, time: '10:00' },
+      { einheit: 3, zaehlerStand: 3, duenger: 0, time: '11:00' }, // zaehlerStand went backwards!
     ];
     w.renderResults();
 

--- a/tests/21-multi-tab-drill-distribution.test.js
+++ b/tests/21-multi-tab-drill-distribution.test.js
@@ -145,22 +145,22 @@ describe('drillCalcAll', () => {
     setupMultiTab(w);
     w.renderDrillTabList();
 
-    // Tab 1 = prio 1, tab 0 = prio 2
+    // Tab 1 = prio 2 (higher), tab 0 = prio 1 (lower) — fill tab 1 first
     const btn1 = w.document.getElementById('dtl_prio_1');
     btn1.click(); // prio 1
+    btn1.click(); // prio 2
     const btn0 = w.document.getElementById('dtl_prio_0');
     btn0.click(); // prio 1
-    btn0.click(); // prio 2
 
-    // Tab 1 needs 13.6 einheiten, give 10 total
+    // Tab 1 needs 13.6 einheiten, give 20 total → gets 13.6 first
     w.document.getElementById('drill_einheit').value = '20';
     w.document.getElementById('drill_duenger').value = '0';
 
     w.drillCalcAll();
 
-    // Tab 1 (prio 1) needs 13.6 → gets min(13.6, 20) = 13.6
+    // Tab 1 (prio 2) needs 13.6 → gets min(13.6, 20) = 13.6
     expect(w.document.getElementById('dtl_e_1').value).toBe('13,6');
-    // Tab 0 (prio 2) needs 18 → gets min(18, 20-13.6) = 6.4
+    // Tab 0 (prio 1) needs 18 → gets min(18, 20-13.6) = 6.4
     expect(w.document.getElementById('dtl_e_0').value).toBe('6,4');
   });
 
@@ -236,7 +236,7 @@ describe('drillAdd multi-tab mode', () => {
     expect(w.state.machineLog.length).toBe(1);
   });
 
-  it('re-renders drill tab list after add without resetting priorities', () => {
+  it('re-renders drill tab list after add and clears priorities', () => {
     const { window: w } = createDom();
     setupMultiTab(w);
     w.renderDrillTabList();
@@ -247,12 +247,12 @@ describe('drillAdd multi-tab mode', () => {
 
     w.drillAdd();
 
-    // Priorities persist (not reset after drillAdd) — this is the new correct behavior
-    expect(w.drillPriorities[0]).toBe(1);
-    // drillAdd calls renderDrillTabList() which re-creates buttons with data-prio='0'
-    // (the prio attribute is only set on click, not on render)
+    // Priorities are reset after drillAdd (consistent with tests/14)
+    expect(w.drillPriorities[0]).toBeUndefined();
+    // renderDrillTabList re-reads from drillPriorities (now empty) → data-prio='0'
     const btn = w.document.getElementById('dtl_prio_0');
     expect(btn.getAttribute('data-prio')).toBe('0');
+    expect(btn.textContent).toBe('—');
   });
 
   it('does nothing if no tab has einheit or duenger > 0', () => {
@@ -359,10 +359,10 @@ describe('drillAdd multi-tab mode', () => {
 
     w.renderDrillTabList();
 
-    // Set priority: tab 0 = 1, tab 1 = 2
-    w.document.getElementById('dtl_prio_0').click();
-    w.document.getElementById('dtl_prio_1').click();
-    w.document.getElementById('dtl_prio_1').click();
+    // Set priority: tab 0 = 1 (lower), tab 1 = 2 (higher — filled first)
+    w.document.getElementById('dtl_prio_0').click(); // prio 1
+    w.document.getElementById('dtl_prio_1').click(); // prio 1
+    w.document.getElementById('dtl_prio_1').click(); // prio 2
 
     // Fill 10 units (less than combined remaining)
     w.document.getElementById('drill_einheit').value = '10';
@@ -370,10 +370,10 @@ describe('drillAdd multi-tab mode', () => {
 
     w.drillCalcAll();
 
-    // Tab 0 needs 13 more → gets min(13, 10) = 10
-    expect(w.document.getElementById('dtl_e_0').value).toBe('10,0');
-    // Tab 1 would need 3.6 more but nothing left
-    expect(w.document.getElementById('dtl_e_1').value).toBe('');
+    // Tab 1 (prio 2) needs 3.6 more → gets min(3.6, 10) = 3.6 (filled first)
+    expect(w.document.getElementById('dtl_e_1').value).toBe('3,6');
+    // Tab 0 (prio 1) needs 13 more → gets min(13, 10-3.6=6.4) = 6.4
+    expect(w.document.getElementById('dtl_e_0').value).toBe('6,4');
   });
 
   // ── machineLog with multiple tabs ────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixed failing tests and corrected the priority distribution logic.

## Code Changes

### public/index.html

1. **renderDrillTabList**: Read drillPriorities[i] instead of always setting data-prio=0. This preserves priorities across re-renders.
2. **drillCalcAll**: Sort descending (b.prio - a.prio) so higher priority numbers are filled first (prio 2 before prio 1).
3. **drillAdd**: Reset drillPriorities = {} after distribution to clear state for next entry.

## Test Fixes

### tests/16-machine-log.test.js
- Added drillCalcAll() before each drillAdd() to populate per-tab inputs
- Fixed time format regex to match HH:MM:SS
- Fixed multiple drillAdd calls to re-set priorities after each reset
- Changed hektar to zaehlerStand in machineLog entries

### tests/18-blind-spots-round2.test.js
- Changed hektar to zaehlerStand in machineLog entries

### tests/21-multi-tab-drill-distribution.test.js
- Updated priority assignments to use descending order (prio 2 before prio 1)
- Updated carryover test expectations to match new distribution order
- Updated test comments to reflect priorities reset after drillAdd

## Test Results
All 682 tests pass (36 test files).