### PR TITLE
fix(#211): Accessibility — aria-pressed, aria-describedby, prefers-reduced-motion, Dialog-Semantik, Touch-Targets

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -601,7 +601,7 @@ font-size: 0.75rem;
     }
     .toggle-btn {
       width: 52px;
-      height: 28px;
+      min-height: 44px;
       border-radius: 14px;
       background: #ccc;
       border: none;
@@ -609,6 +609,7 @@ font-size: 0.75rem;
       position: relative;
       transition: background 0.2s;
       flex-shrink: 0;
+      padding: 8px 0;
     }
     .toggle-btn::after {
       content: '';
@@ -1220,4 +1221,14 @@ font-size: 0.75rem;
     html.dark .theme-toggle {
       background: #2a3320;
       border-color: #3a4030;
+    }
+
+    /* Accessibility: prefers-reduced-motion */
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+      }
     }

--- a/public/index.html
+++ b/public/index.html
@@ -43,8 +43,8 @@
       <h2>📐 Fläche & Aussaatstärke</h2>
       <div class="field">
         <label for="hektar">Hektar (SOLL)</label>
-        <input type="text" inputmode="decimal" autocomplete="off" autocorrect="off" spellcheck="false" id="hektar" placeholder="z.B. 12,5" maxlength="8" oninput="onInputFormat(this, 'decimal', event)" onchange="onInputHektar(this)" onblur="onInputHektar(this)">
-        <div class="error-msg" id="err_hektar"></div>
+        <input type="text" inputmode="decimal" autocomplete="off" autocorrect="off" spellcheck="false" id="hektar" placeholder="z.B. 12,5" maxlength="8" oninput="onInputFormat(this, 'decimal', event)" onchange="onInputHektar(this)" onblur="onInputHektar(this)" aria-describedby="err_hektar">
+        <div class="error-msg" id="err_hektar" role="alert"></div>
       </div>
       <div class="field">
         <label for="ist_hektar">IST-Fläche (ha)</label>
@@ -52,14 +52,14 @@
       </div>
       <div class="field">
         <label for="koerner">Körner pro Hektar</label>
-        <input type="text" inputmode="numeric" id="koerner" placeholder="z.B. 90000" maxlength="8" oninput="onInputFormat(this, 'integer', event)" onchange="onInputKoerner(this)" onblur="onInputKoerner(this)">
+        <input type="text" inputmode="numeric" id="koerner" placeholder="z.B. 90000" maxlength="8" oninput="onInputFormat(this, 'integer', event)" onchange="onInputKoerner(this)" onblur="onInputKoerner(this)" aria-describedby="err_koerner">
         <div class="unit">üblich: 80.000 – 100.000</div>
-        <div class="error-msg" id="err_koerner"></div>
+        <div class="error-msg" id="err_koerner" role="alert"></div>
       </div>
 
       <div class="fahrgassen-toggle">
         <label for="einheit_groesse_toggle">Einheiten-Größe anpassen</label>
-        <button class="toggle-btn" id="einheit_groesse_toggle" onclick="einheitGroesseToggle()" aria-label="Einheiten-Größe"></button>
+        <button class="toggle-btn" id="einheit_groesse_toggle" onclick="einheitGroesseToggle()" aria-label="Einheiten-Größe" aria-pressed="false"></button>
       </div>
       <div class="fahrgassen-settings" id="einheit_groesse_settings">
         <div class="field" style="margin-bottom:8px">
@@ -80,7 +80,7 @@
 
       <div class="fahrgassen-toggle">
         <label for="fahrgassen_toggle">Fahrgassen berücksichtigen</label>
-        <button class="toggle-btn" id="fahrgassen_toggle" onclick="fahrgassenToggle()" aria-label="Fahrgassen"></button>
+        <button class="toggle-btn" id="fahrgassen_toggle" onclick="fahrgassenToggle()" aria-label="Fahrgassen" aria-pressed="false"></button>
       </div>
       <div class="fahrgassen-settings" id="fahrgassen_settings">
         <div class="field" style="margin-bottom:8px">
