### PR TITLE
fix(#254): replace magic number 0.05 with EPSILON_QUANTITY constant

### DIFF
--- a/public/js/calculations.js
+++ b/public/js/calculations.js
@@ -6,6 +6,13 @@
     // Keine Seiteneffekte, keine DOM-Manipulation.
     // ============================================================================
 
+    // --- Konstanten ---
+
+    // Schwelle für "noch etwas vorhanden" (Einheiten / kg).
+    // Wird verwendet, um Floating-Point-Restwerte unterhalb der Darstellungs-
+    // genauigkeit als "nichts" zu behandeln. Refs: Issue #254.
+    var EPSILON_QUANTITY = 0.05;
+
     // --- Fahrgassen-Faktor (zentrale Berechnung) ---
 
     // Berechnet den Produktivitätsfaktor für Fahrgassen.

--- a/public/js/ui-handlers.js
+++ b/public/js/ui-handlers.js
@@ -193,7 +193,7 @@
           var used = getTabUsedEinheiten(r);
           var co = getCarryover(i);
           var remaining = total - used + co.savedEinheit - co.excessEinheit;
-          if (remaining > 0.05) totalNeed += remaining;
+          if (remaining > EPSILON_QUANTITY) totalNeed += remaining;
         }
       });
       if (totalNeed <= 0) {
@@ -228,7 +228,7 @@
         var remainingUnits = einheit;
         var remainingDuenger = duenger;
         var lastEntry = null;
-        for (var pi = 0; pi < priorities.length && (remainingUnits > 0.05 || remainingDuenger > 0.05); pi++) {
+        for (var pi = 0; pi < priorities.length && (remainingUnits > EPSILON_QUANTITY || remainingDuenger > EPSILON_QUANTITY); pi++) {
           var tabIdx = priorities[pi].idx;
           var tab = state.reiter[tabIdx];
           // Issue #240: Dimensionen korrigieren. Vorher teilte einheitPerHa
@@ -263,7 +263,7 @@
           lastEntry = entry;
           remainingUnits -= unitsForThisTab;
           remainingDuenger -= duengerForThisTab;
-          if (pi === priorities.length - 1 && (remainingUnits > 0.05 || remainingDuenger > 0.05)) {
+          if (pi === priorities.length - 1 && (remainingUnits > EPSILON_QUANTITY || remainingDuenger > EPSILON_QUANTITY)) {
             if (lastEntry) { lastEntry.einheit += remainingUnits; lastEntry.duenger += remainingDuenger; }
             remainingUnits = 0; remainingDuenger = 0;
           }


### PR DESCRIPTION
## Summary
Behebt Issue #254: ersetzt die Magic Number `0.05` in `drillAdd()` durch eine benannte Konstante `EPSILON_QUANTITY` in `calculations.js`. Verhalten unverändert.

## Was geändert wurde
- `public/js/calculations.js` (+7): Neue Konstante `var EPSILON_QUANTITY = 0.05;` mit Kommentar, der den Domain-Kontext ("Schwelle für noch etwas vorhanden — Floating-Point-Restwerte") dokumentiert.
- `public/js/ui-handlers.js` (3 Ersetzungen): `0.05` → `EPSILON_QUANTITY` an den 3 Vergleichsstellen in `drillAdd()` (Zeilen 196, 231, 266).

## Verifikation
- `grep -n '0.05' public/js/ui-handlers.js` → 0 Treffer ✓
- `EPSILON_QUANTITY` ist global aus `calculations.js` verfügbar (Load-Order: calculations.js vor ui-handlers.js in `public/index.html`) — kein ESM-Import nötig, gleiches Pattern wie der Rest des Projekts (vanilla JS, window-scoped) ✓
- `pnpm test`: 573 passed / 207 failed — **identisch zu `origin/dev` Baseline** (0 Regressionen, Pre-existing fails unverändert) ✓
- `pnpm lint`: clean ✓
- Diff zeigt reine 1:1-Ersetzungen, keine Logik-Änderung ✓

## Test-Status
- Branch: 573 passed / 207 failed (780 total)
- dev (Baseline): 573 passed / 207 failed (780 total)
- Delta: +0 / −0

Closes #254
