### PR TITLE
fix(#173): correct activeReiter when deleting tab before active

### DIFF
--- a/public/js/ui-handlers.js
+++ b/public/js/ui-handlers.js
@@ -22,7 +22,11 @@
       if (state.reiter.length <= 1) return;
       syncStateFromInputs();
       state.reiter.splice(idx, 1);
-      if (state.activeReiter >= state.reiter.length) state.activeReiter = state.reiter.length - 1;
+      if (idx < state.activeReiter) {
+        state.activeReiter -= 1; // Tab before active was removed — shift active left
+      } else if (state.activeReiter >= state.reiter.length) {
+        state.activeReiter = state.reiter.length - 1; // Active tab removed — clamp to last
+      }
       var newPriorities = {};
       Object.keys(state.drillPriorities).forEach(function(key) {
         var k = parseInt(key, 10);


### PR DESCRIPTION
## Fixes #173

**Bug**: When deleting a tab positioned *before* the active tab, `activeReiter` was not decremented — the wrong tab remained active.

**Example**: 3 tabs (A,B,C), active = B (idx 1). Delete A → B should shift to idx 0 and stay active. Before fix: active index stayed at 1, pointing to C.

**Root cause**: The original code only handled the "active tab removed" case (`activeReiter >= newLength → clamp to last`), but not the "tab before active removed" case.

**Fix** (`public/js/ui-handlers.js`, `removeReiter`):
```js
// Before
if (state.activeReiter >= state.reiter.length) state.activeReiter = state.reiter.length - 1;

// After
if (idx < state.activeReiter) {
  state.activeReiter -= 1; // Tab before active was removed — shift active left
} else if (state.activeReiter >= state.reiter.length) {
  state.activeReiter = state.reiter.length - 1; // Active tab removed — clamp to last
}
```

**Tests**: All 683 tests pass (`pnpm test`).