### PR TITLE
fix(#230): replace magic 50 in drillAdd() with correct kg/Einheit formula

### DIFF
--- a/public/js/calculations.js
+++ b/public/js/calculations.js
@@ -86,6 +86,31 @@
       return getTotalDuenger(r);
     }
 
+    // Dünger (kg) pro Einheit Saatgut für einen Tab.
+    //
+    // Physikalische Bedeutung: Wieviel kg Dünger zusammen mit einer Einheit
+    // Saatgut ausgebracht werden müssen, damit das Soll-Verhältnis
+    // (kg Dünger/ha ÷ Körner/ha × koernerProEinheit) eingehalten wird.
+    //
+    // Herleitung:
+    //   totalDuenger = r.hektar × r.duenger          (kg)
+    //   totalEinheit = r.hektar × r.koerner / kpe    (Einheiten)
+    //   kgProEinheit = totalDuenger / totalEinheit
+    //                = r.duenger × kpe / r.koerner
+    //
+    // Issue #230: Vorher stand hier `tab.duenger / (tab.hektar || 1) * 50` —
+    // ein Überbleibsel der falschen "1 Einheit = 50 kg" Annahme, die in
+    // #186/#191 bereits aus getTotalDuenger/getTabIstDuenger entfernt wurde.
+    // Die neue Formel ist dimensionsrein (kg/Einheit) und kpe-konsistent.
+    //
+    // @param {Object} r — Tab-Objekt mit .hektar, .koerner, .duenger
+    // @param {number} koernerProEinheit — Körner pro Einheit (Standard 50000)
+    // @returns {number} kg Dünger pro Einheit Saatgut (0 wenn r.koerner fehlt)
+    function getDuengerProEinheit(r, koernerProEinheit) {
+      if (!r || !r.duenger || !r.koerner || !koernerProEinheit) return 0;
+      return r.duenger * koernerProEinheit / r.koerner;
+    }
+
     // Berechnet IST-Dünger (kg) basierend auf istHektar.
     // Formel: r.istHektar * r.duenger (kg/ha) → kg total.
     // Issue #186: Vorherige Version dividierte fälschlich durch 50

--- a/public/js/ui-handlers.js
+++ b/public/js/ui-handlers.js
@@ -251,7 +251,13 @@
           var perUnit = (einheitPerHa / (tab.hektar || 1));
           var maxUnitsThisTab = remainingUnits / perUnit;
           var unitsForThisTab = Math.min(remainingUnits, maxUnitsThisTab);
-          var duengerPerUnit = tab.duenger > 0 ? (tab.duenger / (tab.hektar || 1) * 50) : 0;
+          // kg Dünger pro Einheit Saatgut für diesen Tab.
+          // Issue #230: ersetzt die alte, falsche Formel
+          //   `tab.duenger / (tab.hektar || 1) * 50`
+          // (Überbleibsel der "1 Einheit = 50 kg"-Annahme aus #186/#191).
+          // Die neue Berechnung lebt in calculations.js/getDuengerProEinheit
+          // und ist dimensionsrein (kg/Einheit) — kein tab.hektar im Zähler.
+          var duengerPerUnit = getDuengerProEinheit(tab, state.koernerProEinheit);
           var duengerForThisTab = Math.min(remainingDuenger, duengerPerUnit * unitsForThisTab);
           var entry = {
             time: getTabNextTime(tab),

--- a/tests/42-duenger-pro-einheit.test.js
+++ b/tests/42-duenger-pro-einheit.test.js
@@ -1,0 +1,84 @@
+/**
+ * Tests for getDuengerProEinheit() — Issue #230.
+ *
+ * Background: drillAdd() in ui-handlers.js used to compute
+ *   duengerPerUnit = tab.duenger / (tab.hektar || 1) * 50
+ * which was dimensionally wrong (kg/ha / ha × 50 → kg/ha²) and a leftover
+ * from the disproven "1 Einheit = 50 kg" assumption already removed in
+ * #186/#191 from getTotalDuenger/getTabIstDuenger.
+ *
+ * Correct formula:
+ *   duengerProEinheit = tab.duenger × koernerProEinheit / tab.koerner  (kg/Einheit)
+ *
+ * Herleitung:
+ *   totalDuenger = hektar × duenger         (kg)
+ *   totalEinheit = hektar × koerner / kpe   (Einheiten)
+ *   kgProEinheit = totalDuenger / totalEinheit
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createDom } from './helpers.js';
+
+describe('getDuengerProEinheit — Issue #230', () => {
+  let w;
+  beforeEach(() => { w = createDom().window; });
+
+  it('is exposed on window', () => {
+    expect(typeof w.getDuengerProEinheit).toBe('function');
+  });
+
+  it('returns 0 for missing tab.duenger', () => {
+    expect(w.getDuengerProEinheit({ hektar: 10, koerner: 90000 }, 50000)).toBe(0);
+  });
+
+  it('returns 0 for missing tab.koerner', () => {
+    expect(w.getDuengerProEinheit({ hektar: 10, duenger: 150 }, 50000)).toBe(0);
+  });
+
+  it('returns 0 for koernerProEinheit <= 0', () => {
+    expect(w.getDuengerProEinheit({ hektar: 10, koerner: 90000, duenger: 150 }, 0)).toBe(0);
+  });
+
+  it('returns 0 for null tab', () => {
+    expect(w.getDuengerProEinheit(null, 50000)).toBe(0);
+  });
+
+  it('matches the algebraic identity: kg/Einheit ist dimensionsrein', () => {
+    // 10 ha × 90.000 Körner/ha × 1 Einheit/50.000 Körner = 18 Einheiten
+    // 10 ha × 150 kg/ha = 1500 kg Dünger
+    // → 1500 / 18 ≈ 83.33 kg/Einheit
+    var tab = { hektar: 10, koerner: 90000, duenger: 150 };
+    expect(w.getDuengerProEinheit(tab, 50000)).toBeCloseTo(83.333, 2);
+  });
+
+  it('agrees with getTotalDuenger / getTotalEinheiten quotient', () => {
+    // Das ist die algebraische Definition — duengerProEinheit muss
+    // totalDuenger / totalEinheit entsprechen.
+    var tab = { hektar: 5, koerner: 80000, duenger: 100 };
+    var kpe = 50000;
+    var totalD = w.getTotalDuenger(tab);                    // 5 × 100 = 500
+    var totalE = w.getTotalEinheiten(tab, kpe);              // 5 × 80000 / 50000 = 8
+    var expected = totalD / totalE;                          // 500 / 8 = 62.5
+    expect(w.getDuengerProEinheit(tab, kpe)).toBeCloseTo(expected, 6);
+  });
+
+  it('responds correctly to a non-default koernerProEinheit', () => {
+    // 100.000 Körner/Einheit (z.B. Sonnenblumen) → weniger Körner pro Einheit
+    // ist schwerer, also kg/Einheit steigt. Konkret: duengerProEinheit ist
+    // proportional zu kpe.
+    var tab = { hektar: 10, koerner: 90000, duenger: 150 };
+    var kgPerEinheit50k = w.getDuengerProEinheit(tab, 50000);
+    var kgPerEinheit100k = w.getDuengerProEinheit(tab, 100000);
+    // Verdopplung von kpe → Verdopplung von kg/Einheit
+    expect(kgPerEinheit100k / kgPerEinheit50k).toBeCloseTo(2, 6);
+  });
+
+  it('Issue #230 regression: produces the value the OLD *50 formula CANNOT', () => {
+    // Demonstration, dass die alte Formel `tab.duenger / hektar * 50` etwas
+    // anderes liefert (mit falscher Dimension kg/ha²) und mit der neuen
+    // Formel nicht übereinstimmt.
+    var tab = { hektar: 10, koerner: 90000, duenger: 150 };
+    var oldFormula = tab.duenger / (tab.hektar || 1) * 50;   // 750 — dimensionslos falsch
+    var newFormula = w.getDuengerProEinheit(tab, 50000);      // ≈ 83.33 kg/Einheit
+    expect(newFormula).not.toBeCloseTo(oldFormula, 0);
+  });
+});


### PR DESCRIPTION
## Problem

Issue #230 flagged an undokumentierte Konstante `50` in `drillAdd()` (ui-handlers.js Z. 254):

```js
var duengerPerUnit = tab.duenger > 0 ? (tab.duenger / (tab.hektar || 1) * 50) : 0;
```

Die Konstante war ein Überbleibsel der bereits in #186/#191 widerlegten "1 Einheit = 50 kg"-Annahme. Dimensionsmäßig liefert die Formel **kg/ha²** (kg/ha ÷ ha × 50), nicht das physikalisch gemeinte kg Dünger pro Einheit Saatgut.

## Fix

1. Neue Pure-Function `getDuengerProEinheit(r, koernerProEinheit)` in `calculations.js` extrahiert:

   ```
   kgProEinheit = totalDuenger / totalEinheit
                = (hektar × duenger) / (hektar × koerner / kpe)
                = duenger × kpe / koerner    (kg/Einheit, dimensionsrein)
   ```

2. `drillAdd()` ruft jetzt diese Funktion statt die inline-Formel. Dokumentiert mit Verweis auf #230, #186 und #191.

## Tests

`tests/42-duenger-pro-einheit.test.js` — 9 Cases:
- Null/empty inputs → 0
- Algebraische Identität vs `getTotalDuenger / getTotalEinheiten`
- Skalierung mit nicht-default `koernerProEinheit`
- Expliziter Kontrast zur alten `*50`-Formel

`pnpm test tests/42-duenger-pro-einheit.test.js` → 9/9 ✓
`pnpm test` (full) → 507 passed / 227 failed (vorher 498/227). Keine Regression: die 227 Pre-existing-Failures sind unrelated (mehrheitlich Tests die `dtl_e_0`/drillMulti-Tab Pfade testen, die unabhängig von #230 kaputt sind — separates Issue wert).

`pnpm lint` → keine neuen Fehler; ein warning (`'getDuengerProEinheit' defined but never used`) ist konsistent mit dem Pattern aller anderen `calculations.js`-Funktionen (cross-file usage wird vom Lint nicht erkannt).

## Out of scope (separate issues needed)

- Die `perUnit`/`maxUnitsThisTab`-Berechnung im selben Loop (Z. 251-253) ist ebenfalls falsch (`koernerProEinheit/hektar` ist kein sinnvoller Wert) und bricht die multi-tab `drillAdd()` Distribution auch mit korrekter duenger-Formel. Das ist ein **anderer Bug** und sollte als separates Issue / PR adressiert werden.
- `renderDrillTabList()` setzt keine `id` auf die per-tab Inputs (`dtl_e_0`, `dtl_d_0`), wodurch die `drillCalcAll`-Tests in tests/14, tests/21, tests/35 fehlschlagen. Auch unabhängig.

Closes #230