### PR TITLE
fix(#235): Produkt-Identität konsistent auf agrar-rechner umbenennen

### DIFF
--- a/IDEAS.md
+++ b/IDEAS.md
@@ -1,4 +1,4 @@
-# Feature-Ideen für den Mais-Rechner
+# Feature-Ideen für den Agrar-Rechner
 
 ## Hohe Priorität
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Mais-Rechner — Dokumentation
+# Agrar-Rechner — Dokumentation
 
 ## Inhaltsverzeichnis
 
@@ -21,7 +21,7 @@
 
 ## Überblick
 
-Der **Mais-Rechner** ist eine Single-Page Progressive Web App (PWA) für Landwirte, die bei der Aussaat von Mais die benötigte **Saatgut-Menge (Einheiten)** und **Dünger-Menge (kg)** präzise berechnet. Er verwaltet mehrere Felder gleichzeitig über Tabs, führt ein **Drill-Protokoll** über eingefüllte Mengen, berechnet automatisch **Überträge (Carryover)** zwischen Feldern bei Flächenabweichungen und zeigt eine **Dashboard-Übersicht** aller Felder.
+Der **Agrar-Rechner** ist eine Single-Page Progressive Web App (PWA) für Landwirte, die bei der Aussaat von Mais die benötigte **Saatgut-Menge (Einheiten)** und **Dünger-Menge (kg)** präzise berechnet. Er verwaltet mehrere Felder gleichzeitig über Tabs, führt ein **Drill-Protokoll** über eingefüllte Mengen, berechnet automatisch **Überträge (Carryover)** zwischen Feldern bei Flächenabweichungen und zeigt eine **Dashboard-Übersicht** aller Felder.
 
 **Typische Workflows:**
 1. Landwirt gibt für ein Feld (Tab) Hektar, Körner/ha und Dünger/kg ein → App berechnet automatisch Gesamtkörner, Einheiten und Dünger

--- a/public/index.html
+++ b/public/index.html
@@ -9,8 +9,8 @@
   <link rel="manifest" href="manifest.json">
   <link rel="icon" type="image/svg+xml" href="icon.svg">
   <link rel="apple-touch-icon" href="icon-180.png">
-  <meta name="apple-mobile-web-app-title" content="Mais-Rechner">
-  <title>Mais-Rechner</title>
+  <meta name="apple-mobile-web-app-title" content="Agrar-Rechner">
+  <title>Agrar-Rechner</title>
   <link rel="stylesheet" href="css/styles.css">
 </head>
 <body>
@@ -23,7 +23,7 @@
   <div class="container">
     <div class="header-row">
       <div class="header-titles">
-        <h1>🌾 Mais-Rechner</h1>
+        <h1>🌾 Agrar-Rechner</h1>
         <p class="subtitle">Einheiten & Dünger für Aussaat</p>
       </div>
       <div style="display:flex;gap:8px;align-items:flex-start;">

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -64,12 +64,15 @@ window.app = {
   emit:           appEmit,
   dispatch:       dispatch,
   invalidateCarryoverCache: function() { _internal.carryoverCache = null; },
+  migrateLegacyStorageKeys: migrateLegacyStorageKeys,
+  LEGACY_KEY_MAP:            LEGACY_KEY_MAP,
   _internal: _internal
 };
 
 // --- Dark Mode (portiert aus Inline-Code Z. 3415-3448) ---
 // Key: 'theme' in localStorage (Wert: 'dark' oder 'light', null wenn nicht gesetzt).
-// Migration 3→4 in state.js vereinheitlicht 'mais_rechner_theme' → 'theme'.
+// Migration 3→4 in state.js + migrateLegacyStorageKeys() (#235) vereinheitlicht
+// 'mais_rechner_theme' → 'theme'.
 // initTheme(): Stored Preference → System-Präferenz als Fallback.
 // applyTheme(dark): Setzt CSS-Klasse .dark auf <html>, Button-Icon, Meta-Theme-Color.
 // toggleTheme(): Liest aktuellen Zustand → toggled → speichert + anwendet.

--- a/public/js/render-tabs.js
+++ b/public/js/render-tabs.js
@@ -106,7 +106,7 @@
       // Lauscht auf localStorage-Änderungen von anderen Tabs/Fenstern.
       // Der storage-Event feuert nur in Tabs, die den Wert NICHT selbst gesetzt haben.
       window.addEventListener('storage', function(e) {
-        if (e.key === 'mais_rechner' && e.newValue) {
+        if (e.key === 'agrar_rechner' && e.newValue) {
           try {
             var remote = JSON.parse(e.newValue);
             if (JSON.stringify(remote) !== JSON.stringify(state)) {

--- a/public/js/state.js
+++ b/public/js/state.js
@@ -35,10 +35,46 @@
 
     // --- Persistenz ---
 
+    // --- localStorage-Key-Migration (Issue #235) ---
+    // Frühere localStorage-Keys hießen `mais_rechner*`. Repo und Domain heißen
+    // `agrar-rechner`, daher wurden alle Keys auf `agrar_rechner*` umgestellt.
+    // Beim ersten Start lesen wir die alten Keys, schreiben den Wert in den
+    // neuen Key (falls dort noch nichts liegt) und löschen den alten Key.
+    // Migration läuft synchron, bevor loadState()/saveState() aufgerufen werden.
+    var LEGACY_KEY_MAP = {
+      'mais_rechner':              'agrar_rechner',
+      'mais_rechner_theme':        'theme', // bereits in Migration 3→4 erledigt — hier nur Defensiv-Remap
+      'mais_rechner_ios_install_seen': 'agrar_rechner_ios_install_seen',
+      'mais_rechner_version_seen': 'agrar_rechner_version_seen'
+    };
+
+    function migrateLegacyStorageKeys() {
+      try {
+        for (var oldKey in LEGACY_KEY_MAP) {
+          if (!Object.prototype.hasOwnProperty.call(LEGACY_KEY_MAP, oldKey)) continue;
+          var newKey = LEGACY_KEY_MAP[oldKey];
+          var oldVal;
+          try { oldVal = localStorage.getItem(oldKey); } catch(e) { continue; }
+          if (oldVal === null) continue;
+          try {
+            if (localStorage.getItem(newKey) === null) {
+              localStorage.setItem(newKey, oldVal);
+            }
+          } catch(e) { /* write-fehler → nicht kritisch */ }
+          try { localStorage.removeItem(oldKey); } catch(e) { /* egal */ }
+        }
+      } catch(e) {
+        // localStorage komplett nicht verfügbar — silently skip
+      }
+    }
+
+    // Migration frühestmöglich ausführen — vor dem ersten saveState()/loadState().
+    migrateLegacyStorageKeys();
+
     function saveState() {
       invalidateCarryoverCache();
       try {
-        localStorage.setItem('mais_rechner', JSON.stringify(state));
+        localStorage.setItem('agrar_rechner', JSON.stringify(state));
       } catch(e) {
         if (e.name === 'QuotaExceededError' || e.name === 'NS_ERROR_FILE_CANT_CREATE') {
           showSaveError();
@@ -203,7 +239,7 @@
 
     function loadState() {
       try {
-        var saved = localStorage.getItem('mais_rechner');
+        var saved = localStorage.getItem('agrar_rechner');
         if (!saved) return false;
         var data = parsePersistedState(saved);
         if (!isPlainObject(data)) return false;
@@ -230,6 +266,8 @@
         // Migration 3→4: Theme-Key vereinheitlichen, neue Defaults
         if (lv < 4) {
           // Theme: alten Key 'mais_rechner_theme' → neuen Key 'theme'
+          // (durch migrateLegacyStorageKeys() oben meist schon erledigt —
+          //  hier nur Defensiv-Fallback für direkt migrierte Snapshots)
           try {
             var oldTheme = localStorage.getItem('mais_rechner_theme');
             if (oldTheme && !localStorage.getItem('theme')) {
@@ -294,7 +332,7 @@
         // Page-Loads die Migration überspringen können.
         if (originalLv < 4) {
           try {
-            localStorage.setItem('mais_rechner', JSON.stringify(state));
+            localStorage.setItem('agrar_rechner', JSON.stringify(state));
           } catch(e) {
             // Nicht kritisch — Migration war erfolgreich im Memory, beim
             // nächsten Load wird sie einfach erneut durchgeführt (idempotent).
@@ -319,13 +357,13 @@
     // Nur auf iOS/Safari, nur wenn noch nicht installiert und noch nicht dismissed.
     function maybeShowIosInstallHint() {
       var hintSeen = null;
-      try { hintSeen = localStorage.getItem('mais_rechner_ios_install_seen'); } catch(e) {}
+      try { hintSeen = localStorage.getItem('agrar_rechner_ios_install_seen'); } catch(e) {}
       if (!isIOS || isStandalone || hintSeen) return;
       var banner = document.getElementById('ios_install_banner');
       if (banner) banner.classList.add('show');
     }
     function dismissIosInstallHint() {
-      try { localStorage.setItem('mais_rechner_ios_install_seen', '1'); } catch(e) {}
+      try { localStorage.setItem('agrar_rechner_ios_install_seen', '1'); } catch(e) {}
       var banner = document.getElementById('ios_install_banner');
       if (banner) banner.classList.remove('show');
     }
@@ -337,7 +375,7 @@
     var UPDATE_CHANGELOG = 'Erste Veröffentlichung der App.';
     function maybeShowUpdateHint() {
       var seenVersion = null;
-      try { seenVersion = localStorage.getItem('mais_rechner_version_seen'); } catch(e) {}
+      try { seenVersion = localStorage.getItem('agrar_rechner_version_seen'); } catch(e) {}
       if (seenVersion === APP_VERSION) return;
       var banner = document.getElementById('update_banner');
       var verEl = document.getElementById('update_version');
@@ -349,7 +387,7 @@
       }
     }
     function dismissUpdateHint() {
-      try { localStorage.setItem('mais_rechner_version_seen', APP_VERSION); } catch(e) {}
+      try { localStorage.setItem('agrar_rechner_version_seen', APP_VERSION); } catch(e) {}
       var banner = document.getElementById('update_banner');
       if (banner) banner.classList.remove('show');
     }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "Mais-Rechner",
-  "short_name": "Mais-Rechner",
+  "name": "Agrar-Rechner",
+  "short_name": "Agrar-Rechner",
   "description": "Einheiten & Dünger für Aussaat – mit Drill-Protokoll",
   "start_url": "/",
   "scope": "/",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // ⚠️ CACHE_VERSION muss bei jedem Release manuell gebumpet werden!
 // Bei Vergessen bekommen Nutzer die alte Version aus dem Cache.
 // alternativa: Build-Script das Hash/Zeitstempel injiziert.
-const CACHE_VERSION = 'mais-rechner-v13';
+const CACHE_VERSION = 'agrar-rechner-v14';
 const STATIC_ASSETS = [
     '/',
     '/index.html',

--- a/tests/07-state-persistence.test.js
+++ b/tests/07-state-persistence.test.js
@@ -18,7 +18,7 @@ describe('State persistence', () => {
     it('saves state to localStorage', () => {
       w.state.reiter[0].hektar = 10;
       w.saveState();
-      const raw = store['mais_rechner'];
+      const raw = store['agrar_rechner'];
       expect(raw).toBeTruthy();
       const parsed = JSON.parse(raw);
       expect(parsed.reiter[0].hektar).toBe(10);
@@ -26,7 +26,7 @@ describe('State persistence', () => {
 
     it('saves complete state structure', () => {
       w.saveState();
-      const parsed = JSON.parse(store['mais_rechner']);
+      const parsed = JSON.parse(store['agrar_rechner']);
       expect(parsed.reiter).toBeDefined();
       expect(parsed.activeReiter).toBeDefined();
       expect(parsed.fahrgassenEnabled).toBeDefined();
@@ -44,7 +44,7 @@ describe('State persistence', () => {
 
   describe('lv() — load state', () => {
     it('loads state from localStorage', () => {
-      store['mais_rechner'] = JSON.stringify({
+      store['agrar_rechner'] = JSON.stringify({
         reiter: [{ name: 'Test', hektar: 15, koerner: 80000, duenger: 200, entries: [] }],
         activeReiter: 0,
         fahrgassenEnabled: false,
@@ -63,7 +63,7 @@ describe('State persistence', () => {
     });
 
     it('handles corrupted JSON gracefully', () => {
-      store['mais_rechner'] = 'not-valid-json{{{';
+      store['agrar_rechner'] = 'not-valid-json{{{';
       expect(() => w.loadState()).not.toThrow();
     });
 
@@ -73,28 +73,28 @@ describe('State persistence', () => {
     });
 
     it('uses default state when localStorage contains empty object {}', () => {
-      store['mais_rechner'] = '{}';
+      store['agrar_rechner'] = '{}';
       w.loadState();
       expect(w.state.reiter.length).toBe(1);
       expect(w.state.activeReiter).toBe(0);
     });
 
     it('uses default state when localStorage contains empty array []', () => {
-      store['mais_rechner'] = '[]';
+      store['agrar_rechner'] = '[]';
       w.loadState();
       expect(w.state.reiter.length).toBe(1);
       expect(w.state.activeReiter).toBe(0);
     });
 
     it('uses default state when reiter is present but empty', () => {
-      store['mais_rechner'] = JSON.stringify({ reiter: [] });
+      store['agrar_rechner'] = JSON.stringify({ reiter: [] });
       w.loadState();
       expect(w.state.reiter.length).toBe(1);
       expect(w.state.activeReiter).toBe(0);
     });
 
     it('uses default state when reiter is null', () => {
-      store['mais_rechner'] = JSON.stringify({ reiter: null });
+      store['agrar_rechner'] = JSON.stringify({ reiter: null });
       w.loadState();
       expect(w.state.reiter.length).toBe(1);
       expect(w.state.activeReiter).toBe(0);
@@ -103,7 +103,7 @@ describe('State persistence', () => {
 
   describe('Migration: old flat state to tabbed state', () => {
     it('migrates flat state (no reiter) to tabbed format', () => {
-      store['mais_rechner'] = JSON.stringify({
+      store['agrar_rechner'] = JSON.stringify({
         hektar: 10,
         koerner: 90000,
         duenger: 150,
@@ -123,7 +123,7 @@ describe('State persistence', () => {
     });
 
     it('migrates global entries to first tab', () => {
-      store['mais_rechner'] = JSON.stringify({
+      store['agrar_rechner'] = JSON.stringify({
         reiter: [{ name: 'Reiter 1', hektar: 10, koerner: 90000, duenger: 150 }],
         entries: [{ einheit: 5, hektar: 3, duenger: 200, time: '10:00' }],
         activeReiter: 0,
@@ -138,7 +138,7 @@ describe('State persistence', () => {
     });
 
     it('does not overwrite existing tab entries during migration', () => {
-      store['mais_rechner'] = JSON.stringify({
+      store['agrar_rechner'] = JSON.stringify({
         reiter: [{ name: 'Reiter 1', hektar: 10, koerner: 90000, duenger: 150, entries: [{ einheit: 1, hektar: 1, duenger: 50, time: '09:00' }] }],
         entries: [{ einheit: 5, hektar: 3, duenger: 200, time: '10:00' }],
         activeReiter: 0,
@@ -155,7 +155,7 @@ describe('State persistence', () => {
     it('persists migrated snapshot so _lv advances to 4 after first load', () => {
       // Alt-State ohne _lv → Migration 0→4 sollte durchlaufen
       // und das Ergebnis einmalig zurück in localStorage geschrieben werden.
-      store['mais_rechner'] = JSON.stringify({
+      store['agrar_rechner'] = JSON.stringify({
         reiter: [{ name: 'Tab 1', hektar: 10, koerner: 90000, duenger: 150, entries: [] }],
         activeReiter: 0,
         fahrgassenEnabled: false,
@@ -163,25 +163,25 @@ describe('State persistence', () => {
       });
       w.loadState();
       // Nach Migration: gespeicherter Snapshot hat _lv=4
-      var persisted = JSON.parse(store['mais_rechner']);
+      var persisted = JSON.parse(store['agrar_rechner']);
       expect(persisted._lv).toBe(4);
     });
 
     it('does not re-run migration on second load (idempotent at storage level)', () => {
-      store['mais_rechner'] = JSON.stringify({
+      store['agrar_rechner'] = JSON.stringify({
         reiter: [{ name: 'Tab 1', hektar: 10, koerner: 90000, duenger: 150, entries: [] }],
         activeReiter: 0,
         fahrgassenEnabled: false,
         fahrgassenBreite: 0,
       });
       w.loadState();
-      var afterFirst = JSON.parse(store['mais_rechner']);
+      var afterFirst = JSON.parse(store['agrar_rechner']);
       // Zweiter Load: _lv ist schon 4, also kein Re-Migration-Touch.
       // Wenn loadState erneut schreiben würde, wäre das ein No-Op für die
       // Felder; der Test sichert ab, dass _lv erhalten bleibt und keine
       // Re-Schreibung passiert (idempotent = kein Drift).
       w.loadState();
-      var afterSecond = JSON.parse(store['mais_rechner']);
+      var afterSecond = JSON.parse(store['agrar_rechner']);
       expect(afterSecond._lv).toBe(4);
       expect(afterSecond.reiter[0].hektar).toBe(10);
     });

--- a/tests/08-reset-init-sync.test.js
+++ b/tests/08-reset-init-sync.test.js
@@ -110,7 +110,7 @@ describe('initUI()', () => {
   });
 
   it('loads state from localStorage', () => {
-    store['mais_rechner'] = JSON.stringify({
+    store['agrar_rechner'] = JSON.stringify({
       reiter: [{ name: 'Test', hektar: 15, koerner: 80000, duenger: 200, entries: [] }],
       activeReiter: 0,
       fahrgassenEnabled: false,
@@ -122,7 +122,7 @@ describe('initUI()', () => {
   });
 
   it('shows results when state has valid data', () => {
-    store['mais_rechner'] = JSON.stringify({
+    store['agrar_rechner'] = JSON.stringify({
       reiter: [{ name: 'Reiter 1', hektar: 10, koerner: 90000, duenger: 150, entries: [] }],
       activeReiter: 0,
       fahrgassenEnabled: false,
@@ -133,7 +133,7 @@ describe('initUI()', () => {
   });
 
   it('hides results when state has no valid data', () => {
-    store['mais_rechner'] = JSON.stringify({
+    store['agrar_rechner'] = JSON.stringify({
       reiter: [{ name: 'Reiter 1', hektar: 0, koerner: 0, duenger: 0, entries: [] }],
       activeReiter: 0,
       fahrgassenEnabled: false,
@@ -144,7 +144,7 @@ describe('initUI()', () => {
   });
 
   it('restores fahrgassen state', () => {
-    store['mais_rechner'] = JSON.stringify({
+    store['agrar_rechner'] = JSON.stringify({
       reiter: [{ name: 'Reiter 1', hektar: 10, koerner: 90000, duenger: 150, entries: [] }],
       activeReiter: 0,
       fahrgassenEnabled: true,
@@ -157,7 +157,7 @@ describe('initUI()', () => {
   });
 
   it('renders tabs from saved state', () => {
-    store['mais_rechner'] = JSON.stringify({
+    store['agrar_rechner'] = JSON.stringify({
       reiter: [
         { name: 'Feld A', hektar: 10, koerner: 90000, duenger: 150, entries: [] },
         { name: 'Feld B', hektar: 5, koerner: 80000, duenger: 100, entries: [] },

--- a/tests/09-blind-spots.test.js
+++ b/tests/09-blind-spots.test.js
@@ -380,7 +380,7 @@ describe('Blind spots — initUI restores fahrgassen without breite', () => {
   });
 
   it('enables toggle but does not set breite when fahrgassenBreite=0', () => {
-    store['mais_rechner'] = JSON.stringify({
+    store['agrar_rechner'] = JSON.stringify({
       reiter: [{ name: 'Reiter 1', hektar: 0, koerner: 0, duenger: 0, entries: [] }],
       activeReiter: 0,
       fahrgassenEnabled: true,

--- a/tests/10-regression-session-fixes.test.js
+++ b/tests/10-regression-session-fixes.test.js
@@ -27,7 +27,7 @@ describe('Regression: entries undefined on reiter', () => {
 
   it('berechne() works when reiter has no entries field (loaded from old localStorage)', () => {
     // Simulate old localStorage where reiter objects had no entries field
-    store['mais_rechner'] = JSON.stringify({
+    store['agrar_rechner'] = JSON.stringify({
       reiter: [
         { name: 'Feld A', hektar: 10, koerner: 90000, duenger: 150 }
         // no entries field!
@@ -58,7 +58,7 @@ describe('Regression: entries undefined on reiter', () => {
   });
 
   it('berechne() works with multiple reiters where one has no entries', () => {
-    store['mais_rechner'] = JSON.stringify({
+    store['agrar_rechner'] = JSON.stringify({
       reiter: [
         { name: 'Feld A', hektar: 5, koerner: 80000, duenger: 100, entries: [{ einheit: 1, hektar: 2, duenger: 50, time: '10:00' }] },
         { name: 'Feld B', hektar: 8, koerner: 90000, duenger: 200 }  // no entries!
@@ -77,7 +77,7 @@ describe('Regression: entries undefined on reiter', () => {
   });
 
   it('lv() migration adds entries to ALL reiters, not just the first', () => {
-    store['mais_rechner'] = JSON.stringify({
+    store['agrar_rechner'] = JSON.stringify({
       reiter: [
         { name: 'A', hektar: 1, koerner: 80000, duenger: 0 },
         { name: 'B', hektar: 2, koerner: 90000, duenger: 0 },
@@ -276,7 +276,7 @@ describe('Regression: integration — old localStorage + tabs + decimals', () =>
 
   it('old localStorage with no entries → add tab → calculate with decimals', () => {
     // Simulate the exact state that caused the original crash
-    store['mais_rechner'] = JSON.stringify({
+    store['agrar_rechner'] = JSON.stringify({
       reiter: [
         { name: 'Feld A', hektar: 9.2, koerner: 90000, duenger: 150.5 }
       ],

--- a/tests/12-einheit-groesse.test.js
+++ b/tests/12-einheit-groesse.test.js
@@ -41,7 +41,7 @@ describe('einheitGroesseToggle', () => {
 
   it('saves state via sv()', () => {
     w.einheitGroesseToggle();
-    var stored = JSON.parse(w.localStorage.getItem('mais_rechner'));
+    var stored = JSON.parse(w.localStorage.getItem('agrar_rechner'));
     expect(stored.einheitGroesseEnabled).toBe(true);
   });
 });
@@ -99,7 +99,7 @@ describe('einheitGroesseUpdate', () => {
   it('saves state via sv()', () => {
     w.document.getElementById('koerner_pro_einheit').value = '60000';
     w.einheitGroesseUpdate();
-    var stored = JSON.parse(w.localStorage.getItem('mais_rechner'));
+    var stored = JSON.parse(w.localStorage.getItem('agrar_rechner'));
     expect(stored.koernerProEinheit).toBe(60000);
   });
 

--- a/tests/15-render-view.test.js
+++ b/tests/15-render-view.test.js
@@ -137,7 +137,7 @@ describe('switchToProtokoll', () => {
 
   it('saves state via sv()', () => {
     w.switchToProtokoll();
-    var stored = JSON.parse(w.localStorage.getItem('mais_rechner'));
+    var stored = JSON.parse(w.localStorage.getItem('agrar_rechner'));
     expect(stored.activeView).toBe('protokoll');
   });
 

--- a/tests/16-machine-log.test.js
+++ b/tests/16-machine-log.test.js
@@ -121,7 +121,7 @@ describe('drillMachineRemove', () => {
       { einheit: 5, hektar: 3, duenger: 100, time: '10:00' },
     ];
     w.drillMachineRemove(0);
-    var stored = JSON.parse(w.localStorage.getItem('mais_rechner'));
+    var stored = JSON.parse(w.localStorage.getItem('agrar_rechner'));
     expect(stored.machineLog.length).toBe(0);
   });
 });

--- a/tests/17-edge-cases.test.js
+++ b/tests/17-edge-cases.test.js
@@ -122,7 +122,7 @@ describe('lv() migration edge cases', () => {
       duenger: 150,
       entries: [{ einheit: 5, duenger: 100 }]
     };
-    w.localStorage.setItem('mais_rechner', JSON.stringify(oldState));
+    w.localStorage.setItem('agrar_rechner', JSON.stringify(oldState));
     w.loadState();
     expect(w.state.reiter).toBeTruthy();
     expect(w.state.reiter.length).toBe(1);
@@ -136,7 +136,7 @@ describe('lv() migration edge cases', () => {
       reiter: [{ name: 'Tab 1', hektar: 5, koerner: 80000 }],
       entries: [{ einheit: 3, duenger: 50 }]
     };
-    w.localStorage.setItem('mais_rechner', JSON.stringify(oldState));
+    w.localStorage.setItem('agrar_rechner', JSON.stringify(oldState));
     w.loadState();
     expect(w.state.reiter[0].entries.length).toBe(1);
     // Global entries should be removed
@@ -151,7 +151,7 @@ describe('lv() migration edge cases', () => {
       ],
       entries: [{ einheit: 3 }]
     };
-    w.localStorage.setItem('mais_rechner', JSON.stringify(oldState));
+    w.localStorage.setItem('agrar_rechner', JSON.stringify(oldState));
     w.loadState();
     // Tab 1 already has entries, should keep them
     expect(w.state.reiter[0].entries.length).toBe(1);
@@ -165,7 +165,7 @@ describe('lv() migration edge cases', () => {
       reiter: [{ name: 'Tab 1', hektar: 5, koerner: 80000, entries: [] }]
     };
     delete oldState.machineLog;
-    w.localStorage.setItem('mais_rechner', JSON.stringify(oldState));
+    w.localStorage.setItem('agrar_rechner', JSON.stringify(oldState));
     w.loadState();
     expect(w.state.machineLog).toEqual([]);
   });
@@ -441,7 +441,7 @@ describe('drillRemove cross-tab', () => {
   it('saves state after removal', () => {
     w.state.reiter[0].entries = [{ einheit: 5, duenger: 100 }];
     w.drillRemove(0, 0);
-    var stored = JSON.parse(w.localStorage.getItem('mais_rechner'));
+    var stored = JSON.parse(w.localStorage.getItem('agrar_rechner'));
     expect(stored.reiter[0].entries.length).toBe(0);
   });
 });

--- a/tests/18-blind-spots-2.test.js
+++ b/tests/18-blind-spots-2.test.js
@@ -134,7 +134,7 @@ describe('drillMachineRemove()', () => {
   it('persists after removal', () => {
     w.state.machineLog = [{ einheit: 5 }];
     w.drillMachineRemove(0);
-    const stored = JSON.parse(w.localStorage.getItem('mais_rechner'));
+    const stored = JSON.parse(w.localStorage.getItem('agrar_rechner'));
     expect(stored.machineLog.length).toBe(0);
   });
 
@@ -422,7 +422,7 @@ describe('switchToProtokoll()', () => {
 
   it('persists state', () => {
     w.switchToProtokoll();
-    const stored = JSON.parse(w.localStorage.getItem('mais_rechner'));
+    const stored = JSON.parse(w.localStorage.getItem('agrar_rechner'));
     expect(stored.activeView).toBe('protokoll');
   });
 

--- a/tests/18-blind-spots-round2.test.js
+++ b/tests/18-blind-spots-round2.test.js
@@ -352,7 +352,7 @@ describe('lv() migration: ensures entries array on all reiters', () => {
       activeReiter: 0,
       machineLog: []
     };
-    w.localStorage.setItem('mais_rechner', JSON.stringify(migratedState));
+    w.localStorage.setItem('agrar_rechner', JSON.stringify(migratedState));
     w.loadState();
     expect(w.state.reiter[0].entries).toEqual([]);
     expect(w.state.reiter[1].entries.length).toBe(1);
@@ -365,7 +365,7 @@ describe('lv() migration: ensures entries array on all reiters', () => {
       duenger: 150,
       machineLog: []
     };
-    w.localStorage.setItem('mais_rechner', JSON.stringify(migratedState));
+    w.localStorage.setItem('agrar_rechner', JSON.stringify(migratedState));
     w.loadState();
     expect(w.state.reiter).toBeTruthy();
     expect(w.state.reiter.length).toBe(1);

--- a/tests/21-multi-tab-drill-distribution.test.js
+++ b/tests/21-multi-tab-drill-distribution.test.js
@@ -488,7 +488,7 @@ describe('drillPriorities persistence', () => {
     expect(w.state.drillPriorities[0]).toBe(1);
 
     // Saved to localStorage
-    const saved = JSON.parse(store['mais_rechner']);
+    const saved = JSON.parse(store['agrar_rechner']);
     expect(saved.drillPriorities[0]).toBe(1);
   });
 
@@ -514,7 +514,7 @@ describe('drillPriorities persistence', () => {
   it('lv() initializes drillPriorities to {} if missing in saved state', () => {
     const { window: w, store } = createDom();
     // Manually put a state without drillPriorities in localStorage
-    store['mais_rechner'] = JSON.stringify({
+    store['agrar_rechner'] = JSON.stringify({
       reiter: [{ name: 'Tab 1', hektar: 10, koerner: 90000, duenger: 0, entries: [] }],
       activeReiter: 0,
       machineLog: [],

--- a/tests/22-protocol-view.test.js
+++ b/tests/22-protocol-view.test.js
@@ -61,7 +61,7 @@ describe('switchToProtokoll', () => {
 
     w.switchToProtokoll();
 
-    const saved = JSON.parse(store['mais_rechner']);
+    const saved = JSON.parse(store['agrar_rechner']);
     expect(saved.activeView).toBe('protokoll');
   });
 });

--- a/tests/24-einheit-groesse.test.js
+++ b/tests/24-einheit-groesse.test.js
@@ -38,7 +38,7 @@ describe('einheitGroesseToggle', () => {
     const { window: w, store } = createDom();
     w.einheitGroesseToggle();
 
-    const saved = JSON.parse(store['mais_rechner']);
+    const saved = JSON.parse(store['agrar_rechner']);
     expect(saved.einheitGroesseEnabled).toBe(true);
   });
 });
@@ -120,7 +120,7 @@ describe('einheitGroesseUpdate', () => {
     w.document.getElementById('koerner_pro_einheit').value = '40000';
     w.einheitGroesseUpdate();
 
-    const saved = JSON.parse(store['mais_rechner']);
+    const saved = JSON.parse(store['agrar_rechner']);
     expect(saved.koernerProEinheit).toBe(40000);
   });
 });
@@ -140,7 +140,7 @@ describe('initUI einheitGroesse restoration', () => {
       machineLog: [],
       activeView: null,
     };
-    store['mais_rechner'] = JSON.stringify(savedState);
+    store['agrar_rechner'] = JSON.stringify(savedState);
 
     w.initUI();
 
@@ -164,7 +164,7 @@ describe('initUI einheitGroesse restoration', () => {
       machineLog: [],
       activeView: null,
     };
-    store['mais_rechner'] = JSON.stringify(savedState);
+    store['agrar_rechner'] = JSON.stringify(savedState);
 
     w.initUI();
 

--- a/tests/30-drill-machine-remove.test.js
+++ b/tests/30-drill-machine-remove.test.js
@@ -63,7 +63,7 @@ describe('drillMachineRemove', () => {
     w.drillMachineRemove(0);
 
     // sv() is called → state should be persisted
-    const saved = JSON.parse(store['mais_rechner']);
+    const saved = JSON.parse(store['agrar_rechner']);
     expect(saved.machineLog.length).toBe(0);
   });
 

--- a/tests/36-cross-tab-sync.test.js
+++ b/tests/36-cross-tab-sync.test.js
@@ -33,17 +33,17 @@ describe('Cross-Tab-Synchronisation (#128)', () => {
     // and checking that state changes
     const newState = JSON.parse(JSON.stringify(w.state));
     newState.reiter[0].hektar = 99.5;
-    fireStorageEvent(w, 'mais_rechner', JSON.stringify(newState));
+    fireStorageEvent(w, 'agrar_rechner', JSON.stringify(newState));
     expect(w.state.reiter[0].hektar).toBe(99.5);
   });
 
-  it('updates state when another tab saves to mais_rechner', () => {
+  it('updates state when another tab saves to agrar_rechner', () => {
     const { w } = setup();
     const remote = JSON.parse(JSON.stringify(w.state));
     remote.reiter[0].koerner = 42;
     remote.reiter[0].duenger = 123;
 
-    fireStorageEvent(w, 'mais_rechner', JSON.stringify(remote));
+    fireStorageEvent(w, 'agrar_rechner', JSON.stringify(remote));
 
     expect(w.state.reiter[0].koerner).toBe(42);
     expect(w.state.reiter[0].duenger).toBe(123);
@@ -63,7 +63,7 @@ describe('Cross-Tab-Synchronisation (#128)', () => {
     const origHektar = w.state.reiter[0].hektar;
 
     const event = new w.Event('storage');
-    event.key = 'mais_rechner';
+    event.key = 'agrar_rechner';
     event.newValue = null;
     w.dispatchEvent(event);
 
@@ -75,7 +75,7 @@ describe('Cross-Tab-Synchronisation (#128)', () => {
     const origHektar = w.state.reiter[0].hektar;
 
     // Should not throw
-    fireStorageEvent(w, 'mais_rechner', 'not-valid-json');
+    fireStorageEvent(w, 'agrar_rechner', 'not-valid-json');
 
     expect(w.state.reiter[0].hektar).toBe(origHektar);
   });
@@ -87,7 +87,7 @@ describe('Cross-Tab-Synchronisation (#128)', () => {
     const syncSpy = vi.spyOn(w, 'syncInputsFromState');
 
     // Fire event with the exact same state
-    fireStorageEvent(w, 'mais_rechner', JSON.stringify(w.state));
+    fireStorageEvent(w, 'agrar_rechner', JSON.stringify(w.state));
 
     expect(syncSpy).not.toHaveBeenCalled();
     syncSpy.mockRestore();
@@ -100,7 +100,7 @@ describe('Cross-Tab-Synchronisation (#128)', () => {
     const remote = JSON.parse(JSON.stringify(w.state));
     remote.reiter.push({ name: 'Tab 2', hektar: 5, koerner: 200, duenger: 50, istHektar: 0, entries: [] });
 
-    fireStorageEvent(w, 'mais_rechner', JSON.stringify(remote));
+    fireStorageEvent(w, 'agrar_rechner', JSON.stringify(remote));
 
     expect(w.state.reiter.length).toBe(2);
     expect(w.state.reiter[1].name).toBe('Tab 2');
@@ -117,7 +117,7 @@ describe('Cross-Tab-Synchronisation (#128)', () => {
     const remote = JSON.parse(JSON.stringify(w.state));
     remote.activeReiter = 1;
 
-    fireStorageEvent(w, 'mais_rechner', JSON.stringify(remote));
+    fireStorageEvent(w, 'agrar_rechner', JSON.stringify(remote));
 
     expect(w.state.activeReiter).toBe(1);
   });

--- a/tests/38-update-banner.test.js
+++ b/tests/38-update-banner.test.js
@@ -15,16 +15,16 @@ describe('Update Banner ("What\'s New")', () => {
     w = result.window;
     doc = w.document;
     store = result.store;
-    delete store['mais_rechner_version_seen'];
+    delete store['agrar_rechner_version_seen'];
   });
 
   afterEach(() => {
-    delete store['mais_rechner_version_seen'];
+    delete store['agrar_rechner_version_seen'];
   });
 
   describe('maybeShowUpdateHint() via initUI', () => {
     it('shows banner on first visit (no version seen)', () => {
-      delete store['mais_rechner_version_seen'];
+      delete store['agrar_rechner_version_seen'];
       w.initUI();
       const banner = doc.getElementById('update_banner');
       expect(banner).toBeTruthy();
@@ -32,21 +32,21 @@ describe('Update Banner ("What\'s New")', () => {
     });
 
     it('fills version text correctly', () => {
-      delete store['mais_rechner_version_seen'];
+      delete store['agrar_rechner_version_seen'];
       w.initUI();
       const verEl = doc.getElementById('update_version');
       expect(verEl.textContent).toBe('v1.0.0');
     });
 
     it('fills changelog text correctly', () => {
-      delete store['mais_rechner_version_seen'];
+      delete store['agrar_rechner_version_seen'];
       w.initUI();
       const changelogEl = doc.getElementById('update_changelog');
       expect(changelogEl.textContent.length).toBeGreaterThan(0);
     });
 
     it('shows banner when older version was seen', () => {
-      store['mais_rechner_version_seen'] = 'v0.9.0';
+      store['agrar_rechner_version_seen'] = 'v0.9.0';
       w.initUI();
       const banner = doc.getElementById('update_banner');
       expect(banner).toBeTruthy();
@@ -56,7 +56,7 @@ describe('Update Banner ("What\'s New")', () => {
 
   describe('dismissUpdateHint()', () => {
     it('hides the banner after dismiss', () => {
-      delete store['mais_rechner_version_seen'];
+      delete store['agrar_rechner_version_seen'];
       w.initUI();
       w.dismissUpdateHint();
       const banner = doc.getElementById('update_banner');
@@ -64,13 +64,13 @@ describe('Update Banner ("What\'s New")', () => {
     });
 
     it('saves current version to localStorage after dismiss', () => {
-      delete store['mais_rechner_version_seen'];
+      delete store['agrar_rechner_version_seen'];
       w.dismissUpdateHint();
-      expect(store['mais_rechner_version_seen']).toBe('v1.0.0');
+      expect(store['agrar_rechner_version_seen']).toBe('v1.0.0');
     });
 
     it('second initUI does not re-show banner after dismiss', () => {
-      delete store['mais_rechner_version_seen'];
+      delete store['agrar_rechner_version_seen'];
       w.initUI();
       w.dismissUpdateHint();
       w.initUI();
@@ -97,7 +97,7 @@ describe('Update Banner ("What\'s New")', () => {
 
   describe('version footer', () => {
     it('version footer shows APP_VERSION and APP_BUILD_DATE after initUI', () => {
-      delete store['mais_rechner_version_seen'];
+      delete store['agrar_rechner_version_seen'];
       w.initUI();
       const footer = doc.getElementById('version_footer');
       expect(footer).toBeTruthy();

--- a/tests/39-ios-install-banner.test.js
+++ b/tests/39-ios-install-banner.test.js
@@ -20,11 +20,11 @@ describe('iOS Install Hint Banner', () => {
     w = result.window;
     doc = w.document;
     store = result.store;
-    delete store['mais_rechner_ios_install_seen'];
+    delete store['agrar_rechner_ios_install_seen'];
   });
 
   afterEach(() => {
-    delete store['mais_rechner_ios_install_seen'];
+    delete store['agrar_rechner_ios_install_seen'];
   });
 
   describe('maybeShowIosInstallHint()', () => {
@@ -75,7 +75,7 @@ describe('iOS Install Hint Banner', () => {
       Object.defineProperty(w, 'navigator', { value: w.navigator, writable: true });
       w.isIOS = true;
       w.isStandalone = false;
-      store['mais_rechner_ios_install_seen'] = '1';
+      store['agrar_rechner_ios_install_seen'] = '1';
       w.maybeShowIosInstallHint();
       const banner = doc.getElementById('ios_install_banner');
       expect(banner.classList.contains('show')).toBe(false);
@@ -106,7 +106,7 @@ describe('iOS Install Hint Banner', () => {
       w.isIOS = true;
       w.isStandalone = false;
       w.dismissIosInstallHint();
-      expect(store['mais_rechner_ios_install_seen']).toBe('1');
+      expect(store['agrar_rechner_ios_install_seen']).toBe('1');
     });
 
     it('banner does not re-appear on next maybeShowIosInstallHint call', () => {
@@ -136,7 +136,7 @@ describe('iOS Install Hint Banner', () => {
       w.isIOS = true;
       w.isStandalone = false;
       // Clear any persisted hint
-      delete store['mais_rechner_ios_install_seen'];
+      delete store['agrar_rechner_ios_install_seen'];
       // initUI() calls maybeShowIosInstallHint() at the end of calculation flow
       w.initUI();
       // Simulate what happens after calculation: handleBerechnenFlow calls maybeShowIosInstallHint

--- a/tests/43-loadstate-schema-validation.test.js
+++ b/tests/43-loadstate-schema-validation.test.js
@@ -18,7 +18,7 @@ describe('loadState() schema validation (Issue #237)', () => {
 
     describe('Type injection on tab fields', () => {
         it('coerces string-typed number fields to numbers (rejected as invalid → 0)', () => {
-            store['mais_rechner'] = JSON.stringify({
+            store['agrar_rechner'] = JSON.stringify({
                 reiter: [{
                     name: 'Injected',
                     hektar: '"<script>alert(1)</script>"',  // String statt Zahl
@@ -38,7 +38,7 @@ describe('loadState() schema validation (Issue #237)', () => {
         });
 
         it('accepts finite numbers and number-coercible strings as tab fields', () => {
-            store['mais_rechner'] = JSON.stringify({
+            store['agrar_rechner'] = JSON.stringify({
                 reiter: [{
                     name: 'OK',
                     hektar: 12.5,
@@ -57,7 +57,7 @@ describe('loadState() schema validation (Issue #237)', () => {
         });
 
         it('rejects NaN and Infinity in number fields', () => {
-            store['mais_rechner'] = JSON.stringify({
+            store['agrar_rechner'] = JSON.stringify({
                 reiter: [{
                     name: 'Bad',
                     hektar: null,
@@ -77,7 +77,7 @@ describe('loadState() schema validation (Issue #237)', () => {
         });
 
         it('falls back to "Tab" when name is missing or non-string', () => {
-            store['mais_rechner'] = JSON.stringify({
+            store['agrar_rechner'] = JSON.stringify({
                 reiter: [{ hektar: 0, koerner: 0, duenger: 0, entries: [] }],
                 _lv: 4
             });
@@ -87,7 +87,7 @@ describe('loadState() schema validation (Issue #237)', () => {
 
         it('truncates oversize name to 64 chars', () => {
             const longName = 'A'.repeat(200);
-            store['mais_rechner'] = JSON.stringify({
+            store['agrar_rechner'] = JSON.stringify({
                 reiter: [{ name: longName, entries: [] }],
                 _lv: 4
             });
@@ -98,7 +98,7 @@ describe('loadState() schema validation (Issue #237)', () => {
 
     describe('Prototype pollution protection', () => {
         it('strips __proto__ from entries', () => {
-            store['mais_rechner'] = JSON.stringify({
+            store['agrar_rechner'] = JSON.stringify({
                 reiter: [{
                     name: 'P',
                     entries: [{
@@ -120,7 +120,7 @@ describe('loadState() schema validation (Issue #237)', () => {
         });
 
         it('strips constructor and prototype keys at any nesting level', () => {
-            store['mais_rechner'] = JSON.stringify({
+            store['agrar_rechner'] = JSON.stringify({
                 reiter: [{
                     entries: [{
                         constructor: { polluted: true },
@@ -143,7 +143,7 @@ describe('loadState() schema validation (Issue #237)', () => {
         });
 
         it('rejects non-plain entries (arrays, class instances, null)', () => {
-            store['mais_rechner'] = JSON.stringify({
+            store['agrar_rechner'] = JSON.stringify({
                 reiter: [{
                     entries: [
                         [1, 2, 3],                       // Array statt Object
@@ -164,7 +164,7 @@ describe('loadState() schema validation (Issue #237)', () => {
             const sentinel = '__polluted_' + Date.now();
             // JSON.parse kann __proto__ per Spec nicht direkt setzen,
             // aber der Reviver entzieht ihm jeden Angriffsvektor.
-            store['mais_rechner'] = JSON.stringify({
+            store['agrar_rechner'] = JSON.stringify({
                 reiter: [{ entries: [{ __proto__: { [sentinel]: true } }] }],
                 _lv: 4
             });
@@ -175,7 +175,7 @@ describe('loadState() schema validation (Issue #237)', () => {
 
     describe('Unknown / extra fields are stripped', () => {
         it('drops unknown keys from tab objects', () => {
-            store['mais_rechner'] = JSON.stringify({
+            store['agrar_rechner'] = JSON.stringify({
                 reiter: [{
                     name: 'X',
                     hektar: 0,
@@ -198,7 +198,7 @@ describe('loadState() schema validation (Issue #237)', () => {
         });
 
         it('drops unknown keys from entry objects', () => {
-            store['mais_rechner'] = JSON.stringify({
+            store['agrar_rechner'] = JSON.stringify({
                 reiter: [{
                     entries: [{
                         einheit: 1,
@@ -222,7 +222,7 @@ describe('loadState() schema validation (Issue #237)', () => {
         });
 
         it('strips unknown top-level state fields but keeps recognized ones', () => {
-            store['mais_rechner'] = JSON.stringify({
+            store['agrar_rechner'] = JSON.stringify({
                 reiter: [{ name: 'Tab 1', entries: [] }],
                 _lv: 4,
                 xss: 'top-level',
@@ -239,7 +239,7 @@ describe('loadState() schema validation (Issue #237)', () => {
 
     describe('Missing / malformed fields use safe defaults', () => {
         it('fills missing tab fields with zero defaults', () => {
-            store['mais_rechner'] = JSON.stringify({
+            store['agrar_rechner'] = JSON.stringify({
                 reiter: [{ entries: [] }],   // komplett leerer Tab
                 _lv: 4
             });
@@ -253,7 +253,7 @@ describe('loadState() schema validation (Issue #237)', () => {
         });
 
         it('uses empty array for missing entries', () => {
-            store['mais_rechner'] = JSON.stringify({
+            store['agrar_rechner'] = JSON.stringify({
                 reiter: [{ name: 'NoEntries' }],   // keine entries
                 _lv: 4
             });
@@ -262,7 +262,7 @@ describe('loadState() schema validation (Issue #237)', () => {
         });
 
         it('uses empty array when entries is not an array', () => {
-            store['mais_rechner'] = JSON.stringify({
+            store['agrar_rechner'] = JSON.stringify({
                 reiter: [{ name: 'X', entries: 'not-an-array' }],
                 _lv: 4
             });
@@ -271,7 +271,7 @@ describe('loadState() schema validation (Issue #237)', () => {
         });
 
         it('clamps activeReiter into valid range', () => {
-            store['mais_rechner'] = JSON.stringify({
+            store['agrar_rechner'] = JSON.stringify({
                 reiter: [{ name: 'A', entries: [] }],
                 activeReiter: 99,        // out of range
                 _lv: 4
@@ -279,7 +279,7 @@ describe('loadState() schema validation (Issue #237)', () => {
             w.loadState();
             expect(w.state.activeReiter).toBe(0);
 
-            store['mais_rechner'] = JSON.stringify({
+            store['agrar_rechner'] = JSON.stringify({
                 reiter: [{ name: 'A', entries: [] }, { name: 'B', entries: [] }],
                 activeReiter: -1,        // negative
                 _lv: 4
@@ -287,7 +287,7 @@ describe('loadState() schema validation (Issue #237)', () => {
             w.loadState();
             expect(w.state.activeReiter).toBe(0);
 
-            store['mais_rechner'] = JSON.stringify({
+            store['agrar_rechner'] = JSON.stringify({
                 reiter: [{ name: 'A', entries: [] }, { name: 'B', entries: [] }],
                 activeReiter: 1,         // valid
                 _lv: 4
@@ -297,7 +297,7 @@ describe('loadState() schema validation (Issue #237)', () => {
         });
 
         it('coerces activeView to null unless literally "protokoll"', () => {
-            store['mais_rechner'] = JSON.stringify({
+            store['agrar_rechner'] = JSON.stringify({
                 reiter: [{ entries: [] }],
                 activeView: '<script>',
                 _lv: 4
@@ -307,7 +307,7 @@ describe('loadState() schema validation (Issue #237)', () => {
         });
 
         it('falls back to 50000 for invalid koernerProEinheit', () => {
-            store['mais_rechner'] = JSON.stringify({
+            store['agrar_rechner'] = JSON.stringify({
                 reiter: [{ entries: [] }],
                 koernerProEinheit: 'pickle',
                 _lv: 4
@@ -317,7 +317,7 @@ describe('loadState() schema validation (Issue #237)', () => {
         });
 
         it('uses defaults for falsy/empty machineLog and drillPriorities', () => {
-            store['mais_rechner'] = JSON.stringify({
+            store['agrar_rechner'] = JSON.stringify({
                 reiter: [{ entries: [] }],
                 machineLog: 'not-an-array',
                 drillPriorities: [1, 2, 3],   // Array, kein Plain Object
@@ -329,7 +329,7 @@ describe('loadState() schema validation (Issue #237)', () => {
         });
 
         it('sanitizes machineLog entries and drops invalid ones', () => {
-            store['mais_rechner'] = JSON.stringify({
+            store['agrar_rechner'] = JSON.stringify({
                 reiter: [{ entries: [] }],
                 machineLog: [
                     { time: 1000, einheit: 5, duenger: 200 },                  // OK
@@ -348,7 +348,7 @@ describe('loadState() schema validation (Issue #237)', () => {
 
     describe('Manipulated state does not crash app', () => {
         it('loadState() returns true on partially malformed but recoverable state', () => {
-            store['mais_rechner'] = JSON.stringify({
+            store['agrar_rechner'] = JSON.stringify({
                 reiter: [{
                     name: 'T',
                     hektar: 'NaN-ish',
@@ -366,16 +366,16 @@ describe('loadState() schema validation (Issue #237)', () => {
         });
 
         it('loadState() rejects completely malformed root (string, number, array)', () => {
-            store['mais_rechner'] = '"just a string"';
+            store['agrar_rechner'] = '"just a string"';
             expect(() => w.loadState()).not.toThrow();
             // State unverändert (Default bleibt)
             expect(w.state.reiter.length).toBe(1);
             expect(w.state.reiter[0].name).toBe('Tab 1');
 
-            store['mais_rechner'] = '42';
+            store['agrar_rechner'] = '42';
             expect(() => w.loadState()).not.toThrow();
 
-            store['mais_rechner'] = '[]';
+            store['agrar_rechner'] = '[]';
             expect(() => w.loadState()).not.toThrow();
             expect(w.state.reiter.length).toBe(1);
         });
@@ -408,10 +408,10 @@ describe('loadState() schema validation (Issue #237)', () => {
             w.saveState();
 
             // Direkt den gespeicherten String manipulieren
-            const raw = JSON.parse(store['mais_rechner']);
+            const raw = JSON.parse(store['agrar_rechner']);
             raw.reiter[0].hektar = '<script>';
             raw.reiter[0].entries = [{ einheit: 1, xss: 'evil', __proto__: { polluted: true } }];
-            store['mais_rechner'] = JSON.stringify(raw);
+            store['agrar_rechner'] = JSON.stringify(raw);
 
             w.loadState();
             expect(w.state.reiter[0].hektar).toBe(0);          // default

--- a/tests/44-legacy-key-migration.test.js
+++ b/tests/44-legacy-key-migration.test.js
@@ -1,0 +1,129 @@
+/**
+ * Issue #235: localStorage-Key-Migration von mais_rechner* → agrar_rechner*
+ *
+ * Beim ersten Start nach dem Update liest die App den alten Key,
+ * schreibt den Wert in den neuen Key (falls dort noch nichts liegt)
+ * und löscht den alten Key.
+ *
+ * Getestet werden alle vier Legacy-Keys:
+ *   mais_rechner              → agrar_rechner
+ *   mais_rechner_theme        → theme
+ *   mais_rechner_ios_install_seen → agrar_rechner_ios_install_seen
+ *   mais_rechner_version_seen → agrar_rechner_version_seen
+ */
+import { describe, it, expect } from 'vitest';
+import { createDom } from './helpers.js';
+
+const LEGACY_DATA = {
+  _lv: 4,
+  reiter: [{ name: 'Tab 1', hektar: 12.5, istHektar: 12.5, koerner: 90000, duenger: 200, entries: [] }],
+  activeReiter: 0,
+  activeView: null,
+  fahrgassenEnabled: false,
+  fahrgassenBreite: 0,
+  einheitGroesseEnabled: false,
+  koernerProEinheit: 50000,
+  machineLog: [],
+  drillPriorities: {},
+  iosInstallHintShown: false
+};
+
+describe('Issue #235: localStorage key migration', () => {
+  it('moves mais_rechner → agrar_rechner and removes the old key', () => {
+    const ctx = createDom();
+    const payload = JSON.stringify(LEGACY_DATA);
+    ctx.store['mais_rechner'] = payload;
+    expect(ctx.store['agrar_rechner']).toBeUndefined();
+
+    // Migration läuft synchron
+    ctx.window.app.migrateLegacyStorageKeys();
+
+    expect(ctx.store['agrar_rechner']).toBe(payload);
+    expect(ctx.store['mais_rechner']).toBeUndefined();
+  });
+
+  it('moves mais_rechner_theme → theme', () => {
+    const ctx = createDom();
+    ctx.store['mais_rechner_theme'] = 'dark';
+    expect(ctx.store['theme']).toBeUndefined();
+
+    ctx.window.app.migrateLegacyStorageKeys();
+
+    expect(ctx.store['theme']).toBe('dark');
+    expect(ctx.store['mais_rechner_theme']).toBeUndefined();
+  });
+
+  it('moves mais_rechner_ios_install_seen → agrar_rechner_ios_install_seen', () => {
+    const ctx = createDom();
+    ctx.store['mais_rechner_ios_install_seen'] = '1';
+    expect(ctx.store['agrar_rechner_ios_install_seen']).toBeUndefined();
+
+    ctx.window.app.migrateLegacyStorageKeys();
+
+    expect(ctx.store['agrar_rechner_ios_install_seen']).toBe('1');
+    expect(ctx.store['mais_rechner_ios_install_seen']).toBeUndefined();
+  });
+
+  it('moves mais_rechner_version_seen → agrar_rechner_version_seen', () => {
+    const ctx = createDom();
+    ctx.store['mais_rechner_version_seen'] = 'v1.2.3';
+    expect(ctx.store['agrar_rechner_version_seen']).toBeUndefined();
+
+    ctx.window.app.migrateLegacyStorageKeys();
+
+    expect(ctx.store['agrar_rechner_version_seen']).toBe('v1.2.3');
+    expect(ctx.store['mais_rechner_version_seen']).toBeUndefined();
+  });
+
+  it('does not overwrite an existing value at the new key', () => {
+    const ctx = createDom();
+    const existing = JSON.stringify({ ...LEGACY_DATA, marker: 'already-on-new-key' });
+    const legacy = JSON.stringify({ ...LEGACY_DATA, marker: 'legacy' });
+    ctx.store['agrar_rechner'] = existing;
+    ctx.store['mais_rechner'] = legacy;
+
+    ctx.window.app.migrateLegacyStorageKeys();
+
+    // existing agrar_rechner must be preserved
+    expect(ctx.store['agrar_rechner']).toBe(existing);
+    // legacy key is still cleaned up
+    expect(ctx.store['mais_rechner']).toBeUndefined();
+  });
+
+  it('is idempotent — running twice does not corrupt state', () => {
+    const ctx = createDom();
+    const payload = JSON.stringify(LEGACY_DATA);
+    ctx.store['mais_rechner'] = payload;
+
+    ctx.window.app.migrateLegacyStorageKeys();
+    ctx.window.app.migrateLegacyStorageKeys();
+    ctx.window.app.migrateLegacyStorageKeys();
+
+    expect(ctx.store['agrar_rechner']).toBe(payload);
+    expect(ctx.store['mais_rechner']).toBeUndefined();
+  });
+
+  it('LEGACY_KEY_MAP contains exactly the four expected entries', () => {
+    const ctx = createDom();
+    const map = ctx.window.app.LEGACY_KEY_MAP;
+    expect(Object.keys(map).sort()).toEqual([
+      'mais_rechner',
+      'mais_rechner_ios_install_seen',
+      'mais_rechner_theme',
+      'mais_rechner_version_seen'
+    ]);
+    expect(map['mais_rechner']).toBe('agrar_rechner');
+    expect(map['mais_rechner_theme']).toBe('theme');
+    expect(map['mais_rechner_ios_install_seen']).toBe('agrar_rechner_ios_install_seen');
+    expect(map['mais_rechner_version_seen']).toBe('agrar_rechner_version_seen');
+  });
+
+  it('runs automatically during module load (no legacy keys present in fresh install)', () => {
+    // The migration is invoked at the top of state.js, before saveState/loadState.
+    // A fresh createDom() simulates a new install: no legacy data, no errors.
+    const ctx = createDom();
+    expect(ctx.store['agrar_rechner']).toBeUndefined();
+    expect(ctx.store['mais_rechner']).toBeUndefined();
+    expect(ctx.store['theme']).toBeUndefined();
+  });
+});

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1,5 +1,5 @@
 /**
- * Shared test helper — loads the Mais-Rechner JS into a jsdom instance.
+ * Shared test helper — loads the Agrar-Rechner JS into a jsdom instance.
  * Works with the modular architecture: state.js, calculations.js, ui-handlers.js,
  * render-tabs.js, render-results.js, render-drill.js, render-dashboard.js, main.js
  * (Issue #212: rendering.js was split into 4 modules in June 2026.)


### PR DESCRIPTION
Fixes #235

Vereinheitlichung der inkonsistenten Namensgebung zwischen GitHub-Repo/Domain (`agrar-rechner`) und App-Anzeige (`Mais-Rechner` / `mais_rechner`).

## Änderungen

**Anzeige-Namen:**
- `public/index.html`: H1, `<title>`, `apple-mobile-web-app-title` → 'Agrar-Rechner'
- `public/manifest.json`: `name` + `short_name` → 'Agrar-Rechner'
- `public/sw.js`: CACHE_VERSION 'mais-rechner-v13' → 'agrar-rechner-v14' (Bump erzwingt saubere Cache-Erneuerung)

**localStorage-Keys (mit Migration):**
- Haupt-Key: `mais_rechner` → `agrar_rechner`
- iOS-Hint: `mais_rechner_ios_install_seen` → `agrar_rechner_ios_install_seen`
- Update-Banner: `mais_rechner_version_seen` → `agrar_rechner_version_seen`
- Theme: `mais_rechner_theme` → `theme` (war bereits in Migration 3→4 erledigt; jetzt zentral über LEGACY_KEY_MAP)

**Migration:**
`migrateLegacyStorageKeys()` läuft beim App-Boot in `state.js`. Liest die alten Keys, schreibt den Wert in den neuen Key (falls noch nicht vorhanden — keine User-Daten werden überschrieben), löscht den alten Key. Idempotent, defensiv gegen mehrfaches Aufrufen und nicht vorhandene localStorage.

**Code/Docs:**
- `public/js/render-tabs.js`: Storage-Event-Listener auf neuen Key
- `public/js/main.js`: Kommentar präzisiert
- `README.md`, `IDEAS.md`, `tests/helpers.js`: Produkt-Name aktualisiert
- `tests/*`: Bestehende Tests auf neue Keys umgestellt
- Neue Tests: `tests/44-legacy-key-migration.test.js` (8 Tests) decken alle Migrations-Pfade ab

## Test
- `pnpm test`: 8/8 neue Tests grün; baseline 559 passing / 209 failing (pre-existing, identisch zu `dev`)
- `pnpm lint`: clean
- Kein Verhalten geändert für User mit bereits migrierten Daten