### PR TITLE
fix: prevent native context menu on tap/long-press (user-select: none)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,7 +12,8 @@
   <meta name="apple-mobile-web-app-title" content="Mais-Rechner">
   <title>Mais-Rechner</title>
   <style>
-    * { box-sizing: border-box; margin: 0; padding: 0; -webkit-tap-highlight-color: transparent; }
+    * { box-sizing: border-box; margin: 0; padding: 0; -webkit-tap-highlight-color: transparent; -webkit-user-select: none; user-select: none; }
+    input, textarea { -webkit-user-select: auto; user-select: auto; }
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
       background: #f0f4e8;

--- a/tests/37-deploy-sanity.test.js
+++ b/tests/37-deploy-sanity.test.js
@@ -81,4 +81,21 @@ describe('Cloudflare deploy sanity', () => {
     expect(content).toMatch(/"sizes"\s*:\s*"180x180"/);
     expect(content).toMatch(/"src"\s*:\s*"icon-180\.png"/);
   });
+
+  // Issue #176: user-select: none prevents native selection context menu on tap/long-press
+  it('index.html applies user-select: none to prevent text selection on mobile', () => {
+    const indexPath = resolve(publicDir, 'index.html');
+    const content = readFileSync(indexPath, 'utf-8');
+    // Global * selector must include -webkit-user-select: none and user-select: none
+    expect(content).toMatch(/\*\s*\{[^}]*-webkit-user-select:\s*none/);
+    expect(content).toMatch(/\*\s*\{[^}]*user-select:\s*none/);
+  });
+
+  it('index.html re-enables user-select: auto on input and textarea', () => {
+    const indexPath = resolve(publicDir, 'index.html');
+    const content = readFileSync(indexPath, 'utf-8');
+    // Inputs must re-enable user-select so users can edit values
+    expect(content).toMatch(/input\s*,\s*textarea\s*\{[^}]*-webkit-user-select:\s*auto/);
+    expect(content).toMatch(/input\s*,\s*textarea\s*\{[^}]*user-select:\s*auto/);
+  });
 });


### PR DESCRIPTION
## Fix: Native selection context menu on tap/long-press (Issue #176)

### What
Prevents native OS selection/copy UI from appearing on iOS Safari and Android Chrome when tapping or long-pressing anywhere in the app.

### Changes

**`public/index.html`** — 2 additions to `<style>`:
```css
/* Global: disable text selection to prevent context menu */
* { ...; -webkit-user-select: none; user-select: none; }

/* Re-enable for inputs so users can edit values */
input, textarea { -webkit-user-select: auto; user-select: auto; }
```

**`tests/37-deploy-sanity.test.js`** — 2 new tests:
- Verifies `* { -webkit-user-select: none }` is present
- Verifies `input, textarea { -webkit-user-select: auto }` re-enables editing

### Why
The app already had `touch-action: manipulation` on buttons/tabs, but missing `user-select: none` on the global selector allowed the browser's default gesture handling to trigger text/element selection on long-press — which then shows the native context menu (copy, cut, paste, select all).

### Test results
```
Test Files  37 passed (37)
     Tests  683 passed (683)
```

CI must pass before merge.