@@ -275,7 +275,7 @@
   <div class="version-footer" id="version_footer"></div>
   <!-- Dashboard overlay + sheet -->
   <div class="dashboard-overlay" id="dashboard_overlay" onclick="closeDashboard()"></div>
-  <div class="dashboard-sheet" id="dashboard_sheet">
+  <div class="dashboard-sheet" id="dashboard_sheet" role="dialog" aria-modal="true" aria-label="Dashboard — Alle Tabs Übersicht">
     <div class="dashboard-header">
       <h2>📊 Alle Tabs</h2>
       <button class="dashboard-close" onclick="closeDashboard()" aria-label="Schließen">✕</button>

--- a/public/js/render-dashboard.js
+++ b/public/js/render-dashboard.js
@@ -212,13 +212,47 @@
 
     // Öffnet das Dashboard-Sheet und ruft renderDashboard() auf.
     // Issue #186: muss auch nach ENTRY_CHANGED-Events den State korrekt widerspiegeln.
+    // Issue #211: Fokus-Falle und Dialog-Semantik für Accessibility.
+    var _dashboardPrevFocus = null;
+
+    // Trap Tab/Shift+Tab inside the dashboard dialog (Issue #211)
+    function _dashboardKeyHandler(e) {
+      if (e.key === 'Escape') {
+        closeDashboard();
+        e.preventDefault();
+        return;
+      }
+      if (e.key !== 'Tab') return;
+      var sheet = document.getElementById('dashboard_sheet');
+      if (!sheet) return;
+      var focusable = sheet.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+      if (focusable.length === 0) return;
+      var first = focusable[0];
+      var last = focusable[focusable.length - 1];
+      if (e.shiftKey) {
+        if (document.activeElement === first) { last.focus(); e.preventDefault(); }
+      } else {
+        if (document.activeElement === last) { first.focus(); e.preventDefault(); }
+      }
+    }
+
     function openDashboard() {
       var sheet = document.getElementById('dashboard_sheet');
       var overlay = document.getElementById('dashboard_overlay');
+      _dashboardPrevFocus = document.activeElement;
       if (sheet) sheet.classList.add('open');
       if (overlay) overlay.classList.add('open');
       document.body.style.overflow = 'hidden';
       renderDashboard();
+      // Move focus into the dialog for accessibility (Issue #211)
+      // Use setTimeout to avoid jsdom focus-event side effects
+      if (sheet) {
+        setTimeout(function() {
+          var closeBtn = sheet.querySelector('.dashboard-close');
+          if (closeBtn) closeBtn.focus();
+        }, 0);
+      }
+      document.addEventListener('keydown', _dashboardKeyHandler);
     }
 
     // Schließt das Dashboard-Sheet.
@@ -228,4 +262,10 @@
       if (sheet) sheet.classList.remove('open');
       if (overlay) overlay.classList.remove('open');
       document.body.style.overflow = '';
+      document.removeEventListener('keydown', _dashboardKeyHandler);
+      // Restore focus to the element that opened the dashboard
+      if (_dashboardPrevFocus && _dashboardPrevFocus.focus) {
+        _dashboardPrevFocus.focus();
+        _dashboardPrevFocus = null;
+      }
     }

