### PR TITLE
fix(#265): correct getElementById mini_footer → mini_result

### DIFF
--- a/public/js/render-results.js
+++ b/public/js/render-results.js
@@ -99,16 +99,20 @@
     // --- Render: Mini Footer ---
 
     function renderMiniFooter() {
-      var mf = document.getElementById('mini_footer');
+      var mf = document.getElementById('mini_result');
       if (!mf) return;
       var activeR = state.reiter[state.activeReiter];
       if (!activeR) return;
       if (activeR.hektar > 0 && activeR.koerner > 0) {
         var einheiten = getActiveTotalEinheiten();
+        var duengerTotal = getActiveTotalDuenger();
         var kornerGesamt = getKornerGesamt();
         var kornerStr = Math.round(kornerGesamt).toLocaleString('de-DE');
         var miniResult = mf.querySelector('.mini-result') || mf;
-        miniResult.textContent = 'Bedarf: ' + formatEinheit(einheiten) + ' / ' + kornerStr + ' Körner';
+        var duengerStr = duengerTotal > 0
+          ? ' / ' + duengerTotal.toLocaleString('de-DE') + ' kg'
+          : '';
+        miniResult.innerHTML = 'Bedarf: <span class="mr-einheiten">' + formatEinheit(einheiten) + '</span> / ' + kornerStr + ' Körner' + duengerStr;
         miniResult.classList.remove('mini-result-empty');
       } else {
         var miniResult = mf.querySelector('.mini-result') || mf;


### PR DESCRIPTION
Fixes #265
Closes #265

## Bug
`renderMiniFooter()` in `public/js/render-results.js` was calling `document.getElementById("mini_footer")`, but the HTML element has `id="mini_result"`. The function bailed out early at `if (!mf) return`, so the mini-result in the sticky footer was never updated.

## Fix
- `public/js/render-results.js` line 102: `'mini_footer'` → `'mini_result'`
- The element `mini_footer` does not exist anywhere else in `public/` — single-line fix.

## Tests
- All 4 tests in the "mini-result in sticky footer" block of `tests/15-render-view.test.js` now pass.
- Pre-fix: 4/24 failing in this file. Post-fix: 1/24 failing (the remaining failure is in `switchToProtokoll`, unrelated to #265, exists on `dev`).