### PR TITLE
fix: iOS decimal dot → comma in input fields (#148)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2162,13 +2162,20 @@
         cleaned = val.replace(/[^\d]/g, '');
       } else {
         // Dezimal: Ziffern + ein Komma maximal
+        // iOS mit englischer Tastatur: inputmode="decimal" liefert '.' statt ','.
+        // Nur den ersten Punkt in ein Komma umwandeln, wenn noch kein Komma
+        // vorhanden ist (sonst wäre es ein Tausenderpunkt in "1.234,5").
         var hasComma = val.indexOf(',') !== -1;
-        cleaned = val.replace(/[^\d,]/g, '');
-        if (hasComma) {
-          // Nur das erste Komma behalten, Rest abschneiden
-          var parts = cleaned.split(',');
-          cleaned = parts[0] + ',' + (parts[1] || '');
+        if (!hasComma) {
+          var firstDot = val.indexOf('.');
+          if (firstDot > -1) {
+            val = val.substring(0, firstDot) + ',' + val.substring(firstDot + 1);
+          }
         }
+        cleaned = val.replace(/[^\d,]/g, '');
+        // Nur das erste Komma behalten, Rest abschneiden
+        var parts = cleaned.split(',');
+        cleaned = parts[0] + ',' + (parts[1] || '');
       }
       if (el.value !== cleaned) {
         // Cursorposition proportional merken, damit Editierung in der Mitte nicht ans Ende springt

--- a/tests/02-onInputFormat.test.js
+++ b/tests/02-onInputFormat.test.js
@@ -119,6 +119,33 @@ describe('onInputFormat', () => {
       w.onInputFormat(el, 'decimal');
       expect(el.value).toBe('1234,5');
     });
+
+    // iOS with English keyboard: inputmode="decimal" sends '.' instead of ','
+    it('iOS decimal dot: converts dot to comma (12.5 → 12,5)', () => {
+      const el = makeInput('12.5');
+      w.onInputFormat(el, 'decimal');
+      expect(el.value).toBe('12,5');
+    });
+
+    it('iOS decimal dot: handles 1.234,5 gracefully (dot before comma)', () => {
+      const el = makeInput('1.234,5');
+      w.onInputFormat(el, 'decimal');
+      // first dot removed, comma stays → 1234,5
+      expect(el.value).toBe('1234,5');
+    });
+
+    it('iOS decimal dot: handles 0.5 → 0,5', () => {
+      const el = makeInput('0.5');
+      w.onInputFormat(el, 'decimal');
+      expect(el.value).toBe('0,5');
+    });
+
+    it('iOS decimal dot: second dot stripped after comma conversion', () => {
+      const el = makeInput('12..5');
+      w.onInputFormat(el, 'decimal');
+      // first dot → comma, second dot stripped → 12,5
+      expect(el.value).toBe('12,5');
+    });
   });
 
   describe('cursor position preservation', () => {


### PR DESCRIPTION
## Summary

`onInputFormat()` mit `inputmode="decimal"` liefert auf iOS-Geräten mit englischer Tastatur einen Punkt (`.`) statt eines Kommas als Dezimaltrennzeichen. Der Punkt wurde bisher komplett entfernt — der Nutzer tippt `12.5` und bekommt `125` angezeigt.

**Fix in `onInputFormat()`:**
- Wenn kein Komma vorhanden ist: ersten Punkt als Komma interpretieren
- `12.5` → `12,5` (korrekt für iOS-Englisch)
- `1.234,5` → `1234,5` (Tausenderpunkt wird entfernt, Komma bleibt)
- `12..5` → `12,5` (zweiter Punkt entfernt)

## Test Plan

- [x] `pnpm test` — 621 tests pass
- [x] 4 neue Tests für iOS-Dezimalpunkt-Szenarien

Closes #148
