### PR TITLE
chore: auto-close linked issues on PR merge via CI check

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,34 @@
+## Was
+
+<!-- Eine Zeile: was ändert dieser PR? -->
+
+Closes #
+
+## Warum
+
+<!-- Kurz: welches Issue wird gelöst, welcher Kontext fehlt im Diff -->
+
+## Wie
+
+<!-- Wichtigste Entscheidungen, Trade-offs, was wurde bewusst NICHT gemacht -->
+
+## Verifikation
+
+- [ ] `pnpm test` grün
+- [ ] `pnpm lint` grün
+- [ ] Manuelle Verifikation gegen Dev-URL (falls UI-relevant)
+
+## Issue-Verknüpfung
+
+<!-- Pflicht: Eines der folgenden Keywords + Issue-Nummer verwenden,
+     damit GitHub das Issue beim Merge automatisch schließt:
+     - Closes #123
+     - Fixes #123
+     - Resolves #123
+     Keywords im Commit-Title (z.B. fix(#123):) funktionieren NUR
+     bei Squash-Merge und nur, wenn die Commit-Message ins Squash
+     übernommen wird. Im PR-Body ist immer sicherer.
+-->
+
+- Issues: `Closes #...`
+- Verwandt (nicht schließend): `Refs #...` / `See also #...`

--- a/.github/workflows/pr-issue-link.yml
+++ b/.github/workflows/pr-issue-link.yml
@@ -1,0 +1,83 @@
+name: PR must link to an Issue
+
+# Garantiert, dass GitHub die verknüpften Issues beim Merge automatisch
+# schließt. Prüft Title + Body auf eines der Schlüsselwörter:
+#   Closes #N | Fixes #N | Resolves #N
+# Plus: feat(#N) / fix(#N) / refactor(#N) / chore(#N) im PR-Title
+#       (Conventional Commits Prefix).
+# Bei Verstoß: Warn-Kommentar auf dem PR + fail check.
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  pull-requests: write   # nötig für den Warn-Kommentar
+  contents: read
+
+jobs:
+  check-link:
+    name: Issue reference found in PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Read PR title and body
+        id: read
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          {
+            echo "title<<EOF"
+            gh pr view "$PR_NUMBER" --json title --jq .title
+            echo "EOF"
+            echo "body<<EOF"
+            gh pr view "$PR_NUMBER" --json body --jq .body
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Check for issue keyword
+        id: check
+        env:
+          TITLE: ${{ steps.read.outputs.title }}
+          BODY: ${{ steps.read.outputs.body }}
+        run: |
+          set +e
+          if echo "$TITLE $BODY" | grep -qiE '(closes|fixes|resolves|close|fix|resolve)\s+#?[0-9]+'; then
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Conventional-Commit-Titel mit Issue-Ref direkt im Titel:  fix(#232): ...
+          if echo "$TITLE" | grep -qiE '^(feat|fix|refactor|chore|dx|docs|test|perf|build|ci)\(#?[0-9]+(\s*,\s*#?[0-9]+)*\):'; then
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Conventional-Commit-Titel + Issue-Ref irgendwo im Body
+          if echo "$TITLE" | grep -qiE '^(feat|fix|refactor|chore|dx|docs|test|perf|build|ci)(\([^)]+\))?:\s*' \
+             && echo "$BODY" | grep -qE '#[0-9]+'; then
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "ok=false" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Post warning comment
+        if: steps.check.outputs.ok != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr comment "$PR_NUMBER" --body "⚠️ **Issue-Verknüpfung fehlt.** Ohne \`Closes #N\` / \`Fixes #N\` / \`Resolves #N\` im PR-Body (oder \`fix(#N):\` im PR-Titel bei Squash-Merge) schließt GitHub das Issue beim Merge **nicht** automatisch.
+
+          Bitte ergänzen, z.B. am Ende des PR-Body:
+          \`\`\`
+          Closes #123
+          \`\`\`
+          oder den PR-Titel auf Conventional-Commit-Form bringen: \`fix(#123): …\`"
+
+      - name: Fail check
+        if: steps.check.outputs.ok != 'true'
+        run: |
+          echo "::error::PR verlinkt kein Issue mit Closes/Fixes/Resolves-Keyword. Siehe Kommentar."
+          exit 1

--- a/.github/workflows/pr-issue-link.yml
+++ b/.github/workflows/pr-issue-link.yml
@@ -22,6 +22,8 @@ jobs:
     name: Issue reference found in PR
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
       - name: Read PR title and body
         id: read
         env:


### PR DESCRIPTION
## Was

CI-Check, der verhindert, dass Issues beim PR-Merge nicht automatisch geschlossen werden. Aktuell wird die `Closes #N`/`Fixes #N`/`Resolves #N`-Referenz vom Coder/Reviewer leicht vergessen — Issue bleibt offen, Reviewer muss manuell nachschließen.

## Änderungen

- `.github/pull_request_template.md` (neu): erinnert Coder an die Issue-Verknüpfung im PR-Body
- `.github/workflows/pr-issue-link.yml` (neu): checkt PR-Title + Body, failt mit klarem Kommentar bei fehlender Verknüpfung

## Akzeptierte Formen

| Form | Beispiel | Erkennung |
|------|----------|-----------|
| Body-Keyword | `Closes #250` | grep auf (closes\|fixes\|resolves) #N |
| Conv-Commit-Titel | `fix(#250, #251): Dashboard z-index` | grep auf `^(feat\|fix\|...)\(#N(, #M)*\):` |
| Conv-Commit-Titel + Body-Ref | `feat(#232): Export` + Body mit `Refs #232` | beides kombiniert |

## Warum

Reproduziert genau den Fall aus PR #255: Body hatte die `Closes`-Zeile, Auto-Close funktionierte — aber die Verifikation war Sache des Reviewers. Jetzt ist es CI-Aufgabe.

## Verifikation

- [x] YAML parst sauber (Python `yaml.safe_load`)
- [x] Regex-Logik gegen 10 Test-Cases verifiziert (siehe Commit-Message)
- [x] Keine Kollateralschäden — `.hermes/` und `0` untracked geblieben
- [x] Eigener Branch `chore/auto-close-issues-on-pr-merge`, kein Mitnehmen von #253-Änderungen

Closes #258
