### PR TITLE
fix(#231): add JS modules to SW STATIC_ASSETS

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,8 +1,24 @@
 // ⚠️ CACHE_VERSION muss bei jedem Release manuell gebumpet werden!
 // Bei Vergessen bekommen Nutzer die alte Version aus dem Cache.
 // alternativa: Build-Script das Hash/Zeitstempel injiziert.
-const CACHE_VERSION = 'mais-rechner-v12';
-const STATIC_ASSETS = ['/', '/index.html', '/css/styles.css', '/icon.svg', '/manifest.json', '/icon-192.png', '/icon-512.png'];
+const CACHE_VERSION = 'mais-rechner-v13';
+const STATIC_ASSETS = [
+    '/',
+    '/index.html',
+    '/css/styles.css',
+    '/js/state.js',
+    '/js/calculations.js',
+    '/js/ui-handlers.js',
+    '/js/render-tabs.js',
+    '/js/render-results.js',
+    '/js/render-drill.js',
+    '/js/render-dashboard.js',
+    '/js/main.js',
+    '/icon.svg',
+    '/manifest.json',
+    '/icon-192.png',
+    '/icon-512.png',
+];
 
 self.addEventListener('install', e => {
   e.waitUntil(caches.open(CACHE_VERSION).then(c => c.addAll(STATIC_ASSETS)));


### PR DESCRIPTION
Fixes #231

## Problem
The service worker precache list in `public/sw.js` only included HTML, CSS, and icons. The 8 JS modules were missing, so offline mode was broken.

## Fix
- Added all 8 JS modules to `STATIC_ASSETS`:
  - `/js/state.js`, `/js/calculations.js`, `/js/ui-handlers.js`
  - `/js/render-tabs.js`, `/js/render-results.js`, `/js/render-drill.js`
  - `/js/render-dashboard.js`, `/js/main.js`
- Reformatted `STATIC_ASSETS` as a multi-line array for readability
- Bumped `CACHE_VERSION` v12 → v13 (per the file's own instruction to bump on every release)

## Verification
- `pnpm lint` → exit 0
- `pnpm test` → 507/734 pass, identical to pre-change baseline (no regression; the 227 failures are pre-existing in this branch)
- `git diff` shows only the expected `STATIC_ASSETS` + cache version changes
- Caching strategy (`network-first` for HTML, `cache-first` for static assets) is untouched