--- a/public/js/ui-handlers.js
+++ b/public/js/ui-handlers.js
@@ -64,12 +64,15 @@
 
     function fahrgassenToggle() {
       state.fahrgassenEnabled = !state.fahrgassenEnabled;
+      var btn = document.getElementById('fahrgassen_toggle');
       if (state.fahrgassenEnabled) {
         document.getElementById('fahrgassen_settings').classList.add('open');
-        document.getElementById('fahrgassen_toggle').classList.add('active');
+        btn.classList.add('active');
+        btn.setAttribute('aria-pressed', 'true');
       } else {
         document.getElementById('fahrgassen_settings').classList.remove('open');
-        document.getElementById('fahrgassen_toggle').classList.remove('active');
+        btn.classList.remove('active');
+        btn.setAttribute('aria-pressed', 'false');
         state.fahrgassenBreite = 0;
       }
       appEmit('SETTINGS_CHANGED', { setting: 'fahrgassenEnabled' });
@@ -94,12 +97,15 @@
 
     function einheitGroesseToggle() {
       state.einheitGroesseEnabled = !state.einheitGroesseEnabled;
+      var btn = document.getElementById('einheit_groesse_toggle');
       if (state.einheitGroesseEnabled) {
         document.getElementById('einheit_groesse_settings').classList.add('open');
-        document.getElementById('einheit_groesse_toggle').classList.add('active');
+        btn.classList.add('active');
+        btn.setAttribute('aria-pressed', 'true');
       } else {
         document.getElementById('einheit_groesse_settings').classList.remove('open');
-        document.getElementById('einheit_groesse_toggle').classList.remove('active');
+        btn.classList.remove('active');
+        btn.setAttribute('aria-pressed', 'false');
         state.koernerProEinheit = 50000;
       }
       appEmit('SETTINGS_CHANGED', { setting: 'einheitGroesseEnabled' });
@@ -155,10 +161,12 @@
       document.getElementById('results').style.display = 'none';
       document.getElementById('drill_section').style.display = 'none';
       document.getElementById('fahrgassen_toggle').classList.remove('active');
+      document.getElementById('fahrgassen_toggle').setAttribute('aria-pressed', 'false');
       document.getElementById('fahrgassen_settings').classList.remove('open');
       document.getElementById('fahrgassen_breite').value = '';
       document.getElementById('fahrgassen_saved').textContent = '';
       document.getElementById('einheit_groesse_toggle').classList.remove('active');
+      document.getElementById('einheit_groesse_toggle').setAttribute('aria-pressed', 'false');
       document.getElementById('einheit_groesse_settings').classList.remove('open');
       document.getElementById('koerner_pro_einheit').value = '';
       document.getElementById('einheit_groesse_saved').textContent = '';


### PR DESCRIPTION
## Accessibility-Verbesserungen (Issue #211)

### Änderungen

| # | Problem | Fix | Dateien |
|---|---------|-----|---------|
| 1 | Toggle-Buttons ohne `aria-pressed` | `aria-pressed` Attribut + JS-Sync in `fahrgassenToggle()`, `einheitGroesseToggle()`, `resetAll()` | `index.html`, `ui-handlers.js` |
| 2 | Inputs ohne `aria-describedby` für Fehler-Spans | `aria-describedby="err_hektar"` / `err_koerner` + `role="alert"` auf Fehler-Elements | `index.html` |
| 3 | Kein `prefers-reduced-motion` Media-Query | CSS-Regel: alle animation/transition auf 0.01ms bei `prefers-reduced-motion: reduce` | `styles.css` |
| 4 | Dashboard-Sheet ohne `role="dialog"` und Fokus-Falle | `role="dialog"`, `aria-modal="true"`, `aria-label`, Tab/Shift+Tab Fokus-Falle, Escape schließt, Fokus-Restore | `index.html`, `render-dashboard.js` |
| 5 | Touch-Target-Höhe Toggle-Buttons nur 28px | `min-height: 44px` + `padding: 8px 0` | `styles.css` |

### Test-Status

```
- Branch:  495 passed / 229 failed
- dev (baseline):  495 passed / 229 failed
- Delta:  +0 passed, +0 failed (no regression)
```

Alle 229 pre-existing Failures sind orthogonal (parseDE-edge, koernerProEinheit-Berechnungen, etc.).

### Akzeptanzkriterien

- [x] Screen-Reader kündigt Toggle-State an (`aria-pressed`)
- [x] Screen-Reader liest Fehlermeldungen bei Inputs (`aria-describedby` + `role="alert"`)
- [x] Animationen respektieren `prefers-reduced-motion`
- [x] Dashboard hat korrekte Dialog-Semantik (`role="dialog"`, `aria-modal`, Fokus-Falle)

Closes #211