### PR TITLE
refactor(#252): remove dead confirmResetAll shim

### DIFF
--- a/public/js/ui-handlers.js
+++ b/public/js/ui-handlers.js
@@ -175,34 +175,6 @@
       saveState();
     }
 
-    // openResetModal() — öffnet das Reset-Confirmation-Modal (Issue #236).
-    // Die Auswahl (Tab zurücksetzen / Alle Daten löschen / Abbrechen) und die
-    // ggf. nötige Zwei-Stufen-Bestätigung lebt in js/reset-modal.js.
-    // Ersetzt die alte `confirm()`-basierte Variante, die im Footer zwei
-    // Buttons brauchte und Verwechslungsgefahr beim Klick erzeugte.
-    // Hinweis: Der `fullReset`-Parameter bleibt rückwärtskompatibel erhalten,
-    // wird aber ignoriert — die Auswahl trifft der User im Modal.
-    function confirmResetAll(fullReset) {
-      // Argument ist absichtlich unbenutzt (Rückwärtskompatibilität für
-      // inline onclick="confirmResetAll(true)"-Aufrufer in älteren Templates).
-      void fullReset;
-      if (typeof openResetModal === 'function') {
-        openResetModal();
-      } else if (typeof window.openResetModal === 'function') {
-        window.openResetModal();
-      } else {
-        // Fallback, falls reset-modal.js nicht geladen ist: kein nativer
-        // confirm()-Dialog mehr (Issue #236) — direkter Reset mit Minimal-
-        // Sicherheit. resetAll() wird nur bei explizitem fullReset=true
-        // ausgeführt; sonst Tab-Reset.
-        if (fullReset === true) {
-          if (typeof resetAll === 'function') resetAll();
-        } else {
-          if (typeof resetActiveTab === 'function') resetActiveTab();
-        }
-      }
-    }
-
     // --- Drill Protocol ---
 
     function drillAdd() {

--- a/tests/17-edge-cases.test.js
+++ b/tests/17-edge-cases.test.js
@@ -5,7 +5,7 @@
  * - getTabKornerGesamt / getTabTotalDuenger with various inputs
  * - getTabTotalEinheiten with fahrgassen
  * - lv() migration edge cases
- * - confirmResetAll / confirmRemoveReiter (confirm mock)
+ * - confirmRemoveReiter (confirm mock)
  * - resetAll clears machineLog
  */
 import { describe, it, expect, beforeEach } from 'vitest';
@@ -171,24 +171,12 @@ describe('lv() migration edge cases', () => {
   });
 });
 
-describe('confirmResetAll', () => {
+describe('openResetModal', () => {
   let w, doc;
   beforeEach(() => {
     const result = createDom();
     w = result.window;
     doc = w.document;
-  });
-
-  it('opens the reset modal (back-compat shim, no native confirm)', () => {
-    var called = false;
-    var orig = w.confirm;
-    w.confirm = () => { called = true; return true; };
-
-    w.confirmResetAll();
-    expect(doc.getElementById('reset_modal').classList.contains('open')).toBe(true);
-    expect(called).toBe(false);
-
-    w.confirm = orig;
   });
 
   it('clicking "Aktuellen Tab zurücksetzen" in modal resets active tab', () => {

--- a/tests/18-blind-spots-2.test.js
+++ b/tests/18-blind-spots-2.test.js
@@ -1,7 +1,7 @@
 /**
  * Blind spots round 2 — untested code paths verified against current codebase.
  * Functions tested: drillCalcAll, renderDrillTabList, drillMachineRemove,
- * switchToProtokoll, confirmResetAll, renderView, renderTabs,
+ * switchToProtokoll, renderView, renderTabs,
  * getStoredTheme, setStoredTheme, applyTheme, toggleTheme, initTheme
  */
 import { describe, it, expect, beforeEach } from 'vitest';
@@ -432,67 +432,6 @@ describe('switchToProtokoll()', () => {
     w.syncStateFromInputs();
     w.switchToProtokoll();
     expect(w.state.reiter[0].hektar).toBe(15);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// confirmResetAll(fullReset) — Issue #236: opens the reset modal instead
-// of native confirm() dialogs.
-// ---------------------------------------------------------------------------
-describe('confirmResetAll(fullReset)', () => {
-  let w, doc;
-
-  beforeEach(() => {
-    const { window, document: d } = createDom();
-    w = window;
-    doc = d || w.document;
-  });
-
-  it('opens the modal (no native confirm dialog) — fullReset=true', () => {
-    let called = false;
-    w.confirm = () => { called = true; return false; };
-    w.confirmResetAll(true);
-    expect(doc.getElementById('reset_modal').classList.contains('open')).toBe(true);
-    expect(called).toBe(false);
-  });
-
-  it('opens the modal (no native confirm dialog) — fullReset=false', () => {
-    let called = false;
-    w.confirm = () => { called = true; return false; };
-    w.confirmResetAll(false);
-    expect(doc.getElementById('reset_modal').classList.contains('open')).toBe(true);
-    expect(called).toBe(false);
-  });
-
-  it('resets all tabs when fullReset and "Alle Daten löschen" is double-clicked', () => {
-    w.addReiter();
-    w.state.reiter[0].hektar = 10;
-    w.state.reiter[1].hektar = 20;
-    w.openResetModal();
-    var btn = doc.getElementById('reset_modal_confirm_all');
-    btn.click(); // arm
-    btn.click(); // confirm
-    expect(w.state.reiter.length).toBe(1);
-    expect(w.state.reiter[0].hektar).toBe(0);
-  });
-
-  it('resets only active tab when "Aktuellen Tab zurücksetzen" is clicked', () => {
-    w.addReiter();
-    w.state.reiter[0].hektar = 10;
-    w.state.reiter[1].hektar = 20;
-    w.state.activeReiter = 1;
-    w.openResetModal();
-    doc.getElementById('reset_modal_tab').click();
-    expect(w.state.reiter.length).toBe(2);
-    expect(w.state.reiter[0].hektar).toBe(10);
-    expect(w.state.reiter[1].hektar).toBe(0);
-  });
-
-  it('does nothing when modal is cancelled (Abbrechen button)', () => {
-    w.state.reiter[0].hektar = 99;
-    w.openResetModal();
-    doc.getElementById('reset_modal_cancel').click();
-    expect(w.state.reiter[0].hektar).toBe(99);
   });
 });
 

--- a/tests/45-reset-modal.test.js
+++ b/tests/45-reset-modal.test.js
@@ -147,16 +147,6 @@ describe('Reset Confirmation Modal (#236)', () => {
     expect(doc.getElementById('reset_modal').classList.contains('open')).toBe(false);
   });
 
-  it('confirmResetAll() opens the modal (back-compat shim)', () => {
-    w.confirmResetAll();
-    expect(doc.getElementById('reset_modal').classList.contains('open')).toBe(true);
-  });
-
-  it('confirmResetAll(true) also opens the modal (parameter ignored)', () => {
-    w.confirmResetAll(true);
-    expect(doc.getElementById('reset_modal').classList.contains('open')).toBe(true);
-  });
-
   it('no confirm() call anywhere in app JS', () => {
     // Walk the module sources from the dom window (we already loaded them).
     // We can't reach the file content from the runtime, but we can verify


### PR DESCRIPTION
## Summary
Removes the dead `confirmResetAll()` backcompat shim from `public/js/ui-handlers.js` that was kept around to support inline `onclick="confirmResetAll(true)"` callers from before Issue #236 introduced the reset modal.

## Why
- No caller exists anymore (footer button uses `openResetModal(this)` directly per #236)
- The function's fallback path (when `openResetModal` is undefined) would call `resetAll()` / `resetActiveTab()` directly — a real safety smell
- Tests for the shim are now pure overhead

## Changes
- **public/js/ui-handlers.js**: delete `confirmResetAll(fullReset)` (27 lines incl. comment block)
- **tests/45-reset-modal.test.js**: remove 2 shim tests
- **tests/18-blind-spots-2.test.js**: remove 5-test `describe('confirmResetAll')` block + update header
- **tests/17-edge-cases.test.js**: remove 1 shim test, rename `describe('confirmResetAll')` → `describe('openResetModal')` to reflect what it now covers

## Verification
- `grep -rn confirmResetAll public/ tests/ docs/` → zero matches
- `pnpm test` → 571/780 pass (baseline 579; -8 from removed tests, 0 regressions vs dev)
- `pnpm lint` → clean
- 4 files changed, +3 / -114

Closes #252