### PR TITLE
fix #140: Version Footer v1.0.0 · Mai 2025

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1509,8 +1509,9 @@ font-size: 0.75rem;
     // --- "What's New" Update Banner ---
     // Zeigt einmalig einen Hinweis nach App-Updates (neue SW-Version).
     // currentVersion muss bei jedem Release manuell aktualisiert werden.
-    var APP_VERSION = 'v1.1.0';
-    var UPDATE_CHANGELOG = 'Was ist neu? Jetzt neu: "Was ist neu"-Banner nach Updates.';
+    var APP_VERSION = 'v1.0.0';
+    var APP_BUILD_DATE = 'Mai 2025';
+    var UPDATE_CHANGELOG = 'Erste Veröffentlichung der App.';
     function maybeShowUpdateHint() {
       var seenVersion = localStorage.getItem('mais_rechner_version_seen');
       if (seenVersion === APP_VERSION) return;
@@ -3320,7 +3321,7 @@ font-size: 0.75rem;
       loadState();                          // 1. State laden
       maybeShowUpdateHint();               // 1b. "Was ist neu"-Banner falls Version neu
       var vf = document.getElementById('version_footer');
-      if (vf) vf.textContent = APP_VERSION; // Version im Footer anzeigen
+      if (vf) vf.textContent = APP_VERSION + ' · ' + APP_BUILD_DATE; // Version + Build-Datum im Footer anzeigen
       syncInputsFromState();          // 2. Inputs beschreiben
       renderTabs();                   // 3. Tab-Leiste
       renderView();                   // 4. Ansicht (Feld/Protokoll)

--- a/tests/38-update-banner.test.js
+++ b/tests/38-update-banner.test.js
@@ -35,7 +35,7 @@ describe('Update Banner ("What\'s New")', () => {
       delete store['mais_rechner_version_seen'];
       w.initUI();
       const verEl = doc.getElementById('update_version');
-      expect(verEl.textContent).toBe('v1.1.0');
+      expect(verEl.textContent).toBe('v1.0.0');
     });
 
     it('fills changelog text correctly', () => {
@@ -46,7 +46,7 @@ describe('Update Banner ("What\'s New")', () => {
     });
 
     it('shows banner when older version was seen', () => {
-      store['mais_rechner_version_seen'] = 'v1.0.0';
+      store['mais_rechner_version_seen'] = 'v0.9.0';
       w.initUI();
       const banner = doc.getElementById('update_banner');
       expect(banner).toBeTruthy();
@@ -66,7 +66,7 @@ describe('Update Banner ("What\'s New")', () => {
     it('saves current version to localStorage after dismiss', () => {
       delete store['mais_rechner_version_seen'];
       w.dismissUpdateHint();
-      expect(store['mais_rechner_version_seen']).toBe('v1.1.0');
+      expect(store['mais_rechner_version_seen']).toBe('v1.0.0');
     });
 
     it('second initUI does not re-show banner after dismiss', () => {
@@ -80,8 +80,13 @@ describe('Update Banner ("What\'s New")', () => {
   });
 
   describe('APP_VERSION constant', () => {
-    it('APP_VERSION is defined as v1.1.0', () => {
-      expect(w.APP_VERSION).toBe('v1.1.0');
+    it('APP_VERSION is defined as v1.0.0', () => {
+      expect(w.APP_VERSION).toBe('v1.0.0');
+    });
+
+    it('APP_BUILD_DATE is a non-empty string', () => {
+      expect(typeof w.APP_BUILD_DATE).toBe('string');
+      expect(w.APP_BUILD_DATE.length).toBeGreaterThan(0);
     });
 
     it('UPDATE_CHANGELOG is a non-empty string', () => {
@@ -91,12 +96,12 @@ describe('Update Banner ("What\'s New")', () => {
   });
 
   describe('version footer', () => {
-    it('version footer shows APP_VERSION after initUI', () => {
+    it('version footer shows APP_VERSION and APP_BUILD_DATE after initUI', () => {
       delete store['mais_rechner_version_seen'];
       w.initUI();
       const footer = doc.getElementById('version_footer');
       expect(footer).toBeTruthy();
-      expect(footer.textContent).toBe('v1.1.0');
+      expect(footer.textContent).toBe('v1.0.0 · Mai 2025');
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes Issue #140 — Versionsnummer im Footer auf `v0.0.1` Placeholder.

## Changes

### `public/index.html`

- `APP_VERSION`: `v1.1.0` → `v1.0.0`
- `APP_BUILD_DATE`: neu — `'Mai 2025'`
- `UPDATE_CHANGELOG`: neu — `'Erste Veröffentlichung der App.'`
- `version_footer`: zeigt jetzt `APP_VERSION + ' · ' + APP_BUILD_DATE` → **`v1.0.0 · Mai 2025`**

### `tests/38-update-banner.test.js`

- Tests auf `v1.0.0` aktualisiert
- Neuer Test für `APP_BUILD_DATE`
- Footer-Test erwartet jetzt `'v1.0.0 · Mai 2025'`

## Test Results

```
Test Files  37 passed (37)
Tests  681 passed (681)
```