### PR TITLE
fix(#274): var i → let in computeAllCarryovers() (4 for-loops)

### DIFF
--- a/public/js/calculations.js
+++ b/public/js/calculations.js
@@ -164,7 +164,7 @@
       if (_internal.carryoverCache !== null) return _internal.carryoverCache;
 
       var result = [];
-      for (var i = 0; i < state.reiter.length; i++) {
+      for (let i = 0; i < state.reiter.length; i++) {
         result.push({ savedEinheit: 0, savedDuenger: 0, excessEinheit: 0, excessDuenger: 0 });
       }
 
@@ -176,7 +176,7 @@
       var totalSavedE = 0, totalSavedD = 0;
       var totalExcessE = 0, totalExcessD = 0;
 
-      for (var i = 0; i < state.reiter.length; i++) {
+      for (let i = 0; i < state.reiter.length; i++) {
         var t = state.reiter[i];
         var istE = getTabIstEinheiten(t);
         var solE = getTabTotalEinheiten(t);
@@ -197,7 +197,7 @@
       // === PHASE 1: Ersparnisse verteilen (vorwärts durch Tabs) ===
       _internal.carryoverCache = result;
       var remSavedE = totalSavedE, remSavedD = totalSavedD;
-      for (var i = 0; i < state.reiter.length && (remSavedE > 0.05 || remSavedD > 0.05); i++) {
+      for (let i = 0; i < state.reiter.length && (remSavedE > 0.05 || remSavedD > 0.05); i++) {
         var t = state.reiter[i];
         // Need for tab i: max(0, IST - used) wenn IST > 0, sonst max(0, SOLL - used)
         var istE = getTabIstEinheiten(t);
@@ -251,7 +251,7 @@
         return 0;
       }
       var tabOrder2 = [];
-      for (var i = 0; i < state.reiter.length; i++) {
+      for (let i = 0; i < state.reiter.length; i++) {
         var t2 = state.reiter[i];
         if (!t2.entries || t2.entries.length === 0) continue;
         var istE2 = getTabIstEinheiten(t2);


### PR DESCRIPTION
## Summary
- `computeAllCarryovers()` in `public/js/calculations.js` deklarierte `var i` in vier separaten for-Schleifen (Zeilen 167, 179, 200, 254).
- Ersetzt durch `let i` → Block-Scope, sauberer, schützt vor SyntaxError bei künftigen `let`/`const`-Refactors.
- Keine Logik-Änderung, keine Performance-Auswirkung.

## Verification
- `pnpm lint` clean
- `pnpm test` 782/782 grün (0 Regressionen)
- Diff: 4 insertions, 4 deletions, 1 file

Closes #274