### PR TITLE
fix(#174): clear stale drill summary after reset actions

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3282,6 +3282,7 @@ font-size: 0.75rem;
       document.getElementById('drill_section').style.display = 'none';
       syncInputsFromState();
       renderTabs();
+      renderDrillSummary();
       saveState();
     }
 
@@ -3319,6 +3320,7 @@ font-size: 0.75rem;
       document.getElementById('einheit_groesse_saved').textContent = '';
       state.drillPriorities = {};
       renderTabs();
+      renderDrillSummary();
       saveState();
     }
 

--- a/tests/17-edge-cases.test.js
+++ b/tests/17-edge-cases.test.js
@@ -289,6 +289,41 @@ describe('resetActiveTab', () => {
   });
 });
 
+describe('resetActiveTab — UI state after reset', () => {
+  let w, doc;
+
+  beforeEach(() => {
+    var env = createDom();
+    w = env.window;
+    doc = w.document;
+  });
+
+  it('calls renderDrillSummary to clear stale drill summary', () => {
+    var callCount = 0;
+    var originalFn = w.renderDrillSummary;
+    w.renderDrillSummary = function() { callCount++; originalFn.call(w); };
+
+    w.state.reiter[0] = {
+      name: 'Tab 1', hektar: 10, koerner: 90000, duenger: 500, entries: []
+    };
+    w.state.drillPriorities = {};
+
+    w.resetActiveTab();
+
+    expect(callCount).toBe(1);
+    w.renderDrillSummary = originalFn;
+  });
+
+  it('clears drill section display after reset', () => {
+    doc.getElementById('drill_section').style.display = 'block';
+    expect(doc.getElementById('drill_section').style.display).toBe('block');
+
+    w.resetActiveTab();
+
+    expect(doc.getElementById('drill_section').style.display).toBe('none');
+  });
+});
+
 describe('confirmRemoveReiter', () => {
   let w;
   beforeEach(() => { w = createDom().window; });


### PR DESCRIPTION
## Fixes

- **`resetActiveTab()`** — added `renderDrillSummary()` after `renderTabs()` to clear stale drill summary values (`ds_saat_remaining`, `ds_duenger_remaining`) after state reset
- **`resetAll()`** — same fix, ensures aggregated drill values are cleared on full reset

## Root Cause

After `resetActiveTab()` or `resetAll()` cleared the tab's `entries[]` array and set `drill_section.style.display = 'none'`, the tab-crossing drill summary (which aggregates SOLL/IST/USED/REMAIN across all tabs) was never refreshed. The `renderDrillSummary()` function — which writes `ds_saat_remaining` and `ds_duenger_remaining` — was only called on drill entry add/remove, not on reset. Result: stale remaining values visible until next user interaction.

## Tests

- Verifies `renderDrillSummary()` is called after `resetActiveTab()`
- Verifies `drill_section` display is set to `'none'` after reset

## Checklist

- [x] Tests pass (685 passing)
- [x] No regressions in existing tests