### PR TITLE
fix(#236): Reset-Buttons vereinfachen — ein Button mit Confirmation-Modal

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -843,6 +843,115 @@ font-size: 0.75rem;
       padding-bottom: 8px;
     }
 
+    /* Reset Confirmation Modal (Issue #236) */
+    .reset-overlay {
+      display: none;
+      position: fixed;
+      inset: 0;
+      background: rgba(0,0,0,0.5);
+      z-index: 200;
+    }
+    .reset-overlay.open {
+      display: block;
+    }
+    .reset-modal {
+      display: none;
+      position: fixed;
+      left: 50%;
+      bottom: 50%;
+      transform: translate(-50%, 50%);
+      width: min(92vw, 420px);
+      max-height: 80vh;
+      overflow-y: auto;
+      background: var(--color-card-bg);
+      color: var(--color-card-text);
+      border-radius: 16px;
+      box-shadow: 0 8px 32px rgba(0,0,0,0.35);
+      padding: 20px 20px max(20px, env(safe-area-inset-bottom));
+      z-index: 201;
+    }
+    .reset-modal.open {
+      display: block;
+    }
+    .reset-modal-header h2 {
+      margin: 0 0 8px 0;
+      padding: 0;
+      border: none;
+      font-size: 1.2rem;
+      color: var(--color-text);
+    }
+    .reset-modal-desc {
+      margin: 0 0 16px 0;
+      font-size: 0.95rem;
+      color: var(--color-text-muted, var(--color-text-subtle));
+      line-height: 1.4;
+    }
+    .reset-modal-actions {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+    .reset-modal-actions .btn {
+      width: 100%;
+      margin: 0;
+      flex: none;
+    }
+    .reset-modal .btn-secondary {
+      background: var(--color-primary);
+      color: #fff;
+      font-size: 1rem;
+      padding: 14px;
+    }
+    .reset-modal .btn-secondary:active {
+      background: var(--color-primary-active);
+    }
+    .reset-modal .btn-danger {
+      background: var(--color-danger);
+      color: #fff;
+      font-size: 1rem;
+      padding: 14px;
+      width: 100%;
+      margin: 0;
+    }
+    .reset-modal .btn-danger:active {
+      background: var(--color-danger-dark);
+    }
+    .reset-modal .btn-danger.armed {
+      background: var(--color-danger-dark);
+      box-shadow: 0 0 0 3px var(--color-danger-soft) inset;
+      animation: resetArmPulse 1.2s ease-in-out infinite;
+    }
+    @keyframes resetArmPulse {
+      0%, 100% { box-shadow: 0 0 0 3px var(--color-danger-soft) inset; }
+      50%      { box-shadow: 0 0 0 6px var(--color-danger-soft) inset; }
+    }
+    .reset-modal .btn-cancel {
+      background: transparent;
+      color: var(--color-text-muted, var(--color-text-subtle));
+      font-size: 1rem;
+      padding: 12px;
+      width: 100%;
+      margin: 0;
+      border: 1px solid var(--color-border);
+    }
+    .reset-modal .btn-cancel:active {
+      background: var(--color-bg-hover);
+    }
+    /* Mobile: Modal als Bottom Sheet (full-width, oben gerundet) */
+    @media (max-width: 600px) {
+      .reset-modal {
+        left: 0;
+        right: 0;
+        bottom: 0;
+        top: auto;
+        width: 100%;
+        max-width: 100%;
+        transform: none;
+        border-radius: 20px 20px 0 0;
+        max-height: 90vh;
+      }
+    }
+
     /* Dashboard */
     .dashboard-overlay {
       display: none;

--- a/public/index.html
+++ b/public/index.html
@@ -213,8 +213,7 @@
         </div>
         <div class="footer-btn-row">
           <button class="btn" onclick="berechne()" id="berechnen_btn">Berechnen</button>
-          <button class="btn btn-secondary" onclick="confirmResetAll()" id="reset_btn">Zurücksetzen</button>
-          <button class="btn btn-danger" onclick="confirmResetAll(true)" id="reset_all_btn">Alles zurücksetzen</button>
+          <button class="btn btn-secondary" onclick="openResetModal(this)" id="reset_btn" aria-haspopup="dialog" aria-controls="reset_modal">Zurücksetzen</button>
         </div>
       </div>
     </div>
@@ -252,7 +251,7 @@
     // Lade-Reihenfolge (wichtig!):
     //   state.js → calculations.js → ui-handlers.js
     //     → render-tabs.js → render-results.js → render-drill.js → render-dashboard.js
-    //     → main.js
+    //     → reset-modal.js → main.js
     //
     //   state.js definiert: state, saveState(), loadState()
     //   calculations.js braucht: state, _internal (von state.js)
@@ -261,6 +260,7 @@
     //   render-results.js braucht: state, render-tabs.js, render-drill.js, calculations.js
     //   render-drill.js braucht: state, ui-handlers.js, calculations.js
     //   render-dashboard.js braucht: state, calculations.js
+    //   reset-modal.js braucht: state, resetActiveTab, resetAll (Issue #236)
     //   main.js: APP_VERSION, Event-Emitter, initTheme
     // ============================================================================
   </script>
@@ -271,6 +271,7 @@
   <script src="js/render-results.js"></script>
   <script src="js/render-drill.js"></script>
   <script src="js/render-dashboard.js"></script>
+  <script src="js/reset-modal.js"></script>
   <script src="js/main.js"></script>
   <div class="version-footer" id="version_footer"></div>
   <!-- Dashboard overlay + sheet -->
@@ -281,6 +282,22 @@
       <button class="dashboard-close" onclick="closeDashboard()" aria-label="Schließen">✕</button>
     </div>
     <div class="dashboard-content" id="dashboard_content"></div>
+  </div>
+
+  <!-- Reset Confirmation Modal (Issue #236) -->
+  <div class="reset-overlay" id="reset_overlay" onclick="_onOverlayClick(event)"></div>
+  <div class="reset-modal" id="reset_modal" role="dialog" aria-modal="true" aria-labelledby="reset_modal_title" aria-describedby="reset_modal_desc">
+    <div class="reset-modal-header">
+      <h2 id="reset_modal_title">Zurücksetzen</h2>
+    </div>
+    <p class="reset-modal-desc" id="reset_modal_desc">
+      Was möchtest du zurücksetzen? Diese Aktion lässt sich nicht rückgängig machen.
+    </p>
+    <div class="reset-modal-actions">
+      <button class="btn btn-secondary" id="reset_modal_tab" onclick="_onResetTab()">Aktuellen Tab zurücksetzen</button>
+      <button class="btn btn-danger" id="reset_modal_confirm_all" onclick="_onResetAll()">Alle Daten löschen</button>
+      <button class="btn btn-cancel" id="reset_modal_cancel" onclick="_onCancel()">Abbrechen</button>
+    </div>
   </div>
 </body>
 </html>

--- a/public/js/render-tabs.js
+++ b/public/js/render-tabs.js
@@ -90,8 +90,6 @@
       if (berechnenBtn) berechnenBtn.style.display = isProtokoll ? 'none' : '';
       var resetBtn = document.getElementById('reset_btn');
       if (resetBtn) resetBtn.style.display = isProtokoll ? 'none' : '';
-      var resetAllBtn = document.getElementById('reset_all_btn');
-      if (resetAllBtn) resetAllBtn.style.display = isProtokoll ? 'none' : '';
       var stickyFooter = document.getElementById('sticky_footer');
       if (stickyFooter) stickyFooter.style.display = isProtokoll ? 'none' : '';
     }

--- a/public/js/reset-modal.js
+++ b/public/js/reset-modal.js
@@ -1,0 +1,140 @@
+// ============================================================================
+// RESET-MODAL — Confirmation modal for reset actions (Issue #236)
+//
+// Ersetzt die beiden nativen `confirm()`-Dialoge durch ein eigenes Modal mit:
+//   1. "Aktuellen Tab zurücksetzen" (normaler Style)
+//   2. "Alle Daten löschen" (rot, Warning-Styling, doppelte Bestätigung)
+//   3. "Abbrechen"
+//
+// Anforderungen:
+//   - Kein window.confirm() mehr
+//   - Tastatur: ESC schließt, Tab/Shift+Tab Focus-Trap, Enter löst primäre Aktion aus
+//   - Screenreader: role="dialog", aria-modal, aria-labelledby
+//   - Mobile-first: bottom sheet auf kleinen Screens, kompakt im Footer
+//   - Erhält resetActiveTab() und resetAll() (definiert in ui-handlers.js)
+// ============================================================================
+
+    // Verweis auf den Trigger-Button, damit wir nach Schließen den Fokus
+    // dahinter zurückgeben können (A11y-Pflicht beim Schließen von Dialogen).
+    var _modalLastTrigger = null;
+
+    // Markiert, ob die "Alle Daten löschen"-Aktion bereits bestätigt wurde
+    // (Zwei-Stufen-Bestätigung gegen versehentliches Klicken).
+    var _fullResetArmed = false;
+
+    function _getModal() { return document.getElementById('reset_modal'); }
+    function _getOverlay() { return document.getElementById('reset_overlay'); }
+
+    function _focusableInModal() {
+      var m = _getModal();
+      if (!m) return [];
+      // Standard-Focusable + Buttons
+      var selector = 'a[href], button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])';
+      return Array.prototype.slice.call(m.querySelectorAll(selector));
+    }
+
+    function _trapFocus(e) {
+      if (e.key !== 'Tab') return;
+      var focusables = _focusableInModal().filter(function(el) {
+        return el.offsetParent !== null; // sichtbar
+      });
+      if (focusables.length === 0) {
+        e.preventDefault();
+        return;
+      }
+      var first = focusables[0];
+      var last = focusables[focusables.length - 1];
+      var active = document.activeElement;
+      if (e.shiftKey) {
+        if (active === first || !_getModal().contains(active)) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (active === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    }
+
+    function _onKeydown(e) {
+      if (e.key === 'Escape' || e.keyCode === 27) {
+        e.preventDefault();
+        closeResetModal();
+        return;
+      }
+      _trapFocus(e);
+    }
+
+    function _disarmFullReset() {
+      _fullResetArmed = false;
+      var btn = document.getElementById('reset_modal_confirm_all');
+      if (!btn) return;
+      btn.classList.remove('armed');
+      btn.textContent = 'Alle Daten löschen';
+    }
+
+    function _onResetTab() {
+      closeResetModal();
+      if (typeof resetActiveTab === 'function') resetActiveTab();
+    }
+
+    function _onResetAll() {
+      if (!_fullResetArmed) {
+        // Erste Stufe: bestätigen verlangen (sichtbare Warnung).
+        _fullResetArmed = true;
+        var btn = document.getElementById('reset_modal_confirm_all');
+        if (btn) {
+          btn.classList.add('armed');
+          btn.textContent = 'Tippen zum Bestätigen: Alle Daten löschen';
+          btn.focus();
+        }
+        return;
+      }
+      // Zweite Stufe: ausführen.
+      closeResetModal();
+      if (typeof resetAll === 'function') resetAll();
+    }
+
+    function _onOverlayClick(e) {
+      // Overlay-Klick = Abbrechen (sofort schließen, ohne Aktion)
+      if (e.target === _getOverlay()) closeResetModal();
+    }
+
+    function _onCancel() {
+      closeResetModal();
+    }
+
+    function openResetModal(triggerEl) {
+      var modal = _getModal();
+      var overlay = _getOverlay();
+      if (!modal || !overlay) return;
+
+      _modalLastTrigger = triggerEl || document.getElementById('reset_btn') || null;
+      _disarmFullReset();
+
+      overlay.classList.add('open');
+      modal.classList.add('open');
+
+      // Fokus auf den ungefährlichsten Action-Button (Abbrechen),
+      // damit versehentliches Enter nicht Daten löscht.
+      var cancel = document.getElementById('reset_modal_cancel');
+      if (cancel) cancel.focus();
+
+      document.addEventListener('keydown', _onKeydown);
+    }
+
+    function closeResetModal() {
+      var modal = _getModal();
+      var overlay = _getOverlay();
+      if (modal) modal.classList.remove('open');
+      if (overlay) overlay.classList.remove('open');
+      _disarmFullReset();
+      document.removeEventListener('keydown', _onKeydown);
+      // Fokus zurück zum Trigger (A11y)
+      if (_modalLastTrigger && typeof _modalLastTrigger.focus === 'function') {
+        _modalLastTrigger.focus();
+      }
+      _modalLastTrigger = null;
+    }

--- a/public/js/ui-handlers.js
+++ b/public/js/ui-handlers.js
@@ -175,18 +175,31 @@
       saveState();
     }
 
-    // confirmResetAll(fullReset) — Bestätigungsdialog, ruft resetActiveTab() oder resetAll()
-    // fullReset=false → nur aktuellen Tab zurücksetzen
-    // fullReset=true  → ALLE Daten zurücksetzen (alle Tabs, Einstellungen, machineLog)
-    // Portiert aus Inline-Code Z. 3266-3276 (vor Phase 5 Inline-Entfernung).
+    // openResetModal() — öffnet das Reset-Confirmation-Modal (Issue #236).
+    // Die Auswahl (Tab zurücksetzen / Alle Daten löschen / Abbrechen) und die
+    // ggf. nötige Zwei-Stufen-Bestätigung lebt in js/reset-modal.js.
+    // Ersetzt die alte `confirm()`-basierte Variante, die im Footer zwei
+    // Buttons brauchte und Verwechslungsgefahr beim Klick erzeugte.
+    // Hinweis: Der `fullReset`-Parameter bleibt rückwärtskompatibel erhalten,
+    // wird aber ignoriert — die Auswahl trifft der User im Modal.
     function confirmResetAll(fullReset) {
-      var tabName = state.reiter[state.activeReiter].name;
-      if (fullReset) {
-        if (!confirm('Wirklich ALLE Daten zurücksetzen?\n\nAlle Tabs, Einträge und Einstellungen werden gelöscht.')) return;
-        resetAll();
+      // Argument ist absichtlich unbenutzt (Rückwärtskompatibilität für
+      // inline onclick="confirmResetAll(true)"-Aufrufer in älteren Templates).
+      void fullReset;
+      if (typeof openResetModal === 'function') {
+        openResetModal();
+      } else if (typeof window.openResetModal === 'function') {
+        window.openResetModal();
       } else {
-        if (!confirm('Wirklich zurücksetzen?\n\nAlle Eingaben für "' + tabName + '" werden gelöscht.')) return;
-        resetActiveTab();
+        // Fallback, falls reset-modal.js nicht geladen ist: kein nativer
+        // confirm()-Dialog mehr (Issue #236) — direkter Reset mit Minimal-
+        // Sicherheit. resetAll() wird nur bei explizitem fullReset=true
+        // ausgeführt; sonst Tab-Reset.
+        if (fullReset === true) {
+          if (typeof resetAll === 'function') resetAll();
+        } else {
+          if (typeof resetActiveTab === 'function') resetActiveTab();
+        }
       }
     }
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // ⚠️ CACHE_VERSION muss bei jedem Release manuell gebumpet werden!
 // Bei Vergessen bekommen Nutzer die alte Version aus dem Cache.
 // alternativa: Build-Script das Hash/Zeitstempel injiziert.
-const CACHE_VERSION = 'agrar-rechner-v14';
+const CACHE_VERSION = 'agrar-rechner-v15';
 const STATIC_ASSETS = [
     '/',
     '/index.html',
@@ -13,6 +13,7 @@ const STATIC_ASSETS = [
     '/js/render-results.js',
     '/js/render-drill.js',
     '/js/render-dashboard.js',
+    '/js/reset-modal.js',
     '/js/main.js',
     '/icon.svg',
     '/manifest.json',

--- a/tests/17-edge-cases.test.js
+++ b/tests/17-edge-cases.test.js
@@ -172,62 +172,61 @@ describe('lv() migration edge cases', () => {
 });
 
 describe('confirmResetAll', () => {
-  let w;
-  beforeEach(() => { w = createDom().window; });
-
-  it('calls resetActiveTab when confirmed (partial reset)', () => {
-    // Mock confirm to return true
-    var originalConfirm = w.confirm;
-    w.confirm = () => true;
-
-    w.state.reiter[0] = { ...w.state.reiter[0], hektar: 10, koerner: 90000 };
-    w.confirmResetAll();
-
-    expect(w.state.reiter[0].hektar).toBe(0);
-    expect(w.state.reiter[0].koerner).toBe(0);
-
-    w.confirm = originalConfirm;
+  let w, doc;
+  beforeEach(() => {
+    const result = createDom();
+    w = result.window;
+    doc = w.document;
   });
 
-  it('calls resetAll when fullReset=true', () => {
-    var originalConfirm = w.confirm;
-    w.confirm = () => true;
+  it('opens the reset modal (back-compat shim, no native confirm)', () => {
+    var called = false;
+    var orig = w.confirm;
+    w.confirm = () => { called = true; return true; };
 
+    w.confirmResetAll();
+    expect(doc.getElementById('reset_modal').classList.contains('open')).toBe(true);
+    expect(called).toBe(false);
+
+    w.confirm = orig;
+  });
+
+  it('clicking "Aktuellen Tab zurücksetzen" in modal resets active tab', () => {
+    w.state.reiter[0] = { ...w.state.reiter[0], hektar: 10, koerner: 90000 };
+    w.openResetModal();
+    doc.getElementById('reset_modal_tab').click();
+    expect(w.state.reiter[0].hektar).toBe(0);
+    expect(w.state.reiter[0].koerner).toBe(0);
+  });
+
+  it('clicking "Alle Daten löschen" twice resets all tabs and machineLog', () => {
     w.addReiter();
     w.state.reiter[0] = { ...w.state.reiter[0], hektar: 10, koerner: 90000 };
     w.state.reiter[1] = { ...w.state.reiter[1], hektar: 5, koerner: 45000 };
     w.state.machineLog = [{ einheit: 5, hektar: 3, duenger: 100, time: '10:00' }];
-    w.confirmResetAll(true);  // full reset
-
-    expect(w.state.reiter.length).toBe(1);  // all tabs cleared
-    expect(w.state.machineLog).toEqual([]);   // machineLog cleared
-
-    w.confirm = originalConfirm;
+    w.openResetModal();
+    var btn = doc.getElementById('reset_modal_confirm_all');
+    btn.click(); // arm
+    btn.click(); // confirm
+    expect(w.state.reiter.length).toBe(1);
+    expect(w.state.machineLog).toEqual([]);
   });
 
-  it('does nothing when cancelled', () => {
-    var originalConfirm = w.confirm;
-    w.confirm = () => false;
-
+  it('clicking "Abbrechen" in modal does not modify state', () => {
     w.state.reiter[0] = { ...w.state.reiter[0], hektar: 10, koerner: 90000 };
-    w.confirmResetAll();
-
+    w.openResetModal();
+    doc.getElementById('reset_modal_cancel').click();
     expect(w.state.reiter[0].hektar).toBe(10);
-
-    w.confirm = originalConfirm;
   });
 
-  it('includes tab name in confirm message', () => {
-    var lastMsg = '';
-    var originalConfirm = w.confirm;
-    w.confirm = (msg) => { lastMsg = msg; return false; };
-
-    w.state.reiter[0].name = 'Feld A';
-    w.confirmResetAll();
-
-    expect(lastMsg).toContain('Feld A');
-
-    w.confirm = originalConfirm;
+  it('does not call native window.confirm()', () => {
+    var called = false;
+    var orig = w.confirm;
+    w.confirm = () => { called = true; return true; };
+    w.openResetModal();
+    doc.getElementById('reset_modal_tab').click();
+    expect(called).toBe(false);
+    w.confirm = orig;
   });
 });
 

--- a/tests/18-blind-spots-2.test.js
+++ b/tests/18-blind-spots-2.test.js
@@ -436,56 +436,62 @@ describe('switchToProtokoll()', () => {
 });
 
 // ---------------------------------------------------------------------------
-// confirmResetAll(fullReset)
+// confirmResetAll(fullReset) — Issue #236: opens the reset modal instead
+// of native confirm() dialogs.
 // ---------------------------------------------------------------------------
 describe('confirmResetAll(fullReset)', () => {
-  let w;
+  let w, doc;
 
   beforeEach(() => {
-    const { window } = createDom();
+    const { window, document: d } = createDom();
     w = window;
+    doc = d || w.document;
   });
 
-  it('confirms with fullReset=true (prompts ALL Daten)', () => {
-    let lastMsg = '';
-    w.confirm = (msg) => { lastMsg = msg; return false; };
+  it('opens the modal (no native confirm dialog) — fullReset=true', () => {
+    let called = false;
+    w.confirm = () => { called = true; return false; };
     w.confirmResetAll(true);
-    expect(lastMsg).toContain('ALLE Daten');
+    expect(doc.getElementById('reset_modal').classList.contains('open')).toBe(true);
+    expect(called).toBe(false);
   });
 
-  it('confirms with fullReset=false (prompts single tab)', () => {
-    let lastMsg = '';
-    w.confirm = (msg) => { lastMsg = msg; return false; };
+  it('opens the modal (no native confirm dialog) — fullReset=false', () => {
+    let called = false;
+    w.confirm = () => { called = true; return false; };
     w.confirmResetAll(false);
-    expect(lastMsg).not.toContain('ALLE Daten');
+    expect(doc.getElementById('reset_modal').classList.contains('open')).toBe(true);
+    expect(called).toBe(false);
   });
 
-  it('resets all tabs when fullReset=true and confirmed', () => {
-    w.confirm = () => true;
+  it('resets all tabs when fullReset and "Alle Daten löschen" is double-clicked', () => {
     w.addReiter();
     w.state.reiter[0].hektar = 10;
     w.state.reiter[1].hektar = 20;
-    w.confirmResetAll(true);
+    w.openResetModal();
+    var btn = doc.getElementById('reset_modal_confirm_all');
+    btn.click(); // arm
+    btn.click(); // confirm
     expect(w.state.reiter.length).toBe(1);
     expect(w.state.reiter[0].hektar).toBe(0);
   });
 
-  it('resets only active tab when fullReset=false and confirmed', () => {
-    w.confirm = () => true;
+  it('resets only active tab when "Aktuellen Tab zurücksetzen" is clicked', () => {
     w.addReiter();
     w.state.reiter[0].hektar = 10;
     w.state.reiter[1].hektar = 20;
     w.state.activeReiter = 1;
-    w.confirmResetAll(false);
+    w.openResetModal();
+    doc.getElementById('reset_modal_tab').click();
     expect(w.state.reiter.length).toBe(2);
     expect(w.state.reiter[0].hektar).toBe(10);
     expect(w.state.reiter[1].hektar).toBe(0);
   });
 
-  it('does nothing when cancelled', () => {
-    w.confirm = () => false;
+  it('does nothing when modal is cancelled (Abbrechen button)', () => {
     w.state.reiter[0].hektar = 99;
-    w.confirmResetAll(true);
+    w.openResetModal();
+    doc.getElementById('reset_modal_cancel').click();
     expect(w.state.reiter[0].hektar).toBe(99);
   });
 });
@@ -518,12 +524,6 @@ describe('renderView()', () => {
     w.state.activeView = 'protokoll';
     w.renderView();
     expect(doc.getElementById('reset_btn').style.display).toBe('none');
-  });
-
-  it('reset_all_btn hidden in protokoll view', () => {
-    w.state.activeView = 'protokoll';
-    w.renderView();
-    expect(doc.getElementById('reset_all_btn').style.display).toBe('none');
   });
 
   it('drill_section shown in protokoll view', () => {

--- a/tests/22-protocol-view.test.js
+++ b/tests/22-protocol-view.test.js
@@ -147,7 +147,6 @@ describe('renderView', () => {
 
     expect(w.document.getElementById('berechnen_btn').style.display).toBe('none');
     expect(w.document.getElementById('reset_btn').style.display).toBe('none');
-    expect(w.document.getElementById('reset_all_btn').style.display).toBe('none');
   });
 
   it('hides sticky footer in protokoll mode', () => {

--- a/tests/45-reset-modal.test.js
+++ b/tests/45-reset-modal.test.js
@@ -1,0 +1,228 @@
+/**
+ * Tests for the Reset Confirmation Modal (Issue #236).
+ *
+ * Verifies:
+ *   - Only one reset button in the footer (reset_btn exists, reset_all_btn gone)
+ *   - openResetModal() shows the modal and focuses the cancel button
+ *   - closeResetModal() hides it and returns focus to the trigger
+ *   - "Aktuellen Tab zurücksetzen" calls resetActiveTab()
+ *   - "Alle Daten löschen" requires two clicks (arming) before calling resetAll()
+ *   - Abbrechen button + ESC + overlay click close the modal without side-effects
+ *   - No window.confirm() in the codebase
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createDom } from './helpers.js';
+
+describe('Reset Confirmation Modal (#236)', () => {
+  let w, doc;
+
+  beforeEach(() => {
+    const { window } = createDom();
+    w = window;
+    doc = w.document;
+  });
+
+  it('footer has only one reset button (reset_all_btn removed)', () => {
+    expect(doc.getElementById('reset_btn')).toBeTruthy();
+    expect(doc.getElementById('reset_all_btn')).toBeNull();
+  });
+
+  it('modal markup is in the DOM and hidden by default', () => {
+    var modal = doc.getElementById('reset_modal');
+    var overlay = doc.getElementById('reset_overlay');
+    expect(modal).toBeTruthy();
+    expect(overlay).toBeTruthy();
+    expect(modal.classList.contains('open')).toBe(false);
+    expect(overlay.classList.contains('open')).toBe(false);
+    expect(modal.getAttribute('role')).toBe('dialog');
+    expect(modal.getAttribute('aria-modal')).toBe('true');
+    expect(modal.getAttribute('aria-labelledby')).toBe('reset_modal_title');
+  });
+
+  it('modal exposes the three required action buttons', () => {
+    expect(doc.getElementById('reset_modal_tab')).toBeTruthy();
+    expect(doc.getElementById('reset_modal_confirm_all')).toBeTruthy();
+    expect(doc.getElementById('reset_modal_cancel')).toBeTruthy();
+  });
+
+  it('openResetModal() shows the modal and overlay', () => {
+    w.openResetModal();
+    expect(doc.getElementById('reset_modal').classList.contains('open')).toBe(true);
+    expect(doc.getElementById('reset_overlay').classList.contains('open')).toBe(true);
+  });
+
+  it('openResetModal() focuses the cancel button (safe default)', () => {
+    w.openResetModal();
+    expect(doc.activeElement.id).toBe('reset_modal_cancel');
+  });
+
+  it('openResetModal() can be passed a trigger element for focus return', () => {
+    w.openResetModal(doc.getElementById('reset_btn'));
+    expect(doc.getElementById('reset_modal').classList.contains('open')).toBe(true);
+  });
+
+  it('closeResetModal() hides the modal and overlay', () => {
+    w.openResetModal();
+    w.closeResetModal();
+    expect(doc.getElementById('reset_modal').classList.contains('open')).toBe(false);
+    expect(doc.getElementById('reset_overlay').classList.contains('open')).toBe(false);
+  });
+
+  it('closeResetModal() returns focus to the trigger', () => {
+    var trigger = doc.getElementById('reset_btn');
+    w.openResetModal(trigger);
+    // After open, focus is on cancel
+    expect(doc.activeElement.id).toBe('reset_modal_cancel');
+    w.closeResetModal();
+    expect(doc.activeElement).toBe(trigger);
+  });
+
+  it('clicking "Aktuellen Tab zurücksetzen" calls resetActiveTab() once', () => {
+    // Seed some data into the active tab
+    w.state.reiter[0].hektar = 5;
+    w.state.reiter[0].koerner = 90000;
+    w.state.reiter[0].entries = [{ einheit: 1, duenger: 0, zaehlerStand: 0, time: 'now' }];
+    expect(w.state.reiter[0].hektar).toBe(5);
+
+    w.openResetModal();
+    // Simulate click on the modal "Aktuellen Tab zurücksetzen" button
+    doc.getElementById('reset_modal_tab').click();
+    // The handler closes the modal then calls resetActiveTab
+    expect(doc.getElementById('reset_modal').classList.contains('open')).toBe(false);
+    expect(w.state.reiter[0].hektar).toBe(0);
+    expect(w.state.reiter[0].entries.length).toBe(0);
+  });
+
+  it('"Alle Daten löschen" requires two clicks (arming step)', () => {
+    // Seed data
+    doc.getElementById('hektar').value = '5';
+    doc.getElementById('koerner').value = '90000';
+    w.berechne();
+    w.addReiter();
+    expect(w.state.reiter.length).toBe(2);
+
+    w.openResetModal();
+    var btn = doc.getElementById('reset_modal_confirm_all');
+
+    // First click: arm, do NOT reset yet
+    btn.click();
+    expect(btn.classList.contains('armed')).toBe(true);
+    expect(w.state.reiter.length).toBe(2); // not reset yet
+    expect(btn.textContent).toMatch(/Bestätigen/);
+
+    // Second click: actually reset
+    btn.click();
+    expect(w.state.reiter.length).toBe(1); // resetAll was called
+    expect(doc.getElementById('reset_modal').classList.contains('open')).toBe(false);
+  });
+
+  it('"Abbrechen" closes the modal without calling reset functions', () => {
+    doc.getElementById('hektar').value = '5';
+    doc.getElementById('koerner').value = '90000';
+    w.berechne();
+    w.addReiter();
+    expect(w.state.reiter.length).toBe(2);
+
+    w.openResetModal();
+    doc.getElementById('reset_modal_cancel').click();
+    expect(doc.getElementById('reset_modal').classList.contains('open')).toBe(false);
+    expect(w.state.reiter.length).toBe(2);
+  });
+
+  it('closing the modal disarms the full-reset button for next time', () => {
+    w.openResetModal();
+    var btn = doc.getElementById('reset_modal_confirm_all');
+    btn.click(); // arm
+    expect(btn.classList.contains('armed')).toBe(true);
+    w.closeResetModal();
+    expect(btn.classList.contains('armed')).toBe(false);
+    expect(btn.textContent).toBe('Alle Daten löschen');
+  });
+
+  it('ESC keydown closes the modal', () => {
+    w.openResetModal();
+    expect(doc.getElementById('reset_modal').classList.contains('open')).toBe(true);
+    var evt = new w.KeyboardEvent('keydown', { key: 'Escape', bubbles: true });
+    doc.dispatchEvent(evt);
+    expect(doc.getElementById('reset_modal').classList.contains('open')).toBe(false);
+  });
+
+  it('confirmResetAll() opens the modal (back-compat shim)', () => {
+    w.confirmResetAll();
+    expect(doc.getElementById('reset_modal').classList.contains('open')).toBe(true);
+  });
+
+  it('confirmResetAll(true) also opens the modal (parameter ignored)', () => {
+    w.confirmResetAll(true);
+    expect(doc.getElementById('reset_modal').classList.contains('open')).toBe(true);
+  });
+
+  it('no confirm() call anywhere in app JS', () => {
+    // Walk the module sources from the dom window (we already loaded them).
+    // We can't reach the file content from the runtime, but we can verify
+    // that confirm() is never invoked in our test interactions.
+    // This is a smoke test — the real check is the source-level grep in CI.
+    var called = false;
+    var origConfirm = w.confirm;
+    w.confirm = function() { called = true; return true; };
+    // Trigger each reset path
+    w.openResetModal();
+    doc.getElementById('reset_modal_tab').click();
+    w.openResetModal();
+    doc.getElementById('reset_modal_confirm_all').click();
+    doc.getElementById('reset_modal_confirm_all').click();
+    w.confirm = origConfirm;
+    expect(called).toBe(false);
+  });
+});
+
+describe('Reset modal — source-level invariants', () => {
+  it('does not call window.confirm() in reset-modal.js (comments ok)', async () => {
+    const { readFileSync } = await import('fs');
+    const { resolve, dirname } = await import('path');
+    const { fileURLToPath } = await import('url');
+    const __dirname = dirname(fileURLToPath(import.meta.url));
+    const src = readFileSync(resolve(__dirname, '../public/js/reset-modal.js'), 'utf-8');
+    // Strip line comments first, then check for confirm( call sites.
+    var code = src
+      .split('\n')
+      .map(function(line) { return line.replace(/\/\/.*$/, ''); })
+      .join('\n');
+    expect(code).not.toMatch(/[^a-zA-Z_]confirm\s*\(/);
+  });
+
+  it('does not call window.confirm() in ui-handlers.js (comments ok)', async () => {
+    const { readFileSync } = await import('fs');
+    const { resolve, dirname } = await import('path');
+    const { fileURLToPath } = await import('url');
+    const __dirname = dirname(fileURLToPath(import.meta.url));
+    const src = readFileSync(resolve(__dirname, '../public/js/ui-handlers.js'), 'utf-8');
+    var code = src
+      .split('\n')
+      .map(function(line) { return line.replace(/\/\/.*$/, ''); })
+      .join('\n');
+    expect(code).not.toMatch(/[^a-zA-Z_]confirm\s*\(/);
+  });
+
+  it('index.html loads reset-modal.js script', async () => {
+    const { readFileSync } = await import('fs');
+    const { resolve, dirname } = await import('path');
+    const { fileURLToPath } = await import('url');
+    const __dirname = dirname(fileURLToPath(import.meta.url));
+    const html = readFileSync(resolve(__dirname, '../public/index.html'), 'utf-8');
+    expect(html).toMatch(/src="js\/reset-modal\.js"/);
+  });
+
+  it('footer in index.html has only one reset button', async () => {
+    const { readFileSync } = await import('fs');
+    const { resolve, dirname } = await import('path');
+    const { fileURLToPath } = await import('url');
+    const __dirname = dirname(fileURLToPath(import.meta.url));
+    const html = readFileSync(resolve(__dirname, '../public/index.html'), 'utf-8');
+    // The old "Alles zurücksetzen" button is gone
+    expect(html).not.toMatch(/id="reset_all_btn"/);
+    // And only one reset_btn remains
+    var matches = html.match(/id="reset_btn"/g) || [];
+    expect(matches.length).toBe(1);
+  });
+});

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -79,6 +79,7 @@ export function createDom() {
     loadModule('render-results.js'),
     loadModule('render-drill.js'),
     loadModule('render-dashboard.js'),
+    loadModule('reset-modal.js'),
     // Remove DOMContentLoaded from main.js (auto-init doesn't work in jsdom)
     loadModule('main.js').replace(
       "document.addEventListener('DOMContentLoaded', initUI);",


### PR DESCRIPTION
## Fix #236 — Reset-Buttons vereinfachen

UX-Problem: Der Sticky Footer hatte zwei Reset-Buttons nebeneinander, was zu Verwechslungsgefahr und versehentlichem Datenverlust führte.

### Lösung
- **Footer:** nur noch ein "Zurücksetzen"-Button
- **Klick öffnet ein eigenes Modal** (kein `window.confirm()` mehr) mit:
  1. "Aktuellen Tab zurücksetzen" (normal)
  2. "Alle Daten löschen" (rot, Zwei-Stufen-Bestätigung gegen versehentliches Klicken)
  3. "Abbrechen"

### Anforderungen erfüllt
- ✅ Kein `confirm()`-Aufruf mehr im Codebase
- ✅ Visuell destruktiv markiert (rot, Pulse-Animation beim Armed-State)
- ✅ A11y: `role="dialog"`, `aria-modal`, `aria-labelledby`, ESC schließt, Tab/Shift+Tab Focus-Trap, Fokus-Rückgabe auf Trigger
- ✅ Bestehende Funktionalität (Tab-Reset, Full-Reset) bleibt erhalten
- ✅ Mobile-first: Bottom-Sheet auf <600px, kompakt im Footer sonst
- ✅ Keine neuen Runtime-Dependencies (reines Vanilla JS/CSS)

### Geänderte Dateien
- `public/js/reset-modal.js` (neu) — openResetModal/closeResetModal + Trigger
- `public/js/ui-handlers.js` — `confirmResetAll()` öffnet jetzt das Modal
- `public/js/render-tabs.js` — Totcode für `reset_all_btn` entfernt
- `public/index.html` — 1 Footer-Button, Modal-Markup, neues Script-Tag
- `public/css/styles.css` — Modal-Styling (mobile-first, destructive pulse)
- `public/sw.js` — CACHE_VERSION v14→v15, reset-modal.js zu STATIC_ASSETS

### Tests
- `tests/45-reset-modal.test.js` (neu) — 20 Tests für Modal-Flow, alle grün
- `tests/17-edge-cases.test.js`, `tests/18-blind-spots-2.test.js`, `tests/22-protocol-view.test.js` — an neue Modal-API angepasst
- `tests/helpers.js` — reset-modal.js laden

### Verifikation
- `pnpm test` — 20/20 neue Tests grün, 579/788 bestehende Tests grün (209 pre-existing failures, identisch zum Baseline, keine Regression)
- `pnpm lint` — clean
- Branch gepusht: `origin/fix/236-reset-modal` @ `66d3fe1`