### PR TITLE
fix(#250, #251): Dashboard z-index + Prio-Input Breite

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -656,7 +656,9 @@ font-size: 0.75rem;
       color: var(--color-text-muted);
     }
     .drill-tab-row .drill-tab-values input {
-      width: 55px;
+      width: 90px;
+      max-width: 22vw;
+      min-width: 70px;
       padding: 4px 6px;
       border: 1px solid var(--color-border-disabled);
       border-radius: 4px;
@@ -958,7 +960,7 @@ font-size: 0.75rem;
       position: fixed;
       inset: 0;
       background: rgba(0,0,0,0.4);
-      z-index: 100;
+      z-index: 150;
     }
     .dashboard-overlay.open {
       display: block;
@@ -973,7 +975,7 @@ font-size: 0.75rem;
       border-radius: 20px 20px 0 0;
       max-height: 80vh;
       overflow-y: auto;
-      z-index: 101;
+      z-index: 151;
       padding: 0 0 max(20px, env(safe-area-inset-bottom));
     }
     .dashboard-sheet.open {

--- a/public/js/render-drill.js
+++ b/public/js/render-drill.js
@@ -75,7 +75,6 @@
         einheitIn.inputMode = 'decimal';
         einheitIn.id = 'dtl_e_' + i;
         einheitIn.placeholder = 'Einheiten';
-        einheitIn.style.width = '70px';
         einheitIn.dataset.tabIdx = String(i);
         einheitIn.oninput = function() {
           drillCalcDebounced();
@@ -86,7 +85,6 @@
         duengerIn.inputMode = 'decimal';
         duengerIn.id = 'dtl_d_' + i;
         duengerIn.placeholder = 'kg Dünger';
-        duengerIn.style.width = '70px';
         duengerIn.dataset.tabIdx = String(i);
         duengerIn.oninput = function() {
           drillCalcDebounced();


### PR DESCRIPTION
## Summary

Zwei kleine CSS/JS-Fixes aus dem Council-Review, beide in einem PR.

## Fix 1 — Issue #250 (P1): Dashboard-z-index

Die `#drill_section` lag visuell über dem Dashboard-Sheet, weil der z-index mit 100/101 in der gleichen Region wie andere Stacking-Contexts lag. Bumped auf 150/151, sodass die Hierarchie jetzt klar ist:

- `.dashboard-overlay` z-index: 100 → 150
- `.dashboard-sheet` z-index: 101 → 151
- Reset-Modal (200/201) bleibt darüber — Hierarchie intakt

## Fix 2 — Issue #251 (P2): Prio-Input Breite

Placeholder "Einheiten" und "kg Dünger" wurden in den Drill-Tab-Inputs abgeschnitten, weil die Inputs nur 55px breit waren und zusätzlich von einem Inline-`style.width = '70px'` überschrieben wurden. Uncle-Bob-Recycling: CSS-Regel + Inline-Style kämpften gegeneinander.

**`public/css/styles.css`:**
```css
.drill-tab-row .drill-tab-values input {
  width: 90px;     /* vorher 55px */
  max-width: 22vw; /* mobile cap */
  min-width: 70px;
  ...
}
```

**`public/js/render-drill.js`:** Zwei `style.width = '70px'` Inline-Styles entfernt (Anti-Pattern).

## Verify

- [x] `pnpm lint` grün
- [x] `pnpm test` — 209 failed / 579 passed (identisch mit dev-Baseline, keine Regressionen durch diesen Change; die Failures sind pre-existing)
- [x] Diff exakt wie beschrieben: `+5 / -5` über 2 Dateien
- [x] Branch: `fix/250-251-dashboard-zindex-prio-width`
- [x] Commit: `2c6fc6b`
- [x] Push verifiziert via `git ls-remote --heads origin fix/250-251-dashboard-zindex-prio-width`

## Test Plan

- [ ] Dev-URL nach Merge: Dashboard öffnen, Tab-2-Karte nicht mehr vom Sheet verdeckt
- [ ] Prio-Input Placeholder "Einheiten" und "kg Dünger" vollständig sichtbar (Desktop + Mobile)
- [ ] Reset-Modal öffnet weiterhin über dem Dashboard

Closes #250
Closes #251
