### PR TITLE
fix(#263): renderDrillLog uses correct container id 'drill_entries'

### DIFF
--- a/public/js/render-drill.js
+++ b/public/js/render-drill.js
@@ -122,7 +122,7 @@
     // --- Render: Drill Log ---
 
     function renderDrillLog() {
-      var container = document.getElementById('drill_log_entries');
+      var container = document.getElementById('drill_entries');
       if (!container) return;
       container.innerHTML = '';
       var activeTab = state.reiter[state.activeReiter];


### PR DESCRIPTION
Closes #263

## Problem
renderDrillLog() in public/js/render-drill.js:125 searched for element id 'drill_log_entries', but the HTML at public/index.html:203 defines the container as id='drill_entries'. As a result, the function early-returned at the `if (!container) return;` guard and Protokoll-Entries were never inserted into the UI.

## Fix
One-line correction: `getElementById('drill_log_entries')` -> `getElementById('drill_entries')` in render-drill.js:125. All existing tests already use the correct id (`drill_entries`), so no test changes needed.

## Verification
- pnpm lint: clean
- pnpm test: 596 pass / 184 fail (identical to dev baseline — zero regressions; pre-existing failures stem from #262 parseDE issue, unrelated to this fix)
- Only file changed: public/js/render-drill.js (+1/-1)