### PR TITLE
test: #129 verifiziere skipWaiting + reg.update für SW-Update-Pfade

### DIFF
--- a/tests/37-deploy-sanity.test.js
+++ b/tests/37-deploy-sanity.test.js
@@ -6,7 +6,22 @@ import { describe, it, expect } from 'vitest';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const publicDir = resolve(__dirname, '..', 'public');
 
+// Issue #129: PWA sw.js ohne Cache-Control — Update-Pfade nicht abgesichert
+// - sw.js muss skipWaiting() in install handler haben → neue Version sofort aktivieren
+// - index.html muss reg.update() nach registration aufrufen → Browser prüft neue Version bei jedem Laden
 describe('Cloudflare deploy sanity', () => {
+  it('sw.js calls skipWaiting() to activate new version immediately', () => {
+    const swPath = resolve(publicDir, 'sw.js');
+    const content = readFileSync(swPath, 'utf-8');
+    expect(content).toMatch(/self\.skipWaiting\s*\(\s*\)/);
+  });
+
+  it('index.html calls reg.update() after SW registration to check for updates', () => {
+    const indexPath = resolve(publicDir, 'index.html');
+    const content = readFileSync(indexPath, 'utf-8');
+    expect(content).toMatch(/reg\.update\s*\(\s*\)/);
+  });
+
   it('_redirects does not exist (causes infinite loop on Workers Static Assets)', () => {
     // /* → /index.html erzeugt einen Infinite Loop weil /index.html selbst auf /* matched.
     // Workers Static Assets serviert index.html automatisch als Fallback.


### PR DESCRIPTION
## Zusammenfassung

**Issue #129** — PWA sw.js ohne Cache-Control, Update-Pfade nicht abgesichert

Die Lösung nutzt zwei komplementäre Mechanismen:

1. **`sw.js` — `skipWaiting()` im install-Handler**: Sorgt dafür, dass eine neue Service-Worker-Version sofort aktiviert wird, ohne auf bestehende Tabs zu warten.

2. **`index.html` — `reg.update()` nach SW-Registration**: Zwingt den Browser, bei jedem Seitenladen zu prüfen, ob eine neue SW-Version vorliegt.

### Umsetzung

- **Bereits vorhanden** in `public/sw.js` (Zeile 6): `self.skipWaiting()`
- **Bereits vorhanden** in `public/index.html` (Zeile 3244): `swReg.then(function(reg) { reg.update(); })`
- **Bereits vorhanden** in `public/_headers`: `/sw.js` → `Cache-Control: no-cache, no-store, must-revalidate`

### Test-Matrix (verifiziert via `pnpm test`)

- [x] `sw.js` enthält `skipWaiting()`
- [x] `index.html` enthält `reg.update()`
- [x] `_headers` enthält `/sw.js` mit `no-cache`
- [x] `_redirects` existiert nicht (verursachte infinite loop)
- [x] `sw.js` hat CACHE_VERSION

### Risiko

Minimal. Keine Logikänderung — nur Test-Coverage hinzugefügt, das die bereits implementierten Mechanismen verifiziert.

### Links

- Issue: https://github.com/Bobby9228/agrar-rechner/issues/129
- Branch: `fix/129-sw-cache-headers`