### PR TITLE
fix(#197): add overflow-x:hidden to body to prevent horizontal scroll on mobile

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -20,6 +20,7 @@
       min-height: 100dvh;
       padding: max(20px, env(safe-area-inset-top)) 20px max(20px, env(safe-area-inset-bottom));
       color: #1a1a1a;
+      overflow-x: hidden;
     }
     .container {
       max-width: 420px;


### PR DESCRIPTION
Phase 1 of refactor milestone (.hermes/plans/2026-06-07-refactor-milestone.md).

Adds a single CSS rule `overflow-x: hidden;` to the `body` block in `public/index.html` to prevent horizontal scrolling on mobile viewports.

Diff: 1 line added.

Refs #197