### PR TITLE
fix: align machineLog filter property name with drillAdd() (closes #132)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2935,7 +2935,7 @@
         entries: []  // Drill-Einträge löschen
       };
       // machineLog-Einträge für diesen Tab entfernen
-      state.machineLog = state.machineLog.filter(function(e) { return e.tabIndex !== active; });
+      state.machineLog = state.machineLog.filter(function(e) { return e.tabIdx !== active; });
       document.getElementById('err_hektar').textContent = '';
       document.getElementById('err_koerner').textContent = '';
       document.getElementById('hektar').style.borderColor = '';


### PR DESCRIPTION
## Summary

`drillAdd()` writes `tabIdx` (line 2443) but `resetActiveTab()` filtered by `tabIndex` (line 2938). This 1-char property name mismatch caused MachineLog entries to **never** be removed on tab reset → unbounded localStorage growth → silent data loss (P0).

## Fix

Changed line 2938 in `resetActiveTab()` to filter by `tabIdx` instead of `tabIndex`, matching the convention used everywhere else in the codebase including `drillAdd()`.

## Test Plan

1. Open app with a single tab
2. Create several drill entries (Einfüllen)
3. Press "Zurücksetzen"
4. Inspect localStorage — MachineLog entries for that tab should be gone
5. Inspect other tabs' MachineLog entries — should remain untouched

Closes #132