### PR TITLE
fix(#233): re-enable no-undef for tests/ — follow-up to t_ddd81e3a

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -119,6 +119,12 @@ export default [
             // Bestehender Code referenziert implizite Modul-Globals (z. B.
             // `state`), die in legacy-Dateien nicht importiert werden — diese
             // Regel war der Hauptverursacher der 348 Errors.
+            //
+            // Re-enabled per-file für `tests/` weiter unten (Issue #233
+            // Follow-up, Review-Kommentar t_7215b1de #25): Tests verwenden
+            // bereits ESM `import`, profitieren also von `no-undef` ohne
+            // Refactor-Aufwand. 306 Errors verbleiben in public/js/ bis
+            // Phase 3+ (Modul-Refactor in ESM-`import`-Form).
             "no-undef": "off",
             // Bestehender Code deklariert Schleifen-Variablen in
             // aufeinanderfolgenden Blöcken mehrfach — typisches Legacy-Pattern.
@@ -137,6 +143,11 @@ export default [
         rules: {
             "no-console": "off",
             "no-unused-vars": "off", // helper-Importe können ungenutzt sein
+            // Re-enabled no-undef für Tests: sie verwenden ESM `import`,
+            // also profitieren sie von der Regel ohne Refactor. 0 Errors
+            // verifiziert (Stand: 2026-06-08, t_ddd81e3a). public/js/*
+            // bleibt absichtlich aus, siehe Block oben.
+            "no-undef": ["error", { typeof: true }],
         },
     },
 


### PR DESCRIPTION
## Summary

Re-enable the `no-undef` ESLint rule for the `tests/` directory.
Tests already use proper ESM `import` statements, so the rule
catches real bugs (typos, missing imports) there with zero refactor
cost. `public/js/*` stays at the project-wide `off` until the
module-globals refactor (Phase 3+) lands.

## Why per-file?

`public/js/*` would produce **306 no-undef errors** if the rule
were re-enabled project-wide — those files rely on implicit module
globals like `state` that aren't `import`'d. That refactor is
explicitly out of scope here. ESLint flat config's `files:` glob
gives us a clean carve-out.

## Verification

- `pnpm lint` → exit 0, 0 errors, 0 warnings
- `pnpm test` → 227 fail / 507 pass = pre-existing baseline
  (no regression)
- 0 false positives across all 41 test files (verified by direct
  Linter probe)

## Diff

```diff
diff --git a/eslint.config.js b/eslint.config.js
@@ -119,6 +119,12 @@
             // Bestehender Code referenziert implizite Modul-Globals (z. B.
             // `state`), die in legacy-Dateien nicht importiert werden — diese
             // Regel war der Hauptverursacher der 348 Errors.
+            //
+            // Re-enabled per-file für `tests/` weiter unten (Issue #233
+            // Follow-up, Review-Kommentar t_7215b1de #25): Tests verwenden
+            // bereits ESM `import`, profitieren also von `no-undef` ohne
+            // Refactor-Aufwand. 306 Errors verbleiben in public/js/ bis
+            // Phase 3+ (Modul-Refactor in ESM-`import`-Form).
             "no-undef": "off",
@@ -137,6 +143,11 @@
         rules: {
             "no-console": "off",
             "no-unused-vars": "off", // helper-Importe können ungenutzt sein
+            // Re-enabled no-undef für Tests: sie verwenden ESM `import`,
+            // also profitieren sie von der Regel ohne Refactor. 0 Errors
+            // verifiziert (Stand: 2026-06-08, t_ddd81e3a). public/js/*
+            // bleibt absichtlich aus, siehe Block oben.
+            "no-undef": ["error", { typeof: true }],
         },
     },
```

## Reference

- Follow-up to kanban task t_ddd81e3a
- Parent review: t_7215b1de, comment #25
- Closes the follow-up item flagged during the t_a70147dc /
  PR #234 review

## Out of scope (future work)

- Re-enabling `no-undef` for `public/js/*` — requires converting
  the script-tag modules to ESM `import` form. Tracked in IDEAS.md
  as a Phase 3+ refactor.
- Re-enabling stylistic rules (no-var, semi, quotes, etc.) — separate
  follow-ups.