### PR TITLE
chore: add GitHub Actions CI/CD for dev branch deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,33 @@
+name: Deploy to Cloudflare Pages
+
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  test-and-deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run tests
+        run: pnpm test
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          command: pages deploy public/ --project-name=agrar-rechner


### PR DESCRIPTION
## Summary

Adds automatic deployment to Cloudflare Pages on every push to `dev` branch.

### What
- GitHub Actions workflow: `test → deploy`
- Runs `pnpm test` before deploying
- Deploys `public/` to Cloudflare Pages via `wrangler pages deploy`

### Secrets required (to be added by repo owner)
- `CLOUDFLARE_API_TOKEN` — Cloudflare API token with Pages edit permission
- `CLOUDFLARE_ACCOUNT_ID` — Found in Cloudflare Dashboard → Pages → Settings

### After merge
1. Go to https://github.com/Bobby9228/agrar-rechner/settings/secrets/actions
2. Add `CLOUDFLARE_API_TOKEN`
3. Add `CLOUDFLARE_ACCOUNT_ID`
4. Next push to `dev` will trigger automatic deployment
