### PR TITLE
feat: Cross-Tab-Synchronisation via storage Event-Listener (fixes #128)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3099,6 +3099,26 @@ font-size: 0.75rem;
           document.getElementById('results').style.display = 'block';
         }
       }
+
+      // --- Cross-Tab-Synchronisation ---
+      // Lauscht auf localStorage-Änderungen von anderen Tabs/Fenstern.
+      // Der storage-Event feuert nur in Tabs, die den Wert NICHT selbst gesetzt haben.
+      window.addEventListener('storage', function(e) {
+        if (e.key === 'mais_rechner' && e.newValue) {
+          try {
+            var remote = JSON.parse(e.newValue);
+            if (JSON.stringify(remote) !== JSON.stringify(state)) {
+              state = remote;
+              syncInputsFromState();
+              renderTabs();
+              renderView();
+              renderResults();
+            }
+          } catch(err) {
+            console.warn('Cross-tab sync: ungültiger State ignoriert', err);
+          }
+        }
+      });
     }
 
     // --- Dark Mode ---

--- a/tests/36-cross-tab-sync.test.js
+++ b/tests/36-cross-tab-sync.test.js
@@ -1,0 +1,124 @@
+/**
+ * Tests for Cross-Tab-Synchronisation (Issue #128)
+ *
+ * Verifies that a `storage` event listener is registered during initUI()
+ * and correctly updates state + UI when another tab writes to localStorage.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { createDom } from './helpers.js';
+
+function setup() {
+  const { dom, window: w, store } = createDom();
+  w.initUI();
+  return { dom, w, store };
+}
+
+/**
+ * Simulates a storage event as fired by another tab writing to localStorage.
+ * The storage event only fires in OTHER windows/tabs — not the originating one.
+ */
+function fireStorageEvent(w, key, newValue) {
+  const event = new w.Event('storage');
+  event.key = key;
+  event.newValue = newValue;
+  event.oldValue = null;
+  event.storageArea = w.localStorage;
+  w.dispatchEvent(event);
+}
+
+describe('Cross-Tab-Synchronisation (#128)', () => {
+  it('registers a storage event listener in initUI', () => {
+    const { w } = setup();
+    // Verify the listener is registered by dispatching a storage event
+    // and checking that state changes
+    const newState = JSON.parse(JSON.stringify(w.state));
+    newState.reiter[0].hektar = 99.5;
+    fireStorageEvent(w, 'mais_rechner', JSON.stringify(newState));
+    expect(w.state.reiter[0].hektar).toBe(99.5);
+  });
+
+  it('updates state when another tab saves to mais_rechner', () => {
+    const { w } = setup();
+    const remote = JSON.parse(JSON.stringify(w.state));
+    remote.reiter[0].koerner = 42;
+    remote.reiter[0].duenger = 123;
+
+    fireStorageEvent(w, 'mais_rechner', JSON.stringify(remote));
+
+    expect(w.state.reiter[0].koerner).toBe(42);
+    expect(w.state.reiter[0].duenger).toBe(123);
+  });
+
+  it('ignores storage events for other keys', () => {
+    const { w } = setup();
+    const origHektar = w.state.reiter[0].hektar;
+
+    fireStorageEvent(w, 'mais_rechner_theme', '"dark"');
+
+    expect(w.state.reiter[0].hektar).toBe(origHektar);
+  });
+
+  it('ignores storage events with null newValue (item removed)', () => {
+    const { w } = setup();
+    const origHektar = w.state.reiter[0].hektar;
+
+    const event = new w.Event('storage');
+    event.key = 'mais_rechner';
+    event.newValue = null;
+    w.dispatchEvent(event);
+
+    expect(w.state.reiter[0].hektar).toBe(origHektar);
+  });
+
+  it('ignores invalid JSON in newValue without crashing', () => {
+    const { w } = setup();
+    const origHektar = w.state.reiter[0].hektar;
+
+    // Should not throw
+    fireStorageEvent(w, 'mais_rechner', 'not-valid-json');
+
+    expect(w.state.reiter[0].hektar).toBe(origHektar);
+  });
+
+  it('does not re-render when remote state is identical to local state', () => {
+    const { w } = setup();
+
+    // Spy on syncInputsFromState to verify it's NOT called for identical state
+    const syncSpy = vi.spyOn(w, 'syncInputsFromState');
+
+    // Fire event with the exact same state
+    fireStorageEvent(w, 'mais_rechner', JSON.stringify(w.state));
+
+    expect(syncSpy).not.toHaveBeenCalled();
+    syncSpy.mockRestore();
+  });
+
+  it('syncs multi-tab state from another browser tab', () => {
+    const { w } = setup();
+
+    // Simulate remote state with 2 tabs
+    const remote = JSON.parse(JSON.stringify(w.state));
+    remote.reiter.push({ name: 'Tab 2', hektar: 5, koerner: 200, duenger: 50, istHektar: 0, entries: [] });
+
+    fireStorageEvent(w, 'mais_rechner', JSON.stringify(remote));
+
+    expect(w.state.reiter.length).toBe(2);
+    expect(w.state.reiter[1].name).toBe('Tab 2');
+    expect(w.state.reiter[1].hektar).toBe(5);
+  });
+
+  it('updates activeReiter when changed remotely', () => {
+    const { w } = setup();
+
+    // Add a second tab manually
+    w.state.reiter.push({ name: 'Tab 2', hektar: 10, koerner: 150, duenger: 80, istHektar: 0, entries: [] });
+    w.activeReiter = 0;
+
+    const remote = JSON.parse(JSON.stringify(w.state));
+    remote.activeReiter = 1;
+
+    fireStorageEvent(w, 'mais_rechner', JSON.stringify(remote));
+
+    expect(w.state.activeReiter).toBe(1);
+  });
+});


### PR DESCRIPTION
## Problem

Wenn zwei Browser-Tabs gleichzeitig offen sind, überschreibt der zweite Tab die Änderungen des ersten (Last-write-wins). Es gibt keinen `storage`-Event-Listener und keine Cross-Tab-Synchronisation.

## Lösung

`window.addEventListener('storage')` in `initUI()` registriert:
- Reagiert auf `localStorage`-Änderungen von anderen Tabs/Fenstern
- Aktualisiert `state`, Inputs, Tabs und Results bei Remote-Änderungen
- Ignoriert andere Keys, `null` newValue und ungültiges JSON
- Überspringt Re-Render wenn Remote-State identisch mit lokalem State

## Tests

8 neue Tests in `tests/36-cross-tab-sync.test.js`:
- Listener wird in initUI registriert
- State wird bei Remote-Änderung aktualisiert
- Andere localStorage-Keys werden ignoriert
- null newValue (Key gelöscht) wird ignoriert
- Ungültiges JSON crash-frei ignoriert
- Identischer State triggert keinen Re-Render
- Multi-Tab State wird korrekt synchronisiert
- activeReiter-Änderungen werden übernommen

**640/640 Tests bestanden** (632 bestehend + 8 neu, keine Regressionen).

Closes #128