### PR TITLE
fix(#241): add missing id attributes on drill per-tab inputs

### DIFF
--- a/public/js/render-drill.js
+++ b/public/js/render-drill.js
@@ -57,11 +57,13 @@
           var remaining = totalE - usedE;
           var remainingD = totalD - usedD;
           var statusEl = document.createElement('div');
+          statusEl.id = 'dtl_need_' + i;
           statusEl.style.fontSize = '0.75rem';
           statusEl.style.color = '#666';
           if (remaining <= 0.05 && remainingD <= 0.05) {
             statusEl.textContent = '✓ fertig';
             statusEl.style.color = '#2a9d4a';
+            statusEl.classList.add('done');
           } else {
             statusEl.textContent = 'braucht ' + fmt(Math.max(0, remaining)) + ' Einheiten, ' + fmt(Math.max(0, remainingD)) + ' kg Dünger';
           }
@@ -71,6 +73,7 @@
         var einheitIn = document.createElement('input');
         einheitIn.type = 'text';
         einheitIn.inputMode = 'decimal';
+        einheitIn.id = 'dtl_e_' + i;
         einheitIn.placeholder = 'Einheiten';
         einheitIn.style.width = '70px';
         einheitIn.dataset.tabIdx = String(i);
@@ -81,6 +84,7 @@
         var duengerIn = document.createElement('input');
         duengerIn.type = 'text';
         duengerIn.inputMode = 'decimal';
+        duengerIn.id = 'dtl_d_' + i;
         duengerIn.placeholder = 'kg Dünger';
         duengerIn.style.width = '70px';
         duengerIn.dataset.tabIdx = String(i);


### PR DESCRIPTION
Closes #241

## What
`renderDrillTabList()` in `public/js/render-drill.js` created per-tab input elements without `id` attributes. Tests that look them up via `getElementById` received `null` and crashed.

## Changes
Add three `id` attributes to elements created by `renderDrillTabList()`:

| Element            | id pattern       |
| ------------------ | ---------------- |
| Status ('fertig'/'braucht') | `dtl_need_<i>`  |
| Einheit input      | `dtl_e_<i>`     |
| Dünger input       | `dtl_d_<i>`     |

The priority button (`dtl_prio_<i>`) already had its id set; this change brings the rest of the per-tab elements in line.

Also add the `done` CSS class to the status element when the tab is complete (test/21 checks this via `classList.contains('done')`).

## Test impact
| File  | Before | After |
| ----- | ------ | ----- |
| 14    | 9 fail | 4 fail |
| 18    | 11 fail | 9 fail |
| 21    | 16 fail | 10 fail |
| 22    | 2 fail | 0 fail |

Net: +17 tests passing across the four affected files; 0 regressions in the rest of the suite (`pnpm test`: 226 fail → 209 fail / 534 pass → 551 pass).

## Out of scope
The remaining failures in these test files are pre-existing baseline bugs that don't depend on the missing ids:
- `drillCalcAll` distribution preview (`dtl_e_<i>` and `dtl_d_<i>` are never populated, only cleared on zero/unprioritized)
- machineLog ghost entry when all tabs have prio 0 (bug #73)
- dashboard fahrgassen factor not applied (known bug)
- `einheitGroesse` settings UI restoration

These should be filed as separate issues.