### PR TITLE
fix(dashboard): apply carryover to summary and progress calculation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3484,21 +3484,27 @@ font-size: 0.75rem;
       // --- Summary across all tabs ---
       var totalHa = 0, totalEinheiten = 0, totalUsedEinheit = 0;
       var totalDuenger = 0, totalUsedDuenger = 0;
-      reiter.forEach(function(r) {
+      var totalCarryoverEinheit = 0, totalCarryoverDuenger = 0;
+      reiter.forEach(function(r, idx) {
         if (r.hektar > 0 && r.koerner > 0) {
           totalHa += r.hektar;
           totalEinheiten += getTabTotalEinheiten(r);
           totalDuenger += r.hektar * r.duenger;
           totalUsedEinheit += r.entries.reduce(function(s, e) { return s + e.einheit; }, 0);
           totalUsedDuenger += r.entries.reduce(function(s, e) { return s + e.duenger; }, 0);
+          var tabCo = getCarryover(idx);
+          totalCarryoverEinheit += tabCo.savedEinheit + tabCo.excessEinheit;
+          totalCarryoverDuenger += tabCo.savedDuenger + tabCo.excessDuenger;
         }
       });
-      var totalEinheitRem = Math.max(0, totalEinheiten - totalUsedEinheit);
-      var totalDuengerRem = Math.max(0, totalDuenger - totalUsedDuenger);
+      // Apply carryover: remaining = max(0, SOLL - used - carryover)
+      var totalEinheitRem = Math.max(0, totalEinheiten - totalUsedEinheit - totalCarryoverEinheit);
+      var totalDuengerRem = Math.max(0, totalDuenger - totalUsedDuenger - totalCarryoverDuenger);
+      // Use carryover-adjusted used for percentage
       var totalPct = totalEinheiten > 0 || totalDuenger > 0
         ? Math.min(100, Math.round(Math.max(
-            totalEinheiten > 0 ? totalUsedEinheit / totalEinheiten : 0,
-            totalDuenger > 0 ? totalUsedDuenger / totalDuenger : 0
+            totalEinheiten > 0 ? (totalUsedEinheit + totalCarryoverEinheit) / totalEinheiten : 0,
+            totalDuenger > 0 ? (totalUsedDuenger + totalCarryoverDuenger) / totalDuenger : 0
           ) * 100))
         : 0;
 


### PR DESCRIPTION
## Fix: Dashboard ignores carryover values in summary and progress calculation

### Problem
`renderDashboard()` calculated the summary remaining values using raw `SOLL - used` without applying carryover logic. Individual tab cards already used `getCarryover()`, but the summary section (Einheiten verbl., Dünger verbl.) and the progress bar did not.

This caused inconsistent numbers between dashboard summary, progress bars, and individual cards.

### Fix
Applied carryover logic to the summary section in `renderDashboard()`:

1. **Accumulate carryover per tab** — added `totalCarryoverEinheit` and `totalCarryoverDuenger` accumulators in the `reiter.forEach()` loop
2. **Carryover-adjusted remaining** — `totalEinheitRem = max(0, totalEinheiten - totalUsedEinheit - totalCarryoverEinheit)` (same for Dünger)
3. **Carryover-adjusted percentage** — `totalPct` now uses `(totalUsedEinheit + totalCarryoverEinheit) / totalEinheiten` instead of raw `totalUsedEinheit / totalEinheiten`

Per-tab cards already had correct carryover handling and are unchanged.

### Testing
- `pnpm test` — all 683 tests pass
- Existing dashboard tests cover the fix:
  - `tests/27-dashboard-carryover.test.js` (8 tests)
  - `tests/11-dashboard.test.js` (19 tests)
  - `tests/26-dashboard-fahrgassen.test.js` (8 tests)

Closes #172.