### PR TITLE
chore: document CACHE_VERSION manual bump requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -719,3 +719,12 @@ Für reine statische Sites wird `wrangler pages deploy` empfohlen.
 | `/*.html` | `no-cache` |
 | `/*.png`, `/*.svg` | `public, max-age=604800` (7 Tage) |
 | `/manifest.json` | `no-cache` |
+
+### Service Worker Cache-Version
+
+Der Service Worker nutzt `CACHE_VERSION` (`sw.js` Zeile 2) um alte Caches zu löschen und neue Assets zu cachen.
+**Nach jedem Deployment muss dieser String manuell gebumpet werden** — sonst bekommen Nutzer die alte Version aus dem Browser-Cache.
+
+Im Code ist ein Kommentar (`// ⚠️ CACHE_VERSION muss bei jedem Release manuell gebumpet werden!`) der daran erinnert.
+
+alternative: Ein Build-Script, das den Hash oder Zeitstempel automatisch injiziert — PRs welcome.

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,3 +1,6 @@
+// ⚠️ CACHE_VERSION muss bei jedem Release manuell gebumpet werden!
+// Bei Vergessen bekommen Nutzer die alte Version aus dem Cache.
+// alternativa: Build-Script das Hash/Zeitstempel injiziert.
 const CACHE_VERSION = 'mais-rechner-v11';
 const STATIC_ASSETS = ['/', '/index.html', '/icon.svg', '/manifest.json', '/icon-192.png', '/icon-512.png'];
 


### PR DESCRIPTION
## Zusammenfassung

**Issue #145** — zwei kleine Infrastruktur-Verbesserungen:

### 1. `nodejs_compat` Flag
**Bereits erledigt** durch Issue #134 — `wrangler.jsonc` enthält kein `nodejs_compat` Flag mehr. Keine Aktion nötig.

### 2. Manuelle SW-Cache-Versionierung dokumentiert
- **sw.js**: 3-Zeilen Kommentar vor `CACHE_VERSION` der erklärt dass der String bei jedem Release manuell gebumpet werden muss + Hinweis auf Build-Script-Alternative
- **README.md**: Neuer Abschnitt "Service Worker Cache-Version" unter Deployment → erklärt den Mechanismus und die Bump-Pflicht

**Tests**: 672 bestanden (unverändert)

---

**Branch**: `chore/issue-145-sw-cache-versioning`
**Files**: `public/sw.js`, `README.md` (+12 Zeilen)