### PR TITLE
fix(#237): schema validation in loadState() against type injection & prototype pollution

### DIFF
--- a/public/js/state.js
+++ b/public/js/state.js
@@ -57,11 +57,156 @@
       if (el) el.style.display = 'none';
     }
 
+    // --- Schema-Validierung (Issue #237) ---
+    // Verteidigt loadState() gegen manipulierten localStorage-Inhalt (XSS auf
+    // gleicher Domain, andere App mit gleichem Origin, Man-in-the-Middle bei
+    // unsicherer Konfiguration). Stillschweigendes Verwerfen: ungültige Felder
+    // werden auf sinnvolle Defaults zurückgesetzt, sodass die App lauffähig
+    // bleibt statt zu crashen.
+    //
+    // Erlaubte Keys (Whitelist) — alles andere wird im Reviver verworfen.
+    // Hinzufügen neuer Felder erfordert eine bewusste Entscheidung.
+    var ALLOWED_TOP_KEYS = [
+      'reiter', 'activeReiter', 'activeView',
+      'fahrgassenEnabled', 'fahrgassenBreite',
+      'einheitGroesseEnabled', 'koernerProEinheit',
+      'machineLog', 'drillPriorities', 'iosInstallHintShown',
+      '_lv',
+      // Legacy-Keys (nur für Migration 0→1 lesend toleriert)
+      'hektar', 'istHektar', 'koerner', 'duenger', 'entries',
+      'name'
+    ];
+    var ALLOWED_TAB_KEYS = [
+      'name', 'hektar', 'istHektar', 'koerner', 'duenger',
+      'entries', 'fahrgassenEnabled', 'fahrgassenBreite'
+    ];
+    var ALLOWED_ENTRY_KEYS = [
+      'time', 'einheit', 'duenger', 'hektar', 'istHektar',
+      'koerner', 'duengerRate', 'mlIdx'
+    ];
+    var ALLOWED_MACHINE_LOG_KEYS = [
+      'time', 'einheit', 'duenger', 'hektar', 'istHektar',
+      'koerner', 'duengerRate'
+    ];
+
+    function isPlainObject(v) {
+      // Schließt null, Arrays, Klassen-Instanzen und speziell
+      // Objekte mit abweichendem Prototypen aus. Damit ist der einzige
+      // Weg, einen Plain Object zu erzeugen, die Literalschreibweise —
+      // also auch kein `Object.create(null)` mit Magic-Proto-Keys.
+      if (v === null || typeof v !== 'object') return false;
+      if (Array.isArray(v)) return false;
+      var proto = Object.getPrototypeOf(v);
+      return proto === Object.prototype || proto === null;
+    }
+
+    function sanitizeNumber(v, fallback) {
+      // Akzeptiert echte Number und number-konvertierbare Strings,
+      // verwirft NaN/Infinity/Objekte. Null/Undefined → fallback.
+      if (v === null || v === undefined) return fallback;
+      if (typeof v === 'number') return isFinite(v) ? v : fallback;
+      if (typeof v === 'string' && v.trim() !== '') {
+        var n = Number(v);
+        return isFinite(n) ? n : fallback;
+      }
+      return fallback;
+    }
+
+    function sanitizeString(v, fallback, maxLen) {
+      if (typeof v !== 'string') return fallback;
+      if (maxLen && v.length > maxLen) v = v.slice(0, maxLen);
+      return v;
+    }
+
+    function sanitizeBoolean(v, fallback) {
+      if (typeof v === 'boolean') return v;
+      return fallback;
+    }
+
+    function sanitizeEntry(raw) {
+      // Eintrag: Plain Object, nur erlaubte Keys, jede Property typgeprüft.
+      // Unbekannte Keys und falsche Typen → Default. Verwirft auch
+      // `__proto__`/`constructor`/`prototype` über den Reviver.
+      if (!isPlainObject(raw)) return null;
+      var out = {};
+      out.time        = sanitizeNumber(raw.time, 0);
+      out.einheit     = sanitizeNumber(raw.einheit, 0);
+      out.duenger     = sanitizeNumber(raw.duenger, 0);
+      out.hektar      = sanitizeNumber(raw.hektar, 0);
+      out.istHektar   = sanitizeNumber(raw.istHektar, 0);
+      out.koerner     = sanitizeNumber(raw.koerner, 0);
+      out.duengerRate = sanitizeNumber(raw.duengerRate, 0);
+      if (raw.mlIdx !== undefined) {
+        var ml = sanitizeNumber(raw.mlIdx, -1);
+        out.mlIdx = ml >= 0 ? Math.floor(ml) : -1;
+      }
+      return out;
+    }
+
+    function sanitizeMachineLogEntry(raw) {
+      if (!isPlainObject(raw)) return null;
+      var out = {};
+      out.time        = sanitizeNumber(raw.time, 0);
+      out.einheit     = sanitizeNumber(raw.einheit, 0);
+      out.duenger     = sanitizeNumber(raw.duenger, 0);
+      out.hektar      = sanitizeNumber(raw.hektar, 0);
+      out.istHektar   = sanitizeNumber(raw.istHektar, 0);
+      out.koerner     = sanitizeNumber(raw.koerner, 0);
+      out.duengerRate = sanitizeNumber(raw.duengerRate, 0);
+      return out;
+    }
+
+    function sanitizeTab(raw) {
+      if (!isPlainObject(raw)) {
+        return { name: 'Tab', hektar: 0, istHektar: 0, koerner: 0, duenger: 0, entries: [] };
+      }
+      var tab = {
+        name:      sanitizeString(raw.name, 'Tab', 64),
+        hektar:    sanitizeNumber(raw.hektar, 0),
+        istHektar: sanitizeNumber(raw.istHektar, 0),
+        koerner:   sanitizeNumber(raw.koerner, 0),
+        duenger:   sanitizeNumber(raw.duenger, 0),
+        entries:   []
+      };
+      // Per-Tab-Overrides (optional, mit globalen Defaults)
+      if (raw.fahrgassenEnabled !== undefined) {
+        tab.fahrgassenEnabled = sanitizeBoolean(raw.fahrgassenEnabled, false);
+      }
+      if (raw.fahrgassenBreite !== undefined) {
+        tab.fahrgassenBreite = sanitizeNumber(raw.fahrgassenBreite, 0);
+      }
+      if (Array.isArray(raw.entries)) {
+        for (var i = 0; i < raw.entries.length; i++) {
+          var e = sanitizeEntry(raw.entries[i]);
+          if (e !== null) tab.entries.push(e);
+        }
+      }
+      return tab;
+    }
+
+    function jsonReviver(key, value) {
+      // Defense-in-Depth gegen Prototype Pollution: blockiere die drei
+      // gefährlichen Keys auf jeder Verschachtelungsebene. JSON.parse
+      // ignoriert __proto__ zwar weitgehend, aber konsistentes Whitelisting
+      // ist robust und dokumentiert die erlaubte Form.
+      if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+        return undefined; // Schlüssel wird aus dem Result entfernt
+      }
+      return value;
+    }
+
+    function parsePersistedState(raw) {
+      // Wrapper: nutzt jsonReviver, um gefährliche Keys auf jeder Ebene
+      // abzufangen, BEVOR die nachfolgende Sanitisierung läuft.
+      return JSON.parse(raw, jsonReviver);
+    }
+
     function loadState() {
       try {
         var saved = localStorage.getItem('mais_rechner');
         if (!saved) return false;
-        var data = JSON.parse(saved);
+        var data = parsePersistedState(saved);
+        if (!isPlainObject(data)) return false;
         var originalLv = data._lv || 0;
         var lv = originalLv;
         // Migration 0→1: Einzelne Felder → Tab-Array
@@ -99,17 +244,50 @@
           // drillPriorities Default
           if (!data.drillPriorities) data.drillPriorities = {};
         }
-        // Validate und übernehmen
+        // Validate und übernehmen — Schema-strict ab _lv=4
         if (!Array.isArray(data.reiter) || data.reiter.length === 0) return false;
-        data.reiter.forEach(function(r) {
-          if (!r.entries) r.entries = [];
-          if (r.hektar === undefined) r.hektar = 0;
-          if (r.istHektar === undefined) r.istHektar = 0;
-          if (r.koerner === undefined) r.koerner = 0;
-          if (r.duenger === undefined) r.duenger = 0;
-          if (!r.name) r.name = 'Tab';
-        });
-        data._lv = 4;
+        var sanitizedReiter = [];
+        for (var i = 0; i < data.reiter.length; i++) {
+          sanitizedReiter.push(sanitizeTab(data.reiter[i]));
+        }
+        // Globale Felder typgeprüft + Defaults
+        var activeReiterRaw = sanitizeNumber(data.activeReiter, 0);
+        data.activeReiter = activeReiterRaw >= 0 && activeReiterRaw < sanitizedReiter.length
+          ? Math.floor(activeReiterRaw)
+          : 0;
+        data.activeView = (data.activeView === 'protokoll') ? 'protokoll' : null;
+        if (data.fahrgassenEnabled === undefined) data.fahrgassenEnabled = false;
+        if (data.fahrgassenBreite === undefined) data.fahrgassenBreite = 0;
+        data.fahrgassenEnabled = sanitizeBoolean(data.fahrgassenEnabled, false);
+        data.fahrgassenBreite = sanitizeNumber(data.fahrgassenBreite, 0);
+        if (data.einheitGroesseEnabled === undefined) data.einheitGroesseEnabled = false;
+        data.einheitGroesseEnabled = sanitizeBoolean(data.einheitGroesseEnabled, false);
+        if (data.koernerProEinheit === undefined) data.koernerProEinheit = 50000;
+        data.koernerProEinheit = sanitizeNumber(data.koernerProEinheit, 50000);
+        // machineLog sanitizen
+        var machineLog = [];
+        if (Array.isArray(data.machineLog)) {
+          for (var mi = 0; mi < data.machineLog.length; mi++) {
+            var me = sanitizeMachineLogEntry(data.machineLog[mi]);
+            if (me !== null) machineLog.push(me);
+          }
+        }
+        data.machineLog = machineLog;
+        // drillPriorities muss Plain Object sein
+        if (!isPlainObject(data.drillPriorities)) data.drillPriorities = {};
+        // iosInstallHintShown
+        if (data.iosInstallHintShown === undefined) data.iosInstallHintShown = false;
+        data.iosInstallHintShown = sanitizeBoolean(data.iosInstallHintShown, false);
+        // Final: sanitisiertes reiter einsetzen
+        data.reiter = sanitizedReiter;
+        // Unbekannte Top-Level-Keys strippen (Whitelist)
+        var cleaned = {};
+        for (var ki = 0; ki < ALLOWED_TOP_KEYS.length; ki++) {
+            var k = ALLOWED_TOP_KEYS[ki];
+            if (data[k] !== undefined) cleaned[k] = data[k];
+        }
+        cleaned._lv = 4;
+        data = cleaned;
         state = data;
         // Migration-Persistenz: Wenn die Daten nicht bereits _lv=4 waren,
         // schreibe den migrierten Snapshot einmalig zurück, damit nachfolgende

--- a/tests/43-loadstate-schema-validation.test.js
+++ b/tests/43-loadstate-schema-validation.test.js
@@ -1,0 +1,422 @@
+/**
+ * Tests for loadState() schema validation (Issue #237).
+ * Covers: type injection on tab fields, prototype pollution via entries,
+ * unknown / malicious keys, missing fields, and round-trip safety.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createDom } from './helpers.js';
+
+describe('loadState() schema validation (Issue #237)', () => {
+    let w, doc, store;
+
+    beforeEach(() => {
+        const result = createDom();
+        w = result.window;
+        doc = w.document;
+        store = result.store;
+    });
+
+    describe('Type injection on tab fields', () => {
+        it('coerces string-typed number fields to numbers (rejected as invalid → 0)', () => {
+            store['mais_rechner'] = JSON.stringify({
+                reiter: [{
+                    name: 'Injected',
+                    hektar: '"<script>alert(1)</script>"',  // String statt Zahl
+                    istHektar: null,
+                    koerner: { evil: true },
+                    duenger: [1, 2, 3],
+                    entries: []
+                }],
+                _lv: 4
+            });
+            w.loadState();
+            // Alle ungültigen Number-Felder müssen auf 0 landen, App lauffähig.
+            expect(w.state.reiter[0].hektar).toBe(0);
+            expect(w.state.reiter[0].istHektar).toBe(0);
+            expect(w.state.reiter[0].koerner).toBe(0);
+            expect(w.state.reiter[0].duenger).toBe(0);
+        });
+
+        it('accepts finite numbers and number-coercible strings as tab fields', () => {
+            store['mais_rechner'] = JSON.stringify({
+                reiter: [{
+                    name: 'OK',
+                    hektar: 12.5,
+                    istHektar: '10',       // string "10" → 10
+                    koerner: 85000,
+                    duenger: '175',
+                    entries: []
+                }],
+                _lv: 4
+            });
+            w.loadState();
+            expect(w.state.reiter[0].hektar).toBe(12.5);
+            expect(w.state.reiter[0].istHektar).toBe(10);
+            expect(w.state.reiter[0].koerner).toBe(85000);
+            expect(w.state.reiter[0].duenger).toBe(175);
+        });
+
+        it('rejects NaN and Infinity in number fields', () => {
+            store['mais_rechner'] = JSON.stringify({
+                reiter: [{
+                    name: 'Bad',
+                    hektar: null,
+                    istHektar: NaN,
+                    koerner: Infinity,
+                    duenger: -Infinity,
+                    entries: []
+                }],
+                _lv: 4
+            });
+            w.loadState();
+            // sanitizeNumber: NaN, Infinity, -Infinity, null → fallback (0)
+            expect(w.state.reiter[0].hektar).toBe(0);
+            expect(w.state.reiter[0].istHektar).toBe(0);
+            expect(w.state.reiter[0].koerner).toBe(0);
+            expect(w.state.reiter[0].duenger).toBe(0);
+        });
+
+        it('falls back to "Tab" when name is missing or non-string', () => {
+            store['mais_rechner'] = JSON.stringify({
+                reiter: [{ hektar: 0, koerner: 0, duenger: 0, entries: [] }],
+                _lv: 4
+            });
+            w.loadState();
+            expect(w.state.reiter[0].name).toBe('Tab');
+        });
+
+        it('truncates oversize name to 64 chars', () => {
+            const longName = 'A'.repeat(200);
+            store['mais_rechner'] = JSON.stringify({
+                reiter: [{ name: longName, entries: [] }],
+                _lv: 4
+            });
+            w.loadState();
+            expect(w.state.reiter[0].name.length).toBe(64);
+        });
+    });
+
+    describe('Prototype pollution protection', () => {
+        it('strips __proto__ from entries', () => {
+            store['mais_rechner'] = JSON.stringify({
+                reiter: [{
+                    name: 'P',
+                    entries: [{
+                        __proto__: { polluted: true },
+                        einheit: 5,
+                        duenger: 200,
+                        time: 12345
+                    }]
+                }],
+                _lv: 4
+            });
+            w.loadState();
+            // Kein Object.prototype-Feld "polluted" auf irgendeinem Object
+            expect(({}).polluted).toBeUndefined();
+            // Entry ist sauber, nur erlaubte Felder
+            const entry = w.state.reiter[0].entries[0];
+            expect(entry.polluted).toBeUndefined();
+            expect(entry.einheit).toBe(5);
+        });
+
+        it('strips constructor and prototype keys at any nesting level', () => {
+            store['mais_rechner'] = JSON.stringify({
+                reiter: [{
+                    entries: [{
+                        constructor: { polluted: true },
+                        prototype: { polluted: true },
+                        einheit: 1
+                    }]
+                }],
+                _lv: 4
+            });
+            w.loadState();
+            // 1) Kein Object.prototype-Feld wurde injiziert
+            expect(({}).polluted).toBeUndefined();
+            // 2) entry.constructor ist die echte Object-Constructor-Funktion
+            //    (kein eigenes "constructor"-Property injiziert). jsdom-Realm-
+            //    aware: nutze den live-Auslese über entry.__proto__.constructor
+            const entry = w.state.reiter[0].entries[0];
+            expect(Object.prototype.hasOwnProperty.call(entry, 'constructor')).toBe(false);
+            // 3) entry.prototype ist nicht versehentlich persistiert
+            expect(Object.prototype.hasOwnProperty.call(entry, 'prototype')).toBe(false);
+        });
+
+        it('rejects non-plain entries (arrays, class instances, null)', () => {
+            store['mais_rechner'] = JSON.stringify({
+                reiter: [{
+                    entries: [
+                        [1, 2, 3],                       // Array statt Object
+                        'just a string',                 // String
+                        null,                            // null
+                        { einheit: 5, duenger: 1, time: 1 }  // valid
+                    ]
+                }],
+                _lv: 4
+            });
+            w.loadState();
+            // Nur der eine valide Eintrag überlebt
+            expect(w.state.reiter[0].entries.length).toBe(1);
+            expect(w.state.reiter[0].entries[0].einheit).toBe(5);
+        });
+
+        it('does not pollute Object.prototype via the reviver', () => {
+            const sentinel = '__polluted_' + Date.now();
+            // JSON.parse kann __proto__ per Spec nicht direkt setzen,
+            // aber der Reviver entzieht ihm jeden Angriffsvektor.
+            store['mais_rechner'] = JSON.stringify({
+                reiter: [{ entries: [{ __proto__: { [sentinel]: true } }] }],
+                _lv: 4
+            });
+            w.loadState();
+            expect(({})[sentinel]).toBeUndefined();
+        });
+    });
+
+    describe('Unknown / extra fields are stripped', () => {
+        it('drops unknown keys from tab objects', () => {
+            store['mais_rechner'] = JSON.stringify({
+                reiter: [{
+                    name: 'X',
+                    hektar: 0,
+                    entries: [],
+                    // Beliebige eingeschleuste Felder
+                    __evil: 'xss',
+                    onload: 'alert(1)',
+                    eval: 'malicious',
+                    toString: 'tampered'
+                }],
+                _lv: 4
+            });
+            w.loadState();
+            const tab = w.state.reiter[0];
+            expect(tab.__evil).toBeUndefined();
+            expect(tab.onload).toBeUndefined();
+            expect(tab.eval).toBeUndefined();
+            // toString bleibt Object.prototype.toString (Function), kein überschriebener String
+            expect(typeof tab.toString).toBe('function');
+        });
+
+        it('drops unknown keys from entry objects', () => {
+            store['mais_rechner'] = JSON.stringify({
+                reiter: [{
+                    entries: [{
+                        einheit: 1,
+                        duenger: 1,
+                        time: 1,
+                        xss: '<script>',
+                        onclick: 'evil()',
+                        extra: { nested: true }
+                    }]
+                }],
+                _lv: 4
+            });
+            w.loadState();
+            const entry = w.state.reiter[0].entries[0];
+            expect(entry.xss).toBeUndefined();
+            expect(entry.onclick).toBeUndefined();
+            expect(entry.extra).toBeUndefined();
+            // Erlaubte Felder bleiben erhalten
+            expect(entry.einheit).toBe(1);
+            expect(entry.time).toBe(1);
+        });
+
+        it('strips unknown top-level state fields but keeps recognized ones', () => {
+            store['mais_rechner'] = JSON.stringify({
+                reiter: [{ name: 'Tab 1', entries: [] }],
+                _lv: 4,
+                xss: 'top-level',
+                injected: { evil: true },
+                activeReiter: 0
+            });
+            w.loadState();
+            expect(w.state.xss).toBeUndefined();
+            expect(w.state.injected).toBeUndefined();
+            // Recognized field ist noch da
+            expect(w.state.activeReiter).toBe(0);
+        });
+    });
+
+    describe('Missing / malformed fields use safe defaults', () => {
+        it('fills missing tab fields with zero defaults', () => {
+            store['mais_rechner'] = JSON.stringify({
+                reiter: [{ entries: [] }],   // komplett leerer Tab
+                _lv: 4
+            });
+            w.loadState();
+            const t = w.state.reiter[0];
+            expect(t.hektar).toBe(0);
+            expect(t.istHektar).toBe(0);
+            expect(t.koerner).toBe(0);
+            expect(t.duenger).toBe(0);
+            expect(t.name).toBe('Tab');
+        });
+
+        it('uses empty array for missing entries', () => {
+            store['mais_rechner'] = JSON.stringify({
+                reiter: [{ name: 'NoEntries' }],   // keine entries
+                _lv: 4
+            });
+            w.loadState();
+            expect(w.state.reiter[0].entries).toEqual([]);
+        });
+
+        it('uses empty array when entries is not an array', () => {
+            store['mais_rechner'] = JSON.stringify({
+                reiter: [{ name: 'X', entries: 'not-an-array' }],
+                _lv: 4
+            });
+            w.loadState();
+            expect(w.state.reiter[0].entries).toEqual([]);
+        });
+
+        it('clamps activeReiter into valid range', () => {
+            store['mais_rechner'] = JSON.stringify({
+                reiter: [{ name: 'A', entries: [] }],
+                activeReiter: 99,        // out of range
+                _lv: 4
+            });
+            w.loadState();
+            expect(w.state.activeReiter).toBe(0);
+
+            store['mais_rechner'] = JSON.stringify({
+                reiter: [{ name: 'A', entries: [] }, { name: 'B', entries: [] }],
+                activeReiter: -1,        // negative
+                _lv: 4
+            });
+            w.loadState();
+            expect(w.state.activeReiter).toBe(0);
+
+            store['mais_rechner'] = JSON.stringify({
+                reiter: [{ name: 'A', entries: [] }, { name: 'B', entries: [] }],
+                activeReiter: 1,         // valid
+                _lv: 4
+            });
+            w.loadState();
+            expect(w.state.activeReiter).toBe(1);
+        });
+
+        it('coerces activeView to null unless literally "protokoll"', () => {
+            store['mais_rechner'] = JSON.stringify({
+                reiter: [{ entries: [] }],
+                activeView: '<script>',
+                _lv: 4
+            });
+            w.loadState();
+            expect(w.state.activeView).toBeNull();
+        });
+
+        it('falls back to 50000 for invalid koernerProEinheit', () => {
+            store['mais_rechner'] = JSON.stringify({
+                reiter: [{ entries: [] }],
+                koernerProEinheit: 'pickle',
+                _lv: 4
+            });
+            w.loadState();
+            expect(w.state.koernerProEinheit).toBe(50000);
+        });
+
+        it('uses defaults for falsy/empty machineLog and drillPriorities', () => {
+            store['mais_rechner'] = JSON.stringify({
+                reiter: [{ entries: [] }],
+                machineLog: 'not-an-array',
+                drillPriorities: [1, 2, 3],   // Array, kein Plain Object
+                _lv: 4
+            });
+            w.loadState();
+            expect(w.state.machineLog).toEqual([]);
+            expect(w.state.drillPriorities).toEqual({});
+        });
+
+        it('sanitizes machineLog entries and drops invalid ones', () => {
+            store['mais_rechner'] = JSON.stringify({
+                reiter: [{ entries: [] }],
+                machineLog: [
+                    { time: 1000, einheit: 5, duenger: 200 },                  // OK
+                    'not an object',                                            // drop
+                    null,                                                       // drop
+                    { time: 'bad', einheit: 1, duenger: 1, xss: 'evil' }       // xss raus
+                ],
+                _lv: 4
+            });
+            w.loadState();
+            expect(w.state.machineLog.length).toBe(2);
+            expect(w.state.machineLog[0].einheit).toBe(5);
+            expect(w.state.machineLog[1].xss).toBeUndefined();
+        });
+    });
+
+    describe('Manipulated state does not crash app', () => {
+        it('loadState() returns true on partially malformed but recoverable state', () => {
+            store['mais_rechner'] = JSON.stringify({
+                reiter: [{
+                    name: 'T',
+                    hektar: 'NaN-ish',
+                    koerner: undefined,
+                    entries: [{ einheit: 1 }, null, { __proto__: { x: 1 } }]
+                }],
+                activeReiter: 'oops',
+                _lv: 4
+            });
+            expect(() => w.loadState()).not.toThrow();
+            // App bleibt in lauffähigem Zustand
+            expect(Array.isArray(w.state.reiter)).toBe(true);
+            expect(w.state.reiter.length).toBe(1);
+            expect(typeof w.state.reiter[0].name).toBe('string');
+        });
+
+        it('loadState() rejects completely malformed root (string, number, array)', () => {
+            store['mais_rechner'] = '"just a string"';
+            expect(() => w.loadState()).not.toThrow();
+            // State unverändert (Default bleibt)
+            expect(w.state.reiter.length).toBe(1);
+            expect(w.state.reiter[0].name).toBe('Tab 1');
+
+            store['mais_rechner'] = '42';
+            expect(() => w.loadState()).not.toThrow();
+
+            store['mais_rechner'] = '[]';
+            expect(() => w.loadState()).not.toThrow();
+            expect(w.state.reiter.length).toBe(1);
+        });
+    });
+
+    describe('Round-trip safety: save → load preserves valid data, drops garbage', () => {
+        it('a cleanly saved state round-trips without data loss', () => {
+            w.state.reiter[0].hektar = 7.5;
+            w.state.reiter[0].koerner = 90000;
+            w.state.reiter[0].duenger = 150;
+            w.state.reiter[0].entries = [
+                { time: 1, einheit: 1, duenger: 50, hektar: 1, istHektar: 0, koerner: 90000, duengerRate: 150 }
+            ];
+            w.saveState();
+
+            // Reset state und re-load
+            w.state = {
+                reiter: [{ name: 'Reset', hektar: 0, istHektar: 0, koerner: 0, duenger: 0, entries: [] }],
+                activeReiter: 0
+            };
+            w.loadState();
+            expect(w.state.reiter[0].hektar).toBe(7.5);
+            expect(w.state.reiter[0].koerner).toBe(90000);
+            expect(w.state.reiter[0].entries.length).toBe(1);
+            expect(w.state.reiter[0].entries[0].einheit).toBe(1);
+        });
+
+        it('corrupting stored state in place is repaired silently on next load', () => {
+            w.state.reiter[0].hektar = 5;
+            w.saveState();
+
+            // Direkt den gespeicherten String manipulieren
+            const raw = JSON.parse(store['mais_rechner']);
+            raw.reiter[0].hektar = '<script>';
+            raw.reiter[0].entries = [{ einheit: 1, xss: 'evil', __proto__: { polluted: true } }];
+            store['mais_rechner'] = JSON.stringify(raw);
+
+            w.loadState();
+            expect(w.state.reiter[0].hektar).toBe(0);          // default
+            expect(w.state.reiter[0].entries[0].xss).toBeUndefined();
+            expect(({}).polluted).toBeUndefined();
+        });
+    });
+});


### PR DESCRIPTION
## Kontext
Closes #237.

`loadState()` hat `JSON.parse(saved)` mit nur einer einzigen Prüfung (`Array.isArray(data.reiter)`) deserialisiert. Alle anderen Felder wurden stillschweigend akzeptiert. Angriffsvektoren:

- Type Injection (`hektar: "<script>..."`, `koerner: { evil: true }`)
- Prototype Pollution via `__proto__`, `constructor`, `prototype` in entries
- Unbekannte Felder (XSS-Payloads als zusätzliche Property)
- Out-of-range `activeReiter`/`activeView`

## Änderungen
- `isPlainObject()` / `sanitizeNumber()` / `sanitizeString()` / `sanitizeBoolean()` Helpers
- `sanitizeEntry()` / `sanitizeMachineLogEntry()` / `sanitizeTab()` mit Type-Checks pro Feld
- `jsonReviver()` strippt `__proto__`/`constructor`/`prototype` auf jeder Verschachtelungsebene
- Top-Level Whitelist (`ALLOWED_TOP_KEYS`) — unbekannte State-Felder werden verworfen
- `activeReiter` wird in gültigen Range geclamped, `activeView` auf `'protokoll'|null` koerziert
- Stillschweigendes Defaulting: App bleibt lauffaehig statt zu crashen

## Tests
- **24 neue Tests** in `tests/43-loadstate-schema-validation.test.js`:
  - Type Injection (Strings, Objects, Arrays, NaN, Infinity in Number-Feldern)
  - Prototype Pollution (`__proto__`, `constructor`, `prototype`)
  - Non-Plain-Entries (Arrays, Strings, null werden gedroppt)
  - Unbekannte Felder auf Tab-, Entry- und Top-Level
  - Missing/Malformed Fields mit Default-Werten
  - activeReiter-Clamping (out of range, negativ)
  - activeView-Coercion
  - Round-Trip Safety (save → manipulate → load → repariert)
- **Baseline:** 507/734 passing, 227 pre-existing failures (out of scope)
- **After:** 531/758 passing, 227 pre-existing failures, **0 regressions, +24 new passing**

## Verifikation
- `pnpm lint` → clean
- `pnpm test` → 531/758 passing (baseline + 24)
- Manueller Test mit manipuliertem Payload: alle Felder sanitisiert, Object.prototype nicht polluted, App lauffaehig

## Reviewer-Hinweise
- `isPlainObject()` schließt `Object.create(null)` UND Klassen-Instanzen aus
- `sanitizeNumber()` akzeptiert number-konvertierbare Strings (z.B. `"10"` → `10`), verwirft NaN/Infinity
- Whitelist-Arrays (`ALLOWED_*_KEYS`) dokumentieren explizit, welche Felder persistiert werden
- `name` wird auf 64 Zeichen gekappt (UX-Schutz vor extrem langen Tab-Namen)
- Bestehende `data._lv` Migration-Logik bleibt unveraendert — Schema-Validierung laeuft NACH allen Migrationen