### PR TITLE
fix(#275): remove 4-space top-level extra indent in state.js and calculations.js

### DIFF
--- a/public/js/calculations.js
+++ b/public/js/calculations.js
@@ -1,422 +1,422 @@
 // ============================================================================
-    // BERECHNUNGEN — Pure Functions für alle landwirtschaftlichen Berechnungen
-    //
-    // Alle Funktionen sind pure: gleiche Eingabe → gleiche Ausgabe, kein State-Zugriff.
-    // Das macht sie einfach testbar und vorhersehbar.
-    // Keine Seiteneffekte, keine DOM-Manipulation.
-    // ============================================================================
+// BERECHNUNGEN — Pure Functions für alle landwirtschaftlichen Berechnungen
+//
+// Alle Funktionen sind pure: gleiche Eingabe → gleiche Ausgabe, kein State-Zugriff.
+// Das macht sie einfach testbar und vorhersehbar.
+// Keine Seiteneffekte, keine DOM-Manipulation.
+// ============================================================================
 
-    // --- Konstanten ---
+// --- Konstanten ---
 
-    // Schwelle für "noch etwas vorhanden" (Einheiten / kg).
-    // Wird verwendet, um Floating-Point-Restwerte unterhalb der Darstellungs-
-    // genauigkeit als "nichts" zu behandeln. Refs: Issue #254.
-    var EPSILON_QUANTITY = 0.05;
+// Schwelle für "noch etwas vorhanden" (Einheiten / kg).
+// Wird verwendet, um Floating-Point-Restwerte unterhalb der Darstellungs-
+// genauigkeit als "nichts" zu behandeln. Refs: Issue #254.
+var EPSILON_QUANTITY = 0.05;
 
-    // --- Fahrgassen-Faktor (zentrale Berechnung) ---
+// --- Fahrgassen-Faktor (zentrale Berechnung) ---
 
-    // Berechnet den Produktivitätsfaktor für Fahrgassen.
-    //
-    // Physikalische Grundlage:
-    //   Fahrgassen sind 1m breite Fahrspuren, die alle `breite` Meter
-    //   (Arbeitsbreite des Geräts) im Feld wiederkehren.
-    //   Der produktive Anteil der Fläche ist somit:
-    //     (breite - 1) / breite
-    //
-    //   Beispiel: Arbeitsbreite = 24m → (24-1)/24 = 0.9583 → ~4.2% Verlust
-    //             Arbeitsbreite = 4m  → (4-1)/4   = 0.75   → 25% Verlust
-    //
-    //   Guard: breite < 2 → kein sinnvoller Wert → Faktor 1.0 (keine Korrektur)
-    //
-    // @param {number} breite — Arbeitsbreite in Metern (≥ 2)
-    // @returns {number} Produktivitätsfaktor (0..1); 1 = keine Korrektur
-    function computeFahrgassenFaktor(breite) {
-      if (!breite || breite < 2) return 1;
-      return (breite - 1) / breite;
+// Berechnet den Produktivitätsfaktor für Fahrgassen.
+//
+// Physikalische Grundlage:
+//   Fahrgassen sind 1m breite Fahrspuren, die alle `breite` Meter
+//   (Arbeitsbreite des Geräts) im Feld wiederkehren.
+//   Der produktive Anteil der Fläche ist somit:
+//     (breite - 1) / breite
+//
+//   Beispiel: Arbeitsbreite = 24m → (24-1)/24 = 0.9583 → ~4.2% Verlust
+//             Arbeitsbreite = 4m  → (4-1)/4   = 0.75   → 25% Verlust
+//
+//   Guard: breite < 2 → kein sinnvoller Wert → Faktor 1.0 (keine Korrektur)
+//
+// @param {number} breite — Arbeitsbreite in Metern (≥ 2)
+// @returns {number} Produktivitätsfaktor (0..1); 1 = keine Korrektur
+function computeFahrgassenFaktor(breite) {
+  if (!breite || breite < 2) return 1;
+  return (breite - 1) / breite;
+}
+
+// --- Einheiten-Berechnung (SOLL) ---
+
+// Berechnet die Anzahl Einheiten für ein gegebenes Feld.
+// Berücksichtigt: Körner/ha, Körner/Einheit, Hektar, Fahrgassen-Korrektur.
+//
+// Formel:
+//   einheiten = (hektar × koerner) / koernerProEinheit
+//   einheiten × computeFahrgassenFaktor(breite)  falls fahrgassenEnabled
+//
+// Argumente:
+//   r           — Tab-Objekt mit hektar, koerner, fahrgassenEnabled, fahrgassenBreite, etc.
+//   koernerProEinheit — Körner pro Einheit (Standard: 50000)
+//
+// Rückgabe: number (Einheiten, immer ≥ 0)
+function getTotalEinheiten(r, koernerProEinheit) {
+  if (!r || !r.hektar || !r.koerner || koernerProEinheit <= 0) return 0;
+  var fgEnabled = (r.fahrgassenEnabled !== undefined) ? r.fahrgassenEnabled : state.fahrgassenEnabled;
+  var fgBreite = (r.fahrgassenBreite !== undefined) ? r.fahrgassenBreite : state.fahrgassenBreite;
+  var faktor = 1;
+  if (fgEnabled && fgBreite > 0) {
+    faktor = computeFahrgassenFaktor(fgBreite);
+  }
+  var einheiten = (r.hektar * r.koerner) / koernerProEinheit;
+  return Math.max(0, einheiten * faktor);
+}
+
+// Berechnet die Gesamteinheiten für ein Tab-Objekt (SOLL), mit globalen Einstellungen.
+function getTabTotalEinheiten(r) {
+  return getTotalEinheiten(r, state.koernerProEinheit);
+}
+
+// Berechnet die IST-Einheiten basierend auf der IST-Fläche.
+// Nur wenn istHektar > 0 gesetzt ist, wird die IST-Fläche für die Berechnung verwendet.
+function getTabIstEinheiten(r) {
+  if (!r || !r.istHektar || !r.koerner || state.koernerProEinheit <= 0) return 0;
+  var fgEnabled = (r.fahrgassenEnabled !== undefined) ? r.fahrgassenEnabled : state.fahrgassenEnabled;
+  var fgBreite = (r.fahrgassenBreite !== undefined) ? r.fahrgassenBreite : state.fahrgassenBreite;
+  var faktor = 1;
+  if (fgEnabled && fgBreite > 0) {
+    faktor = computeFahrgassenFaktor(fgBreite);
+  }
+  var einheiten = (r.istHektar * r.koerner) / state.koernerProEinheit;
+  return Math.max(0, einheiten * faktor);
+}
+
+// --- Dünger-Berechnung (SOLL) ---
+
+// Berechnet Düngermenge in kg (kg/ha × ha = kg).
+// Formel: r.hektar * r.duenger
+// Issue #191: Vorherige Version dividierte fälschlich durch 50
+// (aus der "1 Einheit = 50 kg" Annahme), was zu 50× zu kleinen kg-Werten
+// im SOLL-Pfad führte. Aufrufer hängen ' kg' an den Wert — die Funktion
+// muss kg liefern. Konsistent mit getTabIstDuenger (PR #190).
+function getTotalDuenger(r) {
+  if (!r || !r.hektar || !r.duenger) return 0;
+  return Math.max(0, r.hektar * r.duenger);
+}
+
+function getTabTotalDuenger(r) {
+  return getTotalDuenger(r);
+}
+
+// Dünger (kg) pro Einheit Saatgut für einen Tab.
+//
+// Physikalische Bedeutung: Wieviel kg Dünger zusammen mit einer Einheit
+// Saatgut ausgebracht werden müssen, damit das Soll-Verhältnis
+// (kg Dünger/ha ÷ Körner/ha × koernerProEinheit) eingehalten wird.
+//
+// Herleitung:
+//   totalDuenger = r.hektar × r.duenger          (kg)
+//   totalEinheit = r.hektar × r.koerner / kpe    (Einheiten)
+//   kgProEinheit = totalDuenger / totalEinheit
+//                = r.duenger × kpe / r.koerner
+//
+// Issue #230: Vorher stand hier `tab.duenger / (tab.hektar || 1) * 50` —
+// ein Überbleibsel der falschen "1 Einheit = 50 kg" Annahme, die in
+// #186/#191 bereits aus getTotalDuenger/getTabIstDuenger entfernt wurde.
+// Die neue Formel ist dimensionsrein (kg/Einheit) und kpe-konsistent.
+//
+// @param {Object} r — Tab-Objekt mit .hektar, .koerner, .duenger
+// @param {number} koernerProEinheit — Körner pro Einheit (Standard 50000)
+// @returns {number} kg Dünger pro Einheit Saatgut (0 wenn r.koerner fehlt)
+function getDuengerProEinheit(r, koernerProEinheit) {
+  if (!r || !r.duenger || !r.koerner || !koernerProEinheit) return 0;
+  return r.duenger * koernerProEinheit / r.koerner;
+}
+
+// Berechnet IST-Dünger (kg) basierend auf istHektar.
+// Formel: r.istHektar * r.duenger (kg/ha) → kg total.
+// Issue #186: Vorherige Version dividierte fälschlich durch 50
+// (aus der "1 Einheit = 50 kg" Annahme), was zu falschen kg-Werten führte.
+function getTabIstDuenger(r) {
+  if (!r || !r.istHektar || !r.duenger) return 0;
+  return Math.max(0, r.istHektar * r.duenger);
+}
+
+// --- Carryover-Berechnung ---
+
+// Liefert die Summe aller verbrauchten Einheiten/Dünger im Tab (aus entries).
+function getTabUsedEinheiten(r) {
+  if (!r || !r.entries) return 0;
+  return r.entries.reduce(function(s, e) { return s + (e.einheit || 0); }, 0);
+}
+
+function getTabUsedDuenger(r) {
+  if (!r || !r.entries) return 0;
+  return r.entries.reduce(function(s, e) { return s + (e.duenger || 0); }, 0);
+}
+
+// --- Carryover-Cache (interner State, nicht pure) ---
+
+var _internal = {
+  carryoverCache: null,
+  drillCalcTimer: null,
+  pendingKey: null
+};
+
+// Berechnet Carryover (Überschüsse/Ersparnisse) für alle Tabs.
+//
+// Phase 1: Ersparnisse (IST < SOLL → saved = SOLL - IST) werden an unfertige Tabs verteilt.
+//          Tabs die "nur durch Carryover fertig" werden, werden übersprungen.
+// Phase 2: Mehrbedarfe (IST > SOLL → excess) werden aus Mehrbedarfs-Tabs gedeckt.
+//
+// Caching: Ergebnis wird in _internal.carryoverCache gespeichert,
+// bis eine State-Änderung invalidateCarryoverCache() aufruft.
+function computeAllCarryovers() {
+  if (_internal.carryoverCache !== null) return _internal.carryoverCache;
+
+  var result = [];
+  for (let i = 0; i < state.reiter.length; i++) {
+    result.push({ savedEinheit: 0, savedDuenger: 0, excessEinheit: 0, excessDuenger: 0 });
+  }
+
+  // --- PHASE 0: Bedarfsberechnung ---
+  // Savings: SOLL - IST wenn IST > 0 && IST < SOLL (Ersparnis = nicht bepflanzte Fläche)
+  // Excess: IST - SOLL wenn IST > SOLL
+  // Need: max(0, IST - used) wenn IST > 0 (sonst SOLL - used)
+  // Wenn IST=0 → keine Carryover (keine Ersparnis, kein Bedarf jenseits SOLL)
+  var totalSavedE = 0, totalSavedD = 0;
+  var totalExcessE = 0, totalExcessD = 0;
+
+  for (let i = 0; i < state.reiter.length; i++) {
+    var t = state.reiter[i];
+    var istE = getTabIstEinheiten(t);
+    var solE = getTabTotalEinheiten(t);
+    var usedE = getTabUsedEinheiten(t);
+    var istD = getTabIstDuenger(t);
+    var solD = getTabTotalDuenger(t);
+    var usedD = getTabUsedDuenger(t);
+    if (istE > 0) {
+      if (solE > istE) totalSavedE += (solE - istE);
+      else if (istE > solE) totalExcessE += (istE - solE);
     }
+    if (istD > 0) {
+      if (solD > istD) totalSavedD += (solD - istD);
+      else if (istD > solD) totalExcessD += (istD - solD);
+    }
+  }
 
-    // --- Einheiten-Berechnung (SOLL) ---
+  // === PHASE 1: Ersparnisse verteilen (vorwärts durch Tabs) ===
+  _internal.carryoverCache = result;
+  var remSavedE = totalSavedE, remSavedD = totalSavedD;
+  for (let i = 0; i < state.reiter.length && (remSavedE > 0.05 || remSavedD > 0.05); i++) {
+    var t = state.reiter[i];
+    // Need for tab i: max(0, IST - used) wenn IST > 0, sonst max(0, SOLL - used)
+    var istE = getTabIstEinheiten(t);
+    var solE = getTabTotalEinheiten(t);
+    var usedE = getTabUsedEinheiten(t);
+    var istD = getTabIstDuenger(t);
+    var solD = getTabTotalDuenger(t);
+    var usedD = getTabUsedDuenger(t);
+    var basisE = istE > 0 ? istE : solE;
+    var basisD = istD > 0 ? istD : solD;
+    var needE = Math.max(0, basisE - usedE);
+    var needD = Math.max(0, basisD - usedD);
+    // Issue #138: skip if tab would be done with carryover — bereits
+    // implementiert via isTabDone(t, i) weiter unten. Wir verteilen hier
+    // immer und überspringen im nächsten Loop-Durchlauf. Da result[i] sich
+    // ändert während wir durchgehen, berechnen wir isTabDone(t, i) jedes
+    // Mal frisch.
+    var takeE = 0, takeD = 0;
+    if (needE > 0.05 && remSavedE > 0.05) {
+      // Wenn der Tab mit weniger carryover schon fertig wäre, nur so viel
+      // geben wie nötig, damit er genau auf 0 kommt. So bekommt der nächste
+      // Tab mehr vom Carryover (Issue #138).
+      // maxTakeE = min(remSavedE, needE)
+      // Wenn (basisE - usedE - takeE) <= 0 → Tab ist fertig, weniger geben
+      takeE = Math.min(remSavedE, needE);
+    }
+    if (needD > 0.05 && remSavedD > 0.05) {
+      takeD = Math.min(remSavedD, needD);
+    }
+    if (takeE > 0) { result[i].savedEinheit = takeE; remSavedE -= takeE; }
+    if (takeD > 0) { result[i].savedDuenger = takeD; remSavedD -= takeD; }
+  }
 
-    // Berechnet die Anzahl Einheiten für ein gegebenes Feld.
-    // Berücksichtigt: Körner/ha, Körner/Einheit, Hektar, Fahrgassen-Korrektur.
-    //
-    // Formel:
-    //   einheiten = (hektar × koerner) / koernerProEinheit
-    //   einheiten × computeFahrgassenFaktor(breite)  falls fahrgassenEnabled
-    //
-    // Argumente:
-    //   r           — Tab-Objekt mit hektar, koerner, fahrgassenEnabled, fahrgassenBreite, etc.
-    //   koernerProEinheit — Körner pro Einheit (Standard: 50000)
-    //
-    // Rückgabe: number (Einheiten, immer ≥ 0)
-    function getTotalEinheiten(r, koernerProEinheit) {
-      if (!r || !r.hektar || !r.koerner || koernerProEinheit <= 0) return 0;
-      var fgEnabled = (r.fahrgassenEnabled !== undefined) ? r.fahrgassenEnabled : state.fahrgassenEnabled;
-      var fgBreite = (r.fahrgassenBreite !== undefined) ? r.fahrgassenBreite : state.fahrgassenBreite;
-      var faktor = 1;
-      if (fgEnabled && fgBreite > 0) {
-        faktor = computeFahrgassenFaktor(fgBreite);
+  // === PHASE 2: Mehrbedarfe (IST > SOLL) → Tabs absorbieren in Fill-Reihenfolge ===
+  // Tabs die selbst Mehrbedarf haben (diff < 0) kommen zuletzt.
+  // Issue #266-B2: last-filled Tab absorbiert zuerst (Capacity = basis - used > 0),
+  // dann rückwärts in Fill-Chronologie. Capacity wird durch Carryover-Savings
+  // reduziert (savings-empfangende Tabs geben ggf. einen Teil ihrer Ersparnis ab).
+  // Time parsing: time kann String ("10:00") oder Number (Date.now()) sein.
+  // Wir konvertieren zu Minuten-since-midnight für sortierbare Vergleich.
+  function _parseEntryTime(t) {
+    if (typeof t === 'number') return t;
+    if (typeof t === 'string') {
+      // Format "HH:MM" oder "HH:MM:SS"
+      var m = t.match(/^(\d{1,2}):(\d{2})/);
+      if (m) return parseInt(m[1], 10) * 60 + parseInt(m[2], 10);
+      // ISO oder andere Formate → Date.parse Fallback
+      var d = Date.parse(t);
+      if (!isNaN(d)) return d;
+    }
+    return 0;
+  }
+  var tabOrder2 = [];
+  for (let i = 0; i < state.reiter.length; i++) {
+    var t2 = state.reiter[i];
+    if (!t2.entries || t2.entries.length === 0) continue;
+    var istE2 = getTabIstEinheiten(t2);
+    var solE2 = getTabTotalEinheiten(t2);
+    var usedE2 = getTabUsedEinheiten(t2);
+    var istD2 = getTabIstDuenger(t2);
+    var solD2 = getTabTotalDuenger(t2);
+    var usedD2 = getTabUsedDuenger(t2);
+    var basisE2 = istE2 > 0 ? istE2 : solE2;
+    var basisD2 = istD2 > 0 ? istD2 : solD2;
+    // Capacity = wie viel Platz dieser Tab noch hat (basis - used, abzgl. bereits erhaltener Savings)
+    // positive capacity → kann Mehrbedarf absorbieren
+    var capE = Math.max(0, basisE2 - usedE2) - result[i].savedEinheit;
+    var capD = Math.max(0, basisD2 - usedD2) - result[i].savedDuenger;
+    // Self-Mehrbedarf (used > basis): der Tab ist selbst überschüssig → kommt zuletzt
+    var selfExcessE = Math.max(0, usedE2 - basisE2);
+    var selfExcessD = Math.max(0, usedD2 - basisD2);
+    var lastEntry2 = t2.entries[t2.entries.length - 1];
+    var ts2 = _parseEntryTime(lastEntry2 ? (lastEntry2.time || 0) : 0);
+    // capacity-positive tabs: group A (sorted by ts DESC → last-filled first)
+    // self-Mehrbedarf tabs: group B (sorted by ts DESC)
+    tabOrder2.push({
+      idx: i, ts: ts2,
+      capE: capE, capD: capD,
+      selfExcessE: selfExcessE, selfExcessD: selfExcessD
+    });
+  }
+  // Sort: tabs mit freier Kapazität zuerst (last-filled first), dann Tabs mit Selbst-Mehrbedarf
+  tabOrder2.sort(function(a, b) {
+    var aHasCap = (a.capE > 0.05 || a.capD > 0.05) ? 1 : 0;
+    var bHasCap = (b.capE > 0.05 || b.capD > 0.05) ? 1 : 0;
+    if (aHasCap !== bHasCap) return bHasCap - aHasCap; // capacity tabs first
+    return b.ts - a.ts; // within group: last-filled first
+  });
+
+  var remExcessE2 = totalExcessE, remExcessD2 = totalExcessD;
+  for (var j2 = 0; j2 < tabOrder2.length && (remExcessE2 > 0.05 || remExcessD2 > 0.05); j2++) {
+    var entry2 = tabOrder2[j2];
+    var idx2 = entry2.idx;
+    var hasCap = (entry2.capE > 0.05 || entry2.capD > 0.05);
+    if (hasCap) {
+      // Capacity positive → absorbiere proportional
+      var takeCapE = Math.min(remExcessE2, entry2.capE);
+      var takeCapD = Math.min(remExcessD2, entry2.capD);
+      if (takeCapE > 0.05) {
+        result[idx2].excessEinheit = takeCapE;
+        remExcessE2 -= takeCapE;
       }
-      var einheiten = (r.hektar * r.koerner) / koernerProEinheit;
-      return Math.max(0, einheiten * faktor);
-    }
-
-    // Berechnet die Gesamteinheiten für ein Tab-Objekt (SOLL), mit globalen Einstellungen.
-    function getTabTotalEinheiten(r) {
-      return getTotalEinheiten(r, state.koernerProEinheit);
-    }
-
-    // Berechnet die IST-Einheiten basierend auf der IST-Fläche.
-    // Nur wenn istHektar > 0 gesetzt ist, wird die IST-Fläche für die Berechnung verwendet.
-    function getTabIstEinheiten(r) {
-      if (!r || !r.istHektar || !r.koerner || state.koernerProEinheit <= 0) return 0;
-      var fgEnabled = (r.fahrgassenEnabled !== undefined) ? r.fahrgassenEnabled : state.fahrgassenEnabled;
-      var fgBreite = (r.fahrgassenBreite !== undefined) ? r.fahrgassenBreite : state.fahrgassenBreite;
-      var faktor = 1;
-      if (fgEnabled && fgBreite > 0) {
-        faktor = computeFahrgassenFaktor(fgBreite);
+      if (takeCapD > 0.05) {
+        result[idx2].excessDuenger = takeCapD;
+        remExcessD2 -= takeCapD;
       }
-      var einheiten = (r.istHektar * r.koerner) / state.koernerProEinheit;
-      return Math.max(0, einheiten * faktor);
+    } else if (entry2.selfExcessE > 0.05 || entry2.selfExcessD > 0.05) {
+      // Tab ist selbst über-befüllt → seediert Mehrbedarf (negativer Carryover)
+      // z.B. wenn Tab IST > SOLL aber andere Tabs keine Kapazität haben
+      // Für jetzt: ignorieren (Test-Scope deckt diesen Fall nicht)
     }
+  }
 
-    // --- Dünger-Berechnung (SOLL) ---
+  _internal.carryoverCache = result;
+  return result;
+}
 
-    // Berechnet Düngermenge in kg (kg/ha × ha = kg).
-    // Formel: r.hektar * r.duenger
-    // Issue #191: Vorherige Version dividierte fälschlich durch 50
-    // (aus der "1 Einheit = 50 kg" Annahme), was zu 50× zu kleinen kg-Werten
-    // im SOLL-Pfad führte. Aufrufer hängen ' kg' an den Wert — die Funktion
-    // muss kg liefern. Konsistent mit getTabIstDuenger (PR #190).
-    function getTotalDuenger(r) {
-      if (!r || !r.hektar || !r.duenger) return 0;
-      return Math.max(0, r.hektar * r.duenger);
-    }
+function invalidateCarryoverCache() {
+  _internal.carryoverCache = null;
+}
 
-    function getTabTotalDuenger(r) {
-      return getTotalDuenger(r);
-    }
+function getCarryover(tabIndex) {
+  var all = computeAllCarryovers();
+  if (tabIndex >= 0 && tabIndex < all.length) return all[tabIndex];
+  return { savedEinheit: 0, savedDuenger: 0, excessEinheit: 0, excessDuenger: 0 };
+}
 
-    // Dünger (kg) pro Einheit Saatgut für einen Tab.
-    //
-    // Physikalische Bedeutung: Wieviel kg Dünger zusammen mit einer Einheit
-    // Saatgut ausgebracht werden müssen, damit das Soll-Verhältnis
-    // (kg Dünger/ha ÷ Körner/ha × koernerProEinheit) eingehalten wird.
-    //
-    // Herleitung:
-    //   totalDuenger = r.hektar × r.duenger          (kg)
-    //   totalEinheit = r.hektar × r.koerner / kpe    (Einheiten)
-    //   kgProEinheit = totalDuenger / totalEinheit
-    //                = r.duenger × kpe / r.koerner
-    //
-    // Issue #230: Vorher stand hier `tab.duenger / (tab.hektar || 1) * 50` —
-    // ein Überbleibsel der falschen "1 Einheit = 50 kg" Annahme, die in
-    // #186/#191 bereits aus getTotalDuenger/getTabIstDuenger entfernt wurde.
-    // Die neue Formel ist dimensionsrein (kg/Einheit) und kpe-konsistent.
-    //
-    // @param {Object} r — Tab-Objekt mit .hektar, .koerner, .duenger
-    // @param {number} koernerProEinheit — Körner pro Einheit (Standard 50000)
-    // @returns {number} kg Dünger pro Einheit Saatgut (0 wenn r.koerner fehlt)
-    function getDuengerProEinheit(r, koernerProEinheit) {
-      if (!r || !r.duenger || !r.koerner || !koernerProEinheit) return 0;
-      return r.duenger * koernerProEinheit / r.koerner;
-    }
+// --- Tab-Fertig-Check (pure) ---
 
-    // Berechnet IST-Dünger (kg) basierend auf istHektar.
-    // Formel: r.istHektar * r.duenger (kg/ha) → kg total.
-    // Issue #186: Vorherige Version dividierte fälschlich durch 50
-    // (aus der "1 Einheit = 50 kg" Annahme), was zu falschen kg-Werten führte.
-    function getTabIstDuenger(r) {
-      if (!r || !r.istHektar || !r.duenger) return 0;
-      return Math.max(0, r.istHektar * r.duenger);
-    }
+// Prüft ob ein Tab "fertig" ist (alle Bedarfe gedeckt).
+// Berücksichtigt: SOLL-Einheiten, IST-Einheiten, Carryover, bereits verbraucht.
+//
+// Verwendet computeAllCarryovers() für Carryover-Werte (wenn tabIndex mitgegeben).
+// Ohne tabIndex wird Carryover ignoriert (Backward-Compat).
+// Ist nil-safe (fehlende Felder = 0).
+function isTabDone(r, tabIndex) {
+  if (!r || !r.entries) return true; // Keine Entries = fertig (kein Bedarf)
+  // Carryover nur berücksichtigen wenn tabIndex mitgegeben
+  var carryover = (tabIndex !== undefined)
+    ? getCarryover(tabIndex)
+    : { savedEinheit: 0, savedDuenger: 0, excessEinheit: 0, excessDuenger: 0 };
+  // IST > 0 ? IST : SOLL (Issue #186)
+  var istE = getTabIstEinheiten(r);
+  var totalE = istE > 0 ? istE : getTabTotalEinheiten(r);
+  var usedE = getTabUsedEinheiten(r);
+  // Remaining = Need - Carryover.Saved + Carryover.Excess
+  // Need = max(0, totalE - usedE)
+  var needE = Math.max(0, totalE - usedE);
+  var remainingE = needE - carryover.savedEinheit + carryover.excessEinheit;
+  if (remainingE > 0.05) return false;
 
-    // --- Carryover-Berechnung ---
+  var istD = getTabIstDuenger(r);
+  var totalD = istD > 0 ? istD : getTabTotalDuenger(r);
+  var usedD = getTabUsedDuenger(r);
+  var needD = Math.max(0, totalD - usedD);
+  var remainingD = needD - carryover.savedDuenger + carryover.excessDuenger;
+  return remainingD <= 0.05;
+}
 
-    // Liefert die Summe aller verbrauchten Einheiten/Dünger im Tab (aus entries).
-    function getTabUsedEinheiten(r) {
-      if (!r || !r.entries) return 0;
-      return r.entries.reduce(function(s, e) { return s + (e.einheit || 0); }, 0);
-    }
+// --- Hilfsfunktionen für Entry-Time ---
 
-    function getTabUsedDuenger(r) {
-      if (!r || !r.entries) return 0;
-      return r.entries.reduce(function(s, e) { return s + (e.duenger || 0); }, 0);
-    }
+// Zeitstempel des letzten Eintrags in einem Tab (für Sortierung).
+function getTabLastEntryTime(r) {
+  if (!r || !r.entries || r.entries.length === 0) return 0;
+  var last = r.entries[r.entries.length - 1];
+  return last ? (last.time || 0) : 0;
+}
 
-    // --- Carryover-Cache (interner State, nicht pure) ---
+// Liefert die IST-Hektar-Summe für einen Tab.
+// Priorität: Direktes r.istHektar (vom Input-Feld) > Summe aus Entries.
+// Issue #186: Das Input-Feld #ist_hektar schreibt via onInputIstHektar in
+// r.istHektar. Wenn das gesetzt ist, IST es die maßgebliche Quelle — nicht
+// die Summe aus entries[].istHektar (die nur ein Legacy-Snapshot ist).
+function getTabIstHektar(r) {
+  if (!r) return 0;
+  if (r.istHektar && r.istHektar > 0) return r.istHektar;
+  if (!r.entries) return 0;
+  return r.entries.reduce(function(s, e) { return s + (e.istHektar || 0); }, 0);
+}
 
-    var _internal = {
-      carryoverCache: null,
-      drillCalcTimer: null,
-      pendingKey: null
-    };
-
-    // Berechnet Carryover (Überschüsse/Ersparnisse) für alle Tabs.
-    //
-    // Phase 1: Ersparnisse (IST < SOLL → saved = SOLL - IST) werden an unfertige Tabs verteilt.
-    //          Tabs die "nur durch Carryover fertig" werden, werden übersprungen.
-    // Phase 2: Mehrbedarfe (IST > SOLL → excess) werden aus Mehrbedarfs-Tabs gedeckt.
-    //
-    // Caching: Ergebnis wird in _internal.carryoverCache gespeichert,
-    // bis eine State-Änderung invalidateCarryoverCache() aufruft.
-    function computeAllCarryovers() {
-      if (_internal.carryoverCache !== null) return _internal.carryoverCache;
-
-      var result = [];
-      for (let i = 0; i < state.reiter.length; i++) {
-        result.push({ savedEinheit: 0, savedDuenger: 0, excessEinheit: 0, excessDuenger: 0 });
-      }
-
-      // --- PHASE 0: Bedarfsberechnung ---
-      // Savings: SOLL - IST wenn IST > 0 && IST < SOLL (Ersparnis = nicht bepflanzte Fläche)
-      // Excess: IST - SOLL wenn IST > SOLL
-      // Need: max(0, IST - used) wenn IST > 0 (sonst SOLL - used)
-      // Wenn IST=0 → keine Carryover (keine Ersparnis, kein Bedarf jenseits SOLL)
-      var totalSavedE = 0, totalSavedD = 0;
-      var totalExcessE = 0, totalExcessD = 0;
-
-      for (let i = 0; i < state.reiter.length; i++) {
-        var t = state.reiter[i];
-        var istE = getTabIstEinheiten(t);
-        var solE = getTabTotalEinheiten(t);
-        var usedE = getTabUsedEinheiten(t);
-        var istD = getTabIstDuenger(t);
-        var solD = getTabTotalDuenger(t);
-        var usedD = getTabUsedDuenger(t);
-        if (istE > 0) {
-          if (solE > istE) totalSavedE += (solE - istE);
-          else if (istE > solE) totalExcessE += (istE - solE);
-        }
-        if (istD > 0) {
-          if (solD > istD) totalSavedD += (solD - istD);
-          else if (istD > solD) totalExcessD += (istD - solD);
-        }
-      }
-
-      // === PHASE 1: Ersparnisse verteilen (vorwärts durch Tabs) ===
-      _internal.carryoverCache = result;
-      var remSavedE = totalSavedE, remSavedD = totalSavedD;
-      for (let i = 0; i < state.reiter.length && (remSavedE > 0.05 || remSavedD > 0.05); i++) {
-        var t = state.reiter[i];
-        // Need for tab i: max(0, IST - used) wenn IST > 0, sonst max(0, SOLL - used)
-        var istE = getTabIstEinheiten(t);
-        var solE = getTabTotalEinheiten(t);
-        var usedE = getTabUsedEinheiten(t);
-        var istD = getTabIstDuenger(t);
-        var solD = getTabTotalDuenger(t);
-        var usedD = getTabUsedDuenger(t);
-        var basisE = istE > 0 ? istE : solE;
-        var basisD = istD > 0 ? istD : solD;
-        var needE = Math.max(0, basisE - usedE);
-        var needD = Math.max(0, basisD - usedD);
-        // Issue #138: skip if tab would be done with carryover — bereits
-        // implementiert via isTabDone(t, i) weiter unten. Wir verteilen hier
-        // immer und überspringen im nächsten Loop-Durchlauf. Da result[i] sich
-        // ändert während wir durchgehen, berechnen wir isTabDone(t, i) jedes
-        // Mal frisch.
-        var takeE = 0, takeD = 0;
-        if (needE > 0.05 && remSavedE > 0.05) {
-          // Wenn der Tab mit weniger carryover schon fertig wäre, nur so viel
-          // geben wie nötig, damit er genau auf 0 kommt. So bekommt der nächste
-          // Tab mehr vom Carryover (Issue #138).
-          // maxTakeE = min(remSavedE, needE)
-          // Wenn (basisE - usedE - takeE) <= 0 → Tab ist fertig, weniger geben
-          takeE = Math.min(remSavedE, needE);
-        }
-        if (needD > 0.05 && remSavedD > 0.05) {
-          takeD = Math.min(remSavedD, needD);
-        }
-        if (takeE > 0) { result[i].savedEinheit = takeE; remSavedE -= takeE; }
-        if (takeD > 0) { result[i].savedDuenger = takeD; remSavedD -= takeD; }
-      }
-
-      // === PHASE 2: Mehrbedarfe (IST > SOLL) → Tabs absorbieren in Fill-Reihenfolge ===
-      // Tabs die selbst Mehrbedarf haben (diff < 0) kommen zuletzt.
-      // Issue #266-B2: last-filled Tab absorbiert zuerst (Capacity = basis - used > 0),
-      // dann rückwärts in Fill-Chronologie. Capacity wird durch Carryover-Savings
-      // reduziert (savings-empfangende Tabs geben ggf. einen Teil ihrer Ersparnis ab).
-      // Time parsing: time kann String ("10:00") oder Number (Date.now()) sein.
-      // Wir konvertieren zu Minuten-since-midnight für sortierbare Vergleich.
-      function _parseEntryTime(t) {
-        if (typeof t === 'number') return t;
-        if (typeof t === 'string') {
-          // Format "HH:MM" oder "HH:MM:SS"
-          var m = t.match(/^(\d{1,2}):(\d{2})/);
-          if (m) return parseInt(m[1], 10) * 60 + parseInt(m[2], 10);
-          // ISO oder andere Formate → Date.parse Fallback
-          var d = Date.parse(t);
-          if (!isNaN(d)) return d;
-        }
-        return 0;
-      }
-      var tabOrder2 = [];
-      for (let i = 0; i < state.reiter.length; i++) {
-        var t2 = state.reiter[i];
-        if (!t2.entries || t2.entries.length === 0) continue;
-        var istE2 = getTabIstEinheiten(t2);
-        var solE2 = getTabTotalEinheiten(t2);
-        var usedE2 = getTabUsedEinheiten(t2);
-        var istD2 = getTabIstDuenger(t2);
-        var solD2 = getTabTotalDuenger(t2);
-        var usedD2 = getTabUsedDuenger(t2);
-        var basisE2 = istE2 > 0 ? istE2 : solE2;
-        var basisD2 = istD2 > 0 ? istD2 : solD2;
-        // Capacity = wie viel Platz dieser Tab noch hat (basis - used, abzgl. bereits erhaltener Savings)
-        // positive capacity → kann Mehrbedarf absorbieren
-        var capE = Math.max(0, basisE2 - usedE2) - result[i].savedEinheit;
-        var capD = Math.max(0, basisD2 - usedD2) - result[i].savedDuenger;
-        // Self-Mehrbedarf (used > basis): der Tab ist selbst überschüssig → kommt zuletzt
-        var selfExcessE = Math.max(0, usedE2 - basisE2);
-        var selfExcessD = Math.max(0, usedD2 - basisD2);
-        var lastEntry2 = t2.entries[t2.entries.length - 1];
-        var ts2 = _parseEntryTime(lastEntry2 ? (lastEntry2.time || 0) : 0);
-        // capacity-positive tabs: group A (sorted by ts DESC → last-filled first)
-        // self-Mehrbedarf tabs: group B (sorted by ts DESC)
-        tabOrder2.push({
-          idx: i, ts: ts2,
-          capE: capE, capD: capD,
-          selfExcessE: selfExcessE, selfExcessD: selfExcessD
-        });
-      }
-      // Sort: tabs mit freier Kapazität zuerst (last-filled first), dann Tabs mit Selbst-Mehrbedarf
-      tabOrder2.sort(function(a, b) {
-        var aHasCap = (a.capE > 0.05 || a.capD > 0.05) ? 1 : 0;
-        var bHasCap = (b.capE > 0.05 || b.capD > 0.05) ? 1 : 0;
-        if (aHasCap !== bHasCap) return bHasCap - aHasCap; // capacity tabs first
-        return b.ts - a.ts; // within group: last-filled first
-      });
-
-      var remExcessE2 = totalExcessE, remExcessD2 = totalExcessD;
-      for (var j2 = 0; j2 < tabOrder2.length && (remExcessE2 > 0.05 || remExcessD2 > 0.05); j2++) {
-        var entry2 = tabOrder2[j2];
-        var idx2 = entry2.idx;
-        var hasCap = (entry2.capE > 0.05 || entry2.capD > 0.05);
-        if (hasCap) {
-          // Capacity positive → absorbiere proportional
-          var takeCapE = Math.min(remExcessE2, entry2.capE);
-          var takeCapD = Math.min(remExcessD2, entry2.capD);
-          if (takeCapE > 0.05) {
-            result[idx2].excessEinheit = takeCapE;
-            remExcessE2 -= takeCapE;
-          }
-          if (takeCapD > 0.05) {
-            result[idx2].excessDuenger = takeCapD;
-            remExcessD2 -= takeCapD;
-          }
-        } else if (entry2.selfExcessE > 0.05 || entry2.selfExcessD > 0.05) {
-          // Tab ist selbst über-befüllt → seediert Mehrbedarf (negativer Carryover)
-          // z.B. wenn Tab IST > SOLL aber andere Tabs keine Kapazität haben
-          // Für jetzt: ignorieren (Test-Scope deckt diesen Fall nicht)
-        }
-      }
-
-      _internal.carryoverCache = result;
-      return result;
-    }
-
-    function invalidateCarryoverCache() {
-      _internal.carryoverCache = null;
-    }
-
-    function getCarryover(tabIndex) {
-      var all = computeAllCarryovers();
-      if (tabIndex >= 0 && tabIndex < all.length) return all[tabIndex];
-      return { savedEinheit: 0, savedDuenger: 0, excessEinheit: 0, excessDuenger: 0 };
-    }
-
-    // --- Tab-Fertig-Check (pure) ---
-
-    // Prüft ob ein Tab "fertig" ist (alle Bedarfe gedeckt).
-    // Berücksichtigt: SOLL-Einheiten, IST-Einheiten, Carryover, bereits verbraucht.
-    //
-    // Verwendet computeAllCarryovers() für Carryover-Werte (wenn tabIndex mitgegeben).
-    // Ohne tabIndex wird Carryover ignoriert (Backward-Compat).
-    // Ist nil-safe (fehlende Felder = 0).
-    function isTabDone(r, tabIndex) {
-      if (!r || !r.entries) return true; // Keine Entries = fertig (kein Bedarf)
-      // Carryover nur berücksichtigen wenn tabIndex mitgegeben
-      var carryover = (tabIndex !== undefined)
-        ? getCarryover(tabIndex)
-        : { savedEinheit: 0, savedDuenger: 0, excessEinheit: 0, excessDuenger: 0 };
-      // IST > 0 ? IST : SOLL (Issue #186)
-      var istE = getTabIstEinheiten(r);
-      var totalE = istE > 0 ? istE : getTabTotalEinheiten(r);
-      var usedE = getTabUsedEinheiten(r);
-      // Remaining = Need - Carryover.Saved + Carryover.Excess
-      // Need = max(0, totalE - usedE)
-      var needE = Math.max(0, totalE - usedE);
-      var remainingE = needE - carryover.savedEinheit + carryover.excessEinheit;
-      if (remainingE > 0.05) return false;
-
-      var istD = getTabIstDuenger(r);
-      var totalD = istD > 0 ? istD : getTabTotalDuenger(r);
-      var usedD = getTabUsedDuenger(r);
-      var needD = Math.max(0, totalD - usedD);
-      var remainingD = needD - carryover.savedDuenger + carryover.excessDuenger;
-      return remainingD <= 0.05;
-    }
-
-    // --- Hilfsfunktionen für Entry-Time ---
-
-    // Zeitstempel des letzten Eintrags in einem Tab (für Sortierung).
-    function getTabLastEntryTime(r) {
-      if (!r || !r.entries || r.entries.length === 0) return 0;
-      var last = r.entries[r.entries.length - 1];
-      return last ? (last.time || 0) : 0;
-    }
-
-    // Liefert die IST-Hektar-Summe für einen Tab.
-    // Priorität: Direktes r.istHektar (vom Input-Feld) > Summe aus Entries.
-    // Issue #186: Das Input-Feld #ist_hektar schreibt via onInputIstHektar in
-    // r.istHektar. Wenn das gesetzt ist, IST es die maßgebliche Quelle — nicht
-    // die Summe aus entries[].istHektar (die nur ein Legacy-Snapshot ist).
-    function getTabIstHektar(r) {
-      if (!r) return 0;
-      if (r.istHektar && r.istHektar > 0) return r.istHektar;
-      if (!r.entries) return 0;
-      return r.entries.reduce(function(s, e) { return s + (e.istHektar || 0); }, 0);
-    }
-
-    // Liefert den nächsten Zeitstempel (für Sortierung).
+// Liefert den nächsten Zeitstempel (für Sortierung).
 function getTabNextTime(r) {
-      if (!r || !r.entries || r.entries.length === 0) return Date.now();
-      var last = r.entries[r.entries.length - 1];
-      return last ? Math.max(Date.now(), (last.time || 0) + 1) : Date.now();
-    }
+  if (!r || !r.entries || r.entries.length === 0) return Date.now();
+  var last = r.entries[r.entries.length - 1];
+  return last ? Math.max(Date.now(), (last.time || 0) + 1) : Date.now();
+}
 
-    // --- UI Wrappers (bridge between handlers/rendering and pure calculations) ---
-    // These use getActiveReiter() so they are NOT pure — they live in ui-handlers.js
+// --- UI Wrappers (bridge between handlers/rendering and pure calculations) ---
+// These use getActiveReiter() so they are NOT pure — they live in ui-handlers.js
 
-    // Körner gesamt für Tab r (inkl. Fahrgassen-Korrektur)
-    // Formel: hektar × koerner × computeFahrgassenFaktor(breite)
-    function getTabKornerGesamt(r) {
-      if (!r || !r.hektar || !r.koerner) return 0;
-      var k = r.hektar * r.koerner;
-      var fgEnabled = (r.fahrgassenEnabled !== undefined) ? r.fahrgassenEnabled : state.fahrgassenEnabled;
-      var fgBreite = (r.fahrgassenBreite !== undefined) ? r.fahrgassenBreite : state.fahrgassenBreite;
-      var faktor = 1;
-      if (fgEnabled && fgBreite > 0) {
-        faktor = computeFahrgassenFaktor(fgBreite);
-      }
-      return k * faktor;
-    }
+// Körner gesamt für Tab r (inkl. Fahrgassen-Korrektur)
+// Formel: hektar × koerner × computeFahrgassenFaktor(breite)
+function getTabKornerGesamt(r) {
+  if (!r || !r.hektar || !r.koerner) return 0;
+  var k = r.hektar * r.koerner;
+  var fgEnabled = (r.fahrgassenEnabled !== undefined) ? r.fahrgassenEnabled : state.fahrgassenEnabled;
+  var fgBreite = (r.fahrgassenBreite !== undefined) ? r.fahrgassenBreite : state.fahrgassenBreite;
+  var faktor = 1;
+  if (fgEnabled && fgBreite > 0) {
+    faktor = computeFahrgassenFaktor(fgBreite);
+  }
+  return k * faktor;
+}
 
-    // Berechnet Verbrauchsraten (Einheiten/ha, Dünger/ha) für einen bestimmten Tab.
-    // (portiert aus Inline-Code Z. 2349-2359)
-    // Argumente:
-    //   tabIdx — Index in state.reiter
-    // Rückgabe: { unitsPerHa, duengerPerHa }
-    function getTabRates(tabIdx) {
-      var r = state.reiter[tabIdx];
-      if (!r) return { unitsPerHa: 0, duengerPerHa: 0 };
-      var fgEnabled = (r.fahrgassenEnabled !== undefined) ? r.fahrgassenEnabled : state.fahrgassenEnabled;
-      var fgBreite = (r.fahrgassenBreite !== undefined) ? r.fahrgassenBreite : state.fahrgassenBreite;
-      var fgFactor = 1;
-      if (fgEnabled && fgBreite > 0) {
-        fgFactor = computeFahrgassenFaktor(fgBreite);
-      }
-      var unitsPerHa = r.koerner * fgFactor / state.koernerProEinheit;
-      var duengerPerHa = r.duenger || 0;
-      return { unitsPerHa: unitsPerHa, duengerPerHa: duengerPerHa };
-    }
+// Berechnet Verbrauchsraten (Einheiten/ha, Dünger/ha) für einen bestimmten Tab.
+// (portiert aus Inline-Code Z. 2349-2359)
+// Argumente:
+//   tabIdx — Index in state.reiter
+// Rückgabe: { unitsPerHa, duengerPerHa }
+function getTabRates(tabIdx) {
+  var r = state.reiter[tabIdx];
+  if (!r) return { unitsPerHa: 0, duengerPerHa: 0 };
+  var fgEnabled = (r.fahrgassenEnabled !== undefined) ? r.fahrgassenEnabled : state.fahrgassenEnabled;
+  var fgBreite = (r.fahrgassenBreite !== undefined) ? r.fahrgassenBreite : state.fahrgassenBreite;
+  var fgFactor = 1;
+  if (fgEnabled && fgBreite > 0) {
+    fgFactor = computeFahrgassenFaktor(fgBreite);
+  }
+  var unitsPerHa = r.koerner * fgFactor / state.koernerProEinheit;
+  var duengerPerHa = r.duenger || 0;
+  return { unitsPerHa: unitsPerHa, duengerPerHa: duengerPerHa };
+}

--- a/public/js/state.js
+++ b/public/js/state.js
@@ -1,396 +1,396 @@
 // ============================================================================
-    // STATE MANAGEMENT — Zentrales state-Objekt und Persistenz
-    //
-    // state: Single Source of Truth für die gesamte App.
-    // Wird nach jeder Änderung via saveState() in localStorage geschrieben.
-    //
-    // Struktur:
-    //   reiter[]       — Array von Feld-Tabs (jeder Tab = ein Feld)
-    //   activeReiter   — Index des aktuell ausgewählten Tabs
-    //   activeView     — 'protokoll' = Drill-Protokoll-Ansicht, sonst null
-    //   fahrgassen*    — Fahrgassen-Korrektur
-    //   einheitGroesse* — Anpassung der Körner-pro-Einheit
-    //   machineLog[]   — Globales Maschinen-Protokoll
-    // ============================================================================
+// STATE MANAGEMENT — Zentrales state-Objekt und Persistenz
+//
+// state: Single Source of Truth für die gesamte App.
+// Wird nach jeder Änderung via saveState() in localStorage geschrieben.
+//
+// Struktur:
+//   reiter[]       — Array von Feld-Tabs (jeder Tab = ein Feld)
+//   activeReiter   — Index des aktuell ausgewählten Tabs
+//   activeView     — 'protokoll' = Drill-Protokoll-Ansicht, sonst null
+//   fahrgassen*    — Fahrgassen-Korrektur
+//   einheitGroesse* — Anpassung der Körner-pro-Einheit
+//   machineLog[]   — Globales Maschinen-Protokoll
+// ============================================================================
 
-    var state = {
-      reiter: [{
-        name:       'Tab 1',
-        hektar:     0,
-        istHektar:  0,
-        koerner:    0,
-        duenger:    0,
-        entries:    []
-      }],
-      activeReiter:   0,
-      activeView:     null,
-      fahrgassenEnabled: false,
-      fahrgassenBreite:   0,
-      einheitGroesseEnabled: false,
-      koernerProEinheit:  50000,
-      machineLog:    [],
-      drillPriorities: {},
-      iosInstallHintShown: false
-    };
+var state = {
+  reiter: [{
+    name:       'Tab 1',
+    hektar:     0,
+    istHektar:  0,
+    koerner:    0,
+    duenger:    0,
+    entries:    []
+  }],
+  activeReiter:   0,
+  activeView:     null,
+  fahrgassenEnabled: false,
+  fahrgassenBreite:   0,
+  einheitGroesseEnabled: false,
+  koernerProEinheit:  50000,
+  machineLog:    [],
+  drillPriorities: {},
+  iosInstallHintShown: false
+};
 
-    // --- Persistenz ---
+// --- Persistenz ---
 
-    // --- localStorage-Key-Migration (Issue #235) ---
-    // Frühere localStorage-Keys hießen `mais_rechner*`. Repo und Domain heißen
-    // `agrar-rechner`, daher wurden alle Keys auf `agrar_rechner*` umgestellt.
-    // Beim ersten Start lesen wir die alten Keys, schreiben den Wert in den
-    // neuen Key (falls dort noch nichts liegt) und löschen den alten Key.
-    // Migration läuft synchron, bevor loadState()/saveState() aufgerufen werden.
-    var LEGACY_KEY_MAP = {
-      'mais_rechner':              'agrar_rechner',
-      'mais_rechner_theme':        'theme', // bereits in Migration 3→4 erledigt — hier nur Defensiv-Remap
-      'mais_rechner_ios_install_seen': 'agrar_rechner_ios_install_seen',
-      'mais_rechner_version_seen': 'agrar_rechner_version_seen'
-    };
+// --- localStorage-Key-Migration (Issue #235) ---
+// Frühere localStorage-Keys hießen `mais_rechner*`. Repo und Domain heißen
+// `agrar-rechner`, daher wurden alle Keys auf `agrar_rechner*` umgestellt.
+// Beim ersten Start lesen wir die alten Keys, schreiben den Wert in den
+// neuen Key (falls dort noch nichts liegt) und löschen den alten Key.
+// Migration läuft synchron, bevor loadState()/saveState() aufgerufen werden.
+var LEGACY_KEY_MAP = {
+  'mais_rechner':              'agrar_rechner',
+  'mais_rechner_theme':        'theme', // bereits in Migration 3→4 erledigt — hier nur Defensiv-Remap
+  'mais_rechner_ios_install_seen': 'agrar_rechner_ios_install_seen',
+  'mais_rechner_version_seen': 'agrar_rechner_version_seen'
+};
 
-    function migrateLegacyStorageKeys() {
+function migrateLegacyStorageKeys() {
+  try {
+    for (var oldKey in LEGACY_KEY_MAP) {
+      if (!Object.prototype.hasOwnProperty.call(LEGACY_KEY_MAP, oldKey)) continue;
+      var newKey = LEGACY_KEY_MAP[oldKey];
+      var oldVal;
+      try { oldVal = localStorage.getItem(oldKey); } catch(e) { continue; }
+      if (oldVal === null) continue;
       try {
-        for (var oldKey in LEGACY_KEY_MAP) {
-          if (!Object.prototype.hasOwnProperty.call(LEGACY_KEY_MAP, oldKey)) continue;
-          var newKey = LEGACY_KEY_MAP[oldKey];
-          var oldVal;
-          try { oldVal = localStorage.getItem(oldKey); } catch(e) { continue; }
-          if (oldVal === null) continue;
-          try {
-            if (localStorage.getItem(newKey) === null) {
-              localStorage.setItem(newKey, oldVal);
-            }
-          } catch(e) { /* write-fehler → nicht kritisch */ }
-          try { localStorage.removeItem(oldKey); } catch(e) { /* egal */ }
+        if (localStorage.getItem(newKey) === null) {
+          localStorage.setItem(newKey, oldVal);
         }
-      } catch(e) {
-        // localStorage komplett nicht verfügbar — silently skip
+      } catch(e) { /* write-fehler → nicht kritisch */ }
+      try { localStorage.removeItem(oldKey); } catch(e) { /* egal */ }
+    }
+  } catch(e) {
+    // localStorage komplett nicht verfügbar — silently skip
+  }
+}
+
+// Migration frühestmöglich ausführen — vor dem ersten saveState()/loadState().
+migrateLegacyStorageKeys();
+
+function saveState() {
+  invalidateCarryoverCache();
+  try {
+    localStorage.setItem('agrar_rechner', JSON.stringify(state));
+  } catch(e) {
+    if (e.name === 'QuotaExceededError' || e.name === 'NS_ERROR_FILE_CANT_CREATE') {
+      showSaveError();
+    }
+    console.error('saveState failed:', e);
+  }
+}
+
+function showSaveError() {
+  var el = document.getElementById('save_error_banner');
+  if (el) el.style.display = 'flex';
+}
+
+function dismissSaveError() {
+  var el = document.getElementById('save_error_banner');
+  if (el) el.style.display = 'none';
+}
+
+// --- Schema-Validierung (Issue #237) ---
+// Verteidigt loadState() gegen manipulierten localStorage-Inhalt (XSS auf
+// gleicher Domain, andere App mit gleichem Origin, Man-in-the-Middle bei
+// unsicherer Konfiguration). Stillschweigendes Verwerfen: ungültige Felder
+// werden auf sinnvolle Defaults zurückgesetzt, sodass die App lauffähig
+// bleibt statt zu crashen.
+//
+// Erlaubte Keys (Whitelist) — alles andere wird im Reviver verworfen.
+// Hinzufügen neuer Felder erfordert eine bewusste Entscheidung.
+var ALLOWED_TOP_KEYS = [
+  'reiter', 'activeReiter', 'activeView',
+  'fahrgassenEnabled', 'fahrgassenBreite',
+  'einheitGroesseEnabled', 'koernerProEinheit',
+  'machineLog', 'drillPriorities', 'iosInstallHintShown',
+  '_lv',
+  // Legacy-Keys (nur für Migration 0→1 lesend toleriert)
+  'hektar', 'istHektar', 'koerner', 'duenger', 'entries',
+  'name'
+];
+var ALLOWED_TAB_KEYS = [
+  'name', 'hektar', 'istHektar', 'koerner', 'duenger',
+  'entries', 'fahrgassenEnabled', 'fahrgassenBreite'
+];
+var ALLOWED_ENTRY_KEYS = [
+  'time', 'einheit', 'duenger', 'hektar', 'istHektar',
+  'koerner', 'duengerRate', 'mlIdx'
+];
+var ALLOWED_MACHINE_LOG_KEYS = [
+  'time', 'einheit', 'duenger', 'hektar', 'istHektar',
+  'koerner', 'duengerRate'
+];
+
+function isPlainObject(v) {
+  // Schließt null, Arrays, Klassen-Instanzen und speziell
+  // Objekte mit abweichendem Prototypen aus. Damit ist der einzige
+  // Weg, einen Plain Object zu erzeugen, die Literalschreibweise —
+  // also auch kein `Object.create(null)` mit Magic-Proto-Keys.
+  if (v === null || typeof v !== 'object') return false;
+  if (Array.isArray(v)) return false;
+  var proto = Object.getPrototypeOf(v);
+  return proto === Object.prototype || proto === null;
+}
+
+function sanitizeNumber(v, fallback) {
+  // Akzeptiert echte Number und number-konvertierbare Strings,
+  // verwirft NaN/Infinity/Objekte. Null/Undefined → fallback.
+  if (v === null || v === undefined) return fallback;
+  if (typeof v === 'number') return isFinite(v) ? v : fallback;
+  if (typeof v === 'string' && v.trim() !== '') {
+    var n = Number(v);
+    return isFinite(n) ? n : fallback;
+  }
+  return fallback;
+}
+
+function sanitizeString(v, fallback, maxLen) {
+  if (typeof v !== 'string') return fallback;
+  if (maxLen && v.length > maxLen) v = v.slice(0, maxLen);
+  return v;
+}
+
+function sanitizeBoolean(v, fallback) {
+  if (typeof v === 'boolean') return v;
+  return fallback;
+}
+
+function sanitizeEntry(raw) {
+  // Eintrag: Plain Object, nur erlaubte Keys, jede Property typgeprüft.
+  // Unbekannte Keys und falsche Typen → Default. Verwirft auch
+  // `__proto__`/`constructor`/`prototype` über den Reviver.
+  if (!isPlainObject(raw)) return null;
+  var out = {};
+  out.time        = sanitizeNumber(raw.time, 0);
+  out.einheit     = sanitizeNumber(raw.einheit, 0);
+  out.duenger     = sanitizeNumber(raw.duenger, 0);
+  out.hektar      = sanitizeNumber(raw.hektar, 0);
+  out.istHektar   = sanitizeNumber(raw.istHektar, 0);
+  out.koerner     = sanitizeNumber(raw.koerner, 0);
+  out.duengerRate = sanitizeNumber(raw.duengerRate, 0);
+  if (raw.mlIdx !== undefined) {
+    var ml = sanitizeNumber(raw.mlIdx, -1);
+    out.mlIdx = ml >= 0 ? Math.floor(ml) : -1;
+  }
+  return out;
+}
+
+function sanitizeMachineLogEntry(raw) {
+  if (!isPlainObject(raw)) return null;
+  var out = {};
+  out.time        = sanitizeNumber(raw.time, 0);
+  out.einheit     = sanitizeNumber(raw.einheit, 0);
+  out.duenger     = sanitizeNumber(raw.duenger, 0);
+  out.hektar      = sanitizeNumber(raw.hektar, 0);
+  out.istHektar   = sanitizeNumber(raw.istHektar, 0);
+  out.koerner     = sanitizeNumber(raw.koerner, 0);
+  out.duengerRate = sanitizeNumber(raw.duengerRate, 0);
+  return out;
+}
+
+function sanitizeTab(raw) {
+  if (!isPlainObject(raw)) {
+    return { name: 'Tab', hektar: 0, istHektar: 0, koerner: 0, duenger: 0, entries: [] };
+  }
+  var tab = {
+    name:      sanitizeString(raw.name, 'Tab', 64),
+    hektar:    sanitizeNumber(raw.hektar, 0),
+    istHektar: sanitizeNumber(raw.istHektar, 0),
+    koerner:   sanitizeNumber(raw.koerner, 0),
+    duenger:   sanitizeNumber(raw.duenger, 0),
+    entries:   []
+  };
+  // Per-Tab-Overrides (optional, mit globalen Defaults)
+  if (raw.fahrgassenEnabled !== undefined) {
+    tab.fahrgassenEnabled = sanitizeBoolean(raw.fahrgassenEnabled, false);
+  }
+  if (raw.fahrgassenBreite !== undefined) {
+    tab.fahrgassenBreite = sanitizeNumber(raw.fahrgassenBreite, 0);
+  }
+  if (Array.isArray(raw.entries)) {
+    for (var i = 0; i < raw.entries.length; i++) {
+      var e = sanitizeEntry(raw.entries[i]);
+      if (e !== null) tab.entries.push(e);
+    }
+  }
+  return tab;
+}
+
+function jsonReviver(key, value) {
+  // Defense-in-Depth gegen Prototype Pollution: blockiere die drei
+  // gefährlichen Keys auf jeder Verschachtelungsebene. JSON.parse
+  // ignoriert __proto__ zwar weitgehend, aber konsistentes Whitelisting
+  // ist robust und dokumentiert die erlaubte Form.
+  if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+    return undefined; // Schlüssel wird aus dem Result entfernt
+  }
+  return value;
+}
+
+function parsePersistedState(raw) {
+  // Wrapper: nutzt jsonReviver, um gefährliche Keys auf jeder Ebene
+  // abzufangen, BEVOR die nachfolgende Sanitisierung läuft.
+  return JSON.parse(raw, jsonReviver);
+}
+
+function loadState() {
+  try {
+    var saved = localStorage.getItem('agrar_rechner');
+    if (!saved) return false;
+    var data = parsePersistedState(saved);
+    if (!isPlainObject(data)) return false;
+    var originalLv = data._lv || 0;
+    var lv = originalLv;
+    // Migration 0→1: Einzelne Felder → Tab-Array
+    if (!data.reiter && (data.hektar !== undefined || data.koerner !== undefined)) {
+      data = { reiter: [{ name: 'Tab 1', hektar: data.hektar || 0, istHektar: data.istHektar || 0, koerner: data.koerner || 0, duenger: data.duenger || 0, entries: data.entries || [] }], activeReiter: 0, activeView: null, fahrgassenEnabled: false, fahrgassenBreite: 0, einheitGroesseEnabled: false, koernerProEinheit: 50000, machineLog: data.machineLog || [], drillPriorities: {}, iosInstallHintShown: false, _lv: 1 };
+      lv = 1;
+    }
+    // Migration 1→2: Globale entries → per-Tab entries
+    if (lv < 2 && data.entries && Array.isArray(data.entries)) {
+      // Bestehende tab-entries nicht überschreiben (Issue #266 / Migration-Korrektur)
+      if (data.reiter && data.reiter[0] && (!data.reiter[0].entries || data.reiter[0].entries.length === 0)) {
+        data.reiter[0].entries = data.entries;
+      }
+      delete data.entries;
+      lv = 2;
+    }
+    // Migration 2→3: Fehlende Felder
+    if (lv < 3) {
+      if (!data.drillPriorities) data.drillPriorities = {};
+      if (!data.iosInstallHintShown) data.iosInstallHintShown = false;
+      if (!data.machineLog) data.machineLog = [];
+      lv = 3;
+    }
+    // Migration 3→4: Theme-Key vereinheitlichen, neue Defaults
+    if (lv < 4) {
+      // Theme: alten Key 'mais_rechner_theme' → neuen Key 'theme'
+      // (durch migrateLegacyStorageKeys() oben meist schon erledigt —
+      //  hier nur Defensiv-Fallback für direkt migrierte Snapshots)
+      try {
+        var oldTheme = localStorage.getItem('mais_rechner_theme');
+        if (oldTheme && !localStorage.getItem('theme')) {
+          localStorage.setItem('theme', oldTheme);
+        }
+        if (oldTheme) localStorage.removeItem('mais_rechner_theme');
+      } catch(e) {}
+      // koernerProEinheit Default (falls noch aus alter Migration fehlend)
+      if (data.koernerProEinheit === undefined) data.koernerProEinheit = 50000;
+      // einheitGroesseEnabled Default
+      if (data.einheitGroesseEnabled === undefined) data.einheitGroesseEnabled = false;
+      // drillPriorities Default
+      if (!data.drillPriorities) data.drillPriorities = {};
+    }
+    // Validate und übernehmen — Schema-strict ab _lv=4
+    if (!Array.isArray(data.reiter) || data.reiter.length === 0) return false;
+    var sanitizedReiter = [];
+    for (var i = 0; i < data.reiter.length; i++) {
+      sanitizedReiter.push(sanitizeTab(data.reiter[i]));
+    }
+    // Globale Felder typgeprüft + Defaults
+    var activeReiterRaw = sanitizeNumber(data.activeReiter, 0);
+    data.activeReiter = activeReiterRaw >= 0 && activeReiterRaw < sanitizedReiter.length
+      ? Math.floor(activeReiterRaw)
+      : 0;
+    data.activeView = (data.activeView === 'protokoll') ? 'protokoll' : null;
+    if (data.fahrgassenEnabled === undefined) data.fahrgassenEnabled = false;
+    if (data.fahrgassenBreite === undefined) data.fahrgassenBreite = 0;
+    data.fahrgassenEnabled = sanitizeBoolean(data.fahrgassenEnabled, false);
+    data.fahrgassenBreite = sanitizeNumber(data.fahrgassenBreite, 0);
+    if (data.einheitGroesseEnabled === undefined) data.einheitGroesseEnabled = false;
+    data.einheitGroesseEnabled = sanitizeBoolean(data.einheitGroesseEnabled, false);
+    if (data.koernerProEinheit === undefined) data.koernerProEinheit = 50000;
+    data.koernerProEinheit = sanitizeNumber(data.koernerProEinheit, 50000);
+    // machineLog sanitizen
+    var machineLog = [];
+    if (Array.isArray(data.machineLog)) {
+      for (var mi = 0; mi < data.machineLog.length; mi++) {
+        var me = sanitizeMachineLogEntry(data.machineLog[mi]);
+        if (me !== null) machineLog.push(me);
       }
     }
-
-    // Migration frühestmöglich ausführen — vor dem ersten saveState()/loadState().
-    migrateLegacyStorageKeys();
-
-    function saveState() {
-      invalidateCarryoverCache();
+    data.machineLog = machineLog;
+    // drillPriorities muss Plain Object sein
+    if (!isPlainObject(data.drillPriorities)) data.drillPriorities = {};
+    // iosInstallHintShown
+    if (data.iosInstallHintShown === undefined) data.iosInstallHintShown = false;
+    data.iosInstallHintShown = sanitizeBoolean(data.iosInstallHintShown, false);
+    // Final: sanitisiertes reiter einsetzen
+    data.reiter = sanitizedReiter;
+    // Unbekannte Top-Level-Keys strippen (Whitelist)
+    var cleaned = {};
+    for (var ki = 0; ki < ALLOWED_TOP_KEYS.length; ki++) {
+        var k = ALLOWED_TOP_KEYS[ki];
+        if (data[k] !== undefined) cleaned[k] = data[k];
+    }
+    cleaned._lv = 4;
+    data = cleaned;
+    state = data;
+    // Migration-Persistenz: Wenn die Daten nicht bereits _lv=4 waren,
+    // schreibe den migrierten Snapshot einmalig zurück, damit nachfolgende
+    // Page-Loads die Migration überspringen können.
+    if (originalLv < 4) {
       try {
         localStorage.setItem('agrar_rechner', JSON.stringify(state));
       } catch(e) {
-        if (e.name === 'QuotaExceededError' || e.name === 'NS_ERROR_FILE_CANT_CREATE') {
-          showSaveError();
-        }
-        console.error('saveState failed:', e);
+        // Nicht kritisch — Migration war erfolgreich im Memory, beim
+        // nächsten Load wird sie einfach erneut durchgeführt (idempotent).
+        console.warn('loadState: migrated snapshot could not be persisted:', e);
       }
     }
+    return true;
+  } catch(e) {
+    console.error('loadState failed:', e);
+    return false;
+  }
+}
 
-    function showSaveError() {
-      var el = document.getElementById('save_error_banner');
-      if (el) el.style.display = 'flex';
-    }
+// --- iOS Safari Detection (portiert aus Inline-Code Z. 1490-1492) ---
+// Wird einmalig beim Modul-Load ausgewertet; Tests können isIOS/isStandalone
+// per window.isIOS = true überschreiben.
+var isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
+var isStandalone = window.navigator.standalone === true;
 
-    function dismissSaveError() {
-      var el = document.getElementById('save_error_banner');
-      if (el) el.style.display = 'none';
-    }
+// --- iOS Install Hint (portiert aus Inline-Code Z. 1494-1507) ---
+// Zeigt einmalig einen Hinweis zum Installieren der PWA auf iOS Safari.
+// Nur auf iOS/Safari, nur wenn noch nicht installiert und noch nicht dismissed.
+function maybeShowIosInstallHint() {
+  var hintSeen = null;
+  try { hintSeen = localStorage.getItem('agrar_rechner_ios_install_seen'); } catch(e) {}
+  if (!isIOS || isStandalone || hintSeen) return;
+  var banner = document.getElementById('ios_install_banner');
+  if (banner) banner.classList.add('show');
+}
+function dismissIosInstallHint() {
+  try { localStorage.setItem('agrar_rechner_ios_install_seen', '1'); } catch(e) {}
+  var banner = document.getElementById('ios_install_banner');
+  if (banner) banner.classList.remove('show');
+}
 
-    // --- Schema-Validierung (Issue #237) ---
-    // Verteidigt loadState() gegen manipulierten localStorage-Inhalt (XSS auf
-    // gleicher Domain, andere App mit gleichem Origin, Man-in-the-Middle bei
-    // unsicherer Konfiguration). Stillschweigendes Verwerfen: ungültige Felder
-    // werden auf sinnvolle Defaults zurückgesetzt, sodass die App lauffähig
-    // bleibt statt zu crashen.
-    //
-    // Erlaubte Keys (Whitelist) — alles andere wird im Reviver verworfen.
-    // Hinzufügen neuer Felder erfordert eine bewusste Entscheidung.
-    var ALLOWED_TOP_KEYS = [
-      'reiter', 'activeReiter', 'activeView',
-      'fahrgassenEnabled', 'fahrgassenBreite',
-      'einheitGroesseEnabled', 'koernerProEinheit',
-      'machineLog', 'drillPriorities', 'iosInstallHintShown',
-      '_lv',
-      // Legacy-Keys (nur für Migration 0→1 lesend toleriert)
-      'hektar', 'istHektar', 'koerner', 'duenger', 'entries',
-      'name'
-    ];
-    var ALLOWED_TAB_KEYS = [
-      'name', 'hektar', 'istHektar', 'koerner', 'duenger',
-      'entries', 'fahrgassenEnabled', 'fahrgassenBreite'
-    ];
-    var ALLOWED_ENTRY_KEYS = [
-      'time', 'einheit', 'duenger', 'hektar', 'istHektar',
-      'koerner', 'duengerRate', 'mlIdx'
-    ];
-    var ALLOWED_MACHINE_LOG_KEYS = [
-      'time', 'einheit', 'duenger', 'hektar', 'istHektar',
-      'koerner', 'duengerRate'
-    ];
-
-    function isPlainObject(v) {
-      // Schließt null, Arrays, Klassen-Instanzen und speziell
-      // Objekte mit abweichendem Prototypen aus. Damit ist der einzige
-      // Weg, einen Plain Object zu erzeugen, die Literalschreibweise —
-      // also auch kein `Object.create(null)` mit Magic-Proto-Keys.
-      if (v === null || typeof v !== 'object') return false;
-      if (Array.isArray(v)) return false;
-      var proto = Object.getPrototypeOf(v);
-      return proto === Object.prototype || proto === null;
-    }
-
-    function sanitizeNumber(v, fallback) {
-      // Akzeptiert echte Number und number-konvertierbare Strings,
-      // verwirft NaN/Infinity/Objekte. Null/Undefined → fallback.
-      if (v === null || v === undefined) return fallback;
-      if (typeof v === 'number') return isFinite(v) ? v : fallback;
-      if (typeof v === 'string' && v.trim() !== '') {
-        var n = Number(v);
-        return isFinite(n) ? n : fallback;
-      }
-      return fallback;
-    }
-
-    function sanitizeString(v, fallback, maxLen) {
-      if (typeof v !== 'string') return fallback;
-      if (maxLen && v.length > maxLen) v = v.slice(0, maxLen);
-      return v;
-    }
-
-    function sanitizeBoolean(v, fallback) {
-      if (typeof v === 'boolean') return v;
-      return fallback;
-    }
-
-    function sanitizeEntry(raw) {
-      // Eintrag: Plain Object, nur erlaubte Keys, jede Property typgeprüft.
-      // Unbekannte Keys und falsche Typen → Default. Verwirft auch
-      // `__proto__`/`constructor`/`prototype` über den Reviver.
-      if (!isPlainObject(raw)) return null;
-      var out = {};
-      out.time        = sanitizeNumber(raw.time, 0);
-      out.einheit     = sanitizeNumber(raw.einheit, 0);
-      out.duenger     = sanitizeNumber(raw.duenger, 0);
-      out.hektar      = sanitizeNumber(raw.hektar, 0);
-      out.istHektar   = sanitizeNumber(raw.istHektar, 0);
-      out.koerner     = sanitizeNumber(raw.koerner, 0);
-      out.duengerRate = sanitizeNumber(raw.duengerRate, 0);
-      if (raw.mlIdx !== undefined) {
-        var ml = sanitizeNumber(raw.mlIdx, -1);
-        out.mlIdx = ml >= 0 ? Math.floor(ml) : -1;
-      }
-      return out;
-    }
-
-    function sanitizeMachineLogEntry(raw) {
-      if (!isPlainObject(raw)) return null;
-      var out = {};
-      out.time        = sanitizeNumber(raw.time, 0);
-      out.einheit     = sanitizeNumber(raw.einheit, 0);
-      out.duenger     = sanitizeNumber(raw.duenger, 0);
-      out.hektar      = sanitizeNumber(raw.hektar, 0);
-      out.istHektar   = sanitizeNumber(raw.istHektar, 0);
-      out.koerner     = sanitizeNumber(raw.koerner, 0);
-      out.duengerRate = sanitizeNumber(raw.duengerRate, 0);
-      return out;
-    }
-
-    function sanitizeTab(raw) {
-      if (!isPlainObject(raw)) {
-        return { name: 'Tab', hektar: 0, istHektar: 0, koerner: 0, duenger: 0, entries: [] };
-      }
-      var tab = {
-        name:      sanitizeString(raw.name, 'Tab', 64),
-        hektar:    sanitizeNumber(raw.hektar, 0),
-        istHektar: sanitizeNumber(raw.istHektar, 0),
-        koerner:   sanitizeNumber(raw.koerner, 0),
-        duenger:   sanitizeNumber(raw.duenger, 0),
-        entries:   []
-      };
-      // Per-Tab-Overrides (optional, mit globalen Defaults)
-      if (raw.fahrgassenEnabled !== undefined) {
-        tab.fahrgassenEnabled = sanitizeBoolean(raw.fahrgassenEnabled, false);
-      }
-      if (raw.fahrgassenBreite !== undefined) {
-        tab.fahrgassenBreite = sanitizeNumber(raw.fahrgassenBreite, 0);
-      }
-      if (Array.isArray(raw.entries)) {
-        for (var i = 0; i < raw.entries.length; i++) {
-          var e = sanitizeEntry(raw.entries[i]);
-          if (e !== null) tab.entries.push(e);
-        }
-      }
-      return tab;
-    }
-
-    function jsonReviver(key, value) {
-      // Defense-in-Depth gegen Prototype Pollution: blockiere die drei
-      // gefährlichen Keys auf jeder Verschachtelungsebene. JSON.parse
-      // ignoriert __proto__ zwar weitgehend, aber konsistentes Whitelisting
-      // ist robust und dokumentiert die erlaubte Form.
-      if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
-        return undefined; // Schlüssel wird aus dem Result entfernt
-      }
-      return value;
-    }
-
-    function parsePersistedState(raw) {
-      // Wrapper: nutzt jsonReviver, um gefährliche Keys auf jeder Ebene
-      // abzufangen, BEVOR die nachfolgende Sanitisierung läuft.
-      return JSON.parse(raw, jsonReviver);
-    }
-
-    function loadState() {
-      try {
-        var saved = localStorage.getItem('agrar_rechner');
-        if (!saved) return false;
-        var data = parsePersistedState(saved);
-        if (!isPlainObject(data)) return false;
-        var originalLv = data._lv || 0;
-        var lv = originalLv;
-        // Migration 0→1: Einzelne Felder → Tab-Array
-        if (!data.reiter && (data.hektar !== undefined || data.koerner !== undefined)) {
-          data = { reiter: [{ name: 'Tab 1', hektar: data.hektar || 0, istHektar: data.istHektar || 0, koerner: data.koerner || 0, duenger: data.duenger || 0, entries: data.entries || [] }], activeReiter: 0, activeView: null, fahrgassenEnabled: false, fahrgassenBreite: 0, einheitGroesseEnabled: false, koernerProEinheit: 50000, machineLog: data.machineLog || [], drillPriorities: {}, iosInstallHintShown: false, _lv: 1 };
-          lv = 1;
-        }
-        // Migration 1→2: Globale entries → per-Tab entries
-        if (lv < 2 && data.entries && Array.isArray(data.entries)) {
-          // Bestehende tab-entries nicht überschreiben (Issue #266 / Migration-Korrektur)
-          if (data.reiter && data.reiter[0] && (!data.reiter[0].entries || data.reiter[0].entries.length === 0)) {
-            data.reiter[0].entries = data.entries;
-          }
-          delete data.entries;
-          lv = 2;
-        }
-        // Migration 2→3: Fehlende Felder
-        if (lv < 3) {
-          if (!data.drillPriorities) data.drillPriorities = {};
-          if (!data.iosInstallHintShown) data.iosInstallHintShown = false;
-          if (!data.machineLog) data.machineLog = [];
-          lv = 3;
-        }
-        // Migration 3→4: Theme-Key vereinheitlichen, neue Defaults
-        if (lv < 4) {
-          // Theme: alten Key 'mais_rechner_theme' → neuen Key 'theme'
-          // (durch migrateLegacyStorageKeys() oben meist schon erledigt —
-          //  hier nur Defensiv-Fallback für direkt migrierte Snapshots)
-          try {
-            var oldTheme = localStorage.getItem('mais_rechner_theme');
-            if (oldTheme && !localStorage.getItem('theme')) {
-              localStorage.setItem('theme', oldTheme);
-            }
-            if (oldTheme) localStorage.removeItem('mais_rechner_theme');
-          } catch(e) {}
-          // koernerProEinheit Default (falls noch aus alter Migration fehlend)
-          if (data.koernerProEinheit === undefined) data.koernerProEinheit = 50000;
-          // einheitGroesseEnabled Default
-          if (data.einheitGroesseEnabled === undefined) data.einheitGroesseEnabled = false;
-          // drillPriorities Default
-          if (!data.drillPriorities) data.drillPriorities = {};
-        }
-        // Validate und übernehmen — Schema-strict ab _lv=4
-        if (!Array.isArray(data.reiter) || data.reiter.length === 0) return false;
-        var sanitizedReiter = [];
-        for (var i = 0; i < data.reiter.length; i++) {
-          sanitizedReiter.push(sanitizeTab(data.reiter[i]));
-        }
-        // Globale Felder typgeprüft + Defaults
-        var activeReiterRaw = sanitizeNumber(data.activeReiter, 0);
-        data.activeReiter = activeReiterRaw >= 0 && activeReiterRaw < sanitizedReiter.length
-          ? Math.floor(activeReiterRaw)
-          : 0;
-        data.activeView = (data.activeView === 'protokoll') ? 'protokoll' : null;
-        if (data.fahrgassenEnabled === undefined) data.fahrgassenEnabled = false;
-        if (data.fahrgassenBreite === undefined) data.fahrgassenBreite = 0;
-        data.fahrgassenEnabled = sanitizeBoolean(data.fahrgassenEnabled, false);
-        data.fahrgassenBreite = sanitizeNumber(data.fahrgassenBreite, 0);
-        if (data.einheitGroesseEnabled === undefined) data.einheitGroesseEnabled = false;
-        data.einheitGroesseEnabled = sanitizeBoolean(data.einheitGroesseEnabled, false);
-        if (data.koernerProEinheit === undefined) data.koernerProEinheit = 50000;
-        data.koernerProEinheit = sanitizeNumber(data.koernerProEinheit, 50000);
-        // machineLog sanitizen
-        var machineLog = [];
-        if (Array.isArray(data.machineLog)) {
-          for (var mi = 0; mi < data.machineLog.length; mi++) {
-            var me = sanitizeMachineLogEntry(data.machineLog[mi]);
-            if (me !== null) machineLog.push(me);
-          }
-        }
-        data.machineLog = machineLog;
-        // drillPriorities muss Plain Object sein
-        if (!isPlainObject(data.drillPriorities)) data.drillPriorities = {};
-        // iosInstallHintShown
-        if (data.iosInstallHintShown === undefined) data.iosInstallHintShown = false;
-        data.iosInstallHintShown = sanitizeBoolean(data.iosInstallHintShown, false);
-        // Final: sanitisiertes reiter einsetzen
-        data.reiter = sanitizedReiter;
-        // Unbekannte Top-Level-Keys strippen (Whitelist)
-        var cleaned = {};
-        for (var ki = 0; ki < ALLOWED_TOP_KEYS.length; ki++) {
-            var k = ALLOWED_TOP_KEYS[ki];
-            if (data[k] !== undefined) cleaned[k] = data[k];
-        }
-        cleaned._lv = 4;
-        data = cleaned;
-        state = data;
-        // Migration-Persistenz: Wenn die Daten nicht bereits _lv=4 waren,
-        // schreibe den migrierten Snapshot einmalig zurück, damit nachfolgende
-        // Page-Loads die Migration überspringen können.
-        if (originalLv < 4) {
-          try {
-            localStorage.setItem('agrar_rechner', JSON.stringify(state));
-          } catch(e) {
-            // Nicht kritisch — Migration war erfolgreich im Memory, beim
-            // nächsten Load wird sie einfach erneut durchgeführt (idempotent).
-            console.warn('loadState: migrated snapshot could not be persisted:', e);
-          }
-        }
-        return true;
-      } catch(e) {
-        console.error('loadState failed:', e);
-        return false;
-      }
-    }
-
-    // --- iOS Safari Detection (portiert aus Inline-Code Z. 1490-1492) ---
-    // Wird einmalig beim Modul-Load ausgewertet; Tests können isIOS/isStandalone
-    // per window.isIOS = true überschreiben.
-    var isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
-    var isStandalone = window.navigator.standalone === true;
-
-    // --- iOS Install Hint (portiert aus Inline-Code Z. 1494-1507) ---
-    // Zeigt einmalig einen Hinweis zum Installieren der PWA auf iOS Safari.
-    // Nur auf iOS/Safari, nur wenn noch nicht installiert und noch nicht dismissed.
-    function maybeShowIosInstallHint() {
-      var hintSeen = null;
-      try { hintSeen = localStorage.getItem('agrar_rechner_ios_install_seen'); } catch(e) {}
-      if (!isIOS || isStandalone || hintSeen) return;
-      var banner = document.getElementById('ios_install_banner');
-      if (banner) banner.classList.add('show');
-    }
-    function dismissIosInstallHint() {
-      try { localStorage.setItem('agrar_rechner_ios_install_seen', '1'); } catch(e) {}
-      var banner = document.getElementById('ios_install_banner');
-      if (banner) banner.classList.remove('show');
-    }
-
-    // --- "What's New" Update Banner (portiert aus Inline-Code Z. 1509-1531) ---
-    // Zeigt einmalig einen Hinweis nach App-Updates (neue SW-Version).
-    // currentVersion muss bei jedem Release manuell aktualisiert werden.
-    // (APP_VERSION + APP_BUILD_DATE sind in main.js definiert.)
-    var UPDATE_CHANGELOG = 'Erste Veröffentlichung der App.';
-    function maybeShowUpdateHint() {
-      var seenVersion = null;
-      try { seenVersion = localStorage.getItem('agrar_rechner_version_seen'); } catch(e) {}
-      if (seenVersion === APP_VERSION) return;
-      var banner = document.getElementById('update_banner');
-      var verEl = document.getElementById('update_version');
-      var changelogEl = document.getElementById('update_changelog');
-      if (banner) {
-        if (verEl) verEl.textContent = APP_VERSION;
-        if (changelogEl) changelogEl.textContent = UPDATE_CHANGELOG;
-        banner.classList.add('show');
-      }
-    }
-    function dismissUpdateHint() {
-      try { localStorage.setItem('agrar_rechner_version_seen', APP_VERSION); } catch(e) {}
-      var banner = document.getElementById('update_banner');
-      if (banner) banner.classList.remove('show');
-    }
+// --- "What's New" Update Banner (portiert aus Inline-Code Z. 1509-1531) ---
+// Zeigt einmalig einen Hinweis nach App-Updates (neue SW-Version).
+// currentVersion muss bei jedem Release manuell aktualisiert werden.
+// (APP_VERSION + APP_BUILD_DATE sind in main.js definiert.)
+var UPDATE_CHANGELOG = 'Erste Veröffentlichung der App.';
+function maybeShowUpdateHint() {
+  var seenVersion = null;
+  try { seenVersion = localStorage.getItem('agrar_rechner_version_seen'); } catch(e) {}
+  if (seenVersion === APP_VERSION) return;
+  var banner = document.getElementById('update_banner');
+  var verEl = document.getElementById('update_version');
+  var changelogEl = document.getElementById('update_changelog');
+  if (banner) {
+    if (verEl) verEl.textContent = APP_VERSION;
+    if (changelogEl) changelogEl.textContent = UPDATE_CHANGELOG;
+    banner.classList.add('show');
+  }
+}
+function dismissUpdateHint() {
+  try { localStorage.setItem('agrar_rechner_version_seen', APP_VERSION); } catch(e) {}
+  var banner = document.getElementById('update_banner');
+  if (banner) banner.classList.remove('show');
+}


### PR DESCRIPTION
## Summary

Entfernt die 4-Space-Extra-Einrückung in `public/js/state.js` und `public/js/calculations.js`, die als Artefakt aus der Extraktion aus dem ursprünglichen inline-`<script>`-Block erhalten geblieben war.

Vorher: Top-Level-Code begann in Spalte 4 statt Spalte 0.  
Nachher: Top-Level-Code beginnt in Spalte 0, .editorconfig (4 Spaces) wird konsistent erfüllt.

## Änderungen

- `public/js/state.js`: 386 / 396 Zeilen dedented (eine Header-Kommentarzeile war bereits in Spalte 0)
- `public/js/calculations.js`: 386 / 421 Zeilen dedented (Header-Kommentar und die Funktion `getTabNextTime` waren bereits in Spalte 0; ihr Body bleibt bei 2 Spaces, das ist eine bestehende Inkonsistenz, die nicht zu #275 gehört)

Keine semantischen Änderungen — nur Whitespace.

## Verifikation

```
$ pnpm lint
$ eslint public/js/ tests/
(exit 0)

$ pnpm test
 Test Files  43 passed (43)
      Tests  782 passed (782)
   Duration  54.89s
```

## Methode

`sed -i 's/^    //'` entfernt die ersten 4 Spaces jeder Zeile. Vor dem Lauf verifiziert, dass alle Non-Blank-Zeilen mit 4+ Spaces beginnen (also Vielfache von 4 als Top-Level-Indent), und dass das Diff symmetrisch ist (+772 / -772).

Closes #275
