### PR TITLE
fix: btn-add dark-mode + declare einheitRem/duengerRem in renderDashboard()

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -947,6 +947,8 @@
     html.dark .btn-secondary { background: #4a7c23; }
     html.dark .btn-danger { background: #c62828; }
     html.dark .btn-danger:active { background: #b71c1c; }
+    html.dark .btn-add { background: #5a9a2a; }
+    html.dark .btn-add:active { background: #4a7c23; }
 
     html.dark .result {
       background: #2a3320;
@@ -3229,8 +3231,8 @@
           duengerTotal = r.hektar * r.duenger;
           usedDuenger = r.entries.reduce(function(s, e) { return s + e.duenger; }, 0);
           var tabCo = getCarryover(idx);
-          einheitRem = Math.max(0, einheiten - usedEinheit - tabCo.savedEinheit - tabCo.excessEinheit);
-          duengerRem = Math.max(0, duengerTotal - usedDuenger - tabCo.savedDuenger - tabCo.excessDuenger);
+          var einheitRem = Math.max(0, einheiten - usedEinheit - tabCo.savedEinheit - tabCo.excessEinheit);
+          var duengerRem = Math.max(0, duengerTotal - usedDuenger - tabCo.savedDuenger - tabCo.excessDuenger);
           var minFilled = Math.min(
             einheiten > 0 ? usedEinheit / einheiten : 1,
             duengerTotal > 0 ? usedDuenger / duengerTotal : 1


### PR DESCRIPTION
## Summary

- **Dark-Mode**: `.btn-add` fehlte in der `html.dark`-Sektion — jetzt konsistent mit `.btn`, `.btn-secondary`, `.btn-danger` (Z. 947-949).
- **Globals**: `einheitRem` und `duengerRem` in `renderDashboard()` waren implizite Globals → jetzt `var` deklariert.

## Test Plan

- [ ] `.btn-add` im Dark Mode visuell prüfen (Soll: grüner Hintergrund `#5a9a2a`)
- [ ] Dashboard öffnen → kein `einheitRem`/`duengerRem` in der Browser-Konsole als globaler Leak

Closes #142
