### PR TITLE
fix(#278): window.AppGlobals namespace object — re-enable no-undef lint (306 → 0 errors)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -120,12 +120,12 @@ export default [
             // `state`), die in legacy-Dateien nicht importiert werden — diese
             // Regel war der Hauptverursacher der 348 Errors.
             //
-            // Re-enabled per-file für `tests/` weiter unten (Issue #233
-            // Follow-up, Review-Kommentar t_7215b1de #25): Tests verwenden
-            // bereits ESM `import`, profitieren also von `no-undef` ohne
-            // Refactor-Aufwand. 306 Errors verbleiben in public/js/ bis
-            // Phase 3+ (Modul-Refactor in ESM-`import`-Form).
-            "no-undef": "off",
+            // Re-enabled per-file für `tests/` und `public/js/`. Tests
+            // verwenden bereits ESM `import`, public/js/ migriert nach
+            // ADR-001 (Issue #278) auf das AppGlobals-Namespace-Objekt —
+            // beide profitieren also von `no-undef` ohne Refactor-Aufwand.
+            // Stand 2026-06-15 (fix #278): 0 Errors in beiden Trees.
+            // "no-undef": "off",
             // Bestehender Code deklariert Schleifen-Variablen in
             // aufeinanderfolgenden Blöcken mehrfach — typisches Legacy-Pattern.
             "no-redeclare": "off",
@@ -146,7 +146,26 @@ export default [
             // Re-enabled no-undef für Tests: sie verwenden ESM `import`,
             // also profitieren sie von der Regel ohne Refactor. 0 Errors
             // verifiziert (Stand: 2026-06-08, t_ddd81e3a). public/js/*
-            // bleibt absichtlich aus, siehe Block oben.
+            // bekommt eine eigene Override-Section weiter unten (ADR-001,
+            // Issue #278).
+            "no-undef": ["error", { typeof: true }],
+        },
+    },
+
+    // public/js/* Override (ADR-001, Issue #278): AppGlobals-Namespace ist
+    // der neue Single-Entry-Point. Konsumenten greifen über
+    // `AppGlobals.state.foo()` zu statt über den impliziten globalen
+    // `state`. `typeof`-Checks bleiben erlaubt (für defensive Initial-
+    // Checks à la `typeof AppGlobals.X === 'function'`). 0 Errors verifiziert
+    // nach Migration der Cross-File-Calls auf `AppGlobals.X`.
+    {
+        files: ["public/js/**/*.js"],
+        languageOptions: {
+            globals: {
+                AppGlobals: "readonly",
+            },
+        },
+        rules: {
             "no-undef": ["error", { typeof: true }],
         },
     },

--- a/public/index.html
+++ b/public/index.html
@@ -264,6 +264,7 @@
     //   main.js: APP_VERSION, Event-Emitter, initTheme
     // ============================================================================
   </script>
+  <script src="js/app-globals.js"></script>
   <script src="js/state.js"></script>
   <script src="js/calculations.js"></script>
   <script src="js/ui-handlers.js"></script>

--- a/public/js/app-globals.js
+++ b/public/js/app-globals.js
@@ -1,0 +1,27 @@
+// ============================================================================
+// APP-GLOBALS — Single namespace for implicit globals (ADR-001, Issue #278)
+//
+// Wird vor allen anderen public/js-Dateien geladen. Jedes weitere Modul
+// registriert am Dateiende seine Exporte via Object.assign(window.AppGlobals, …).
+// Konsumenten greifen dann über AppGlobals.X zu — kein impliziter globaler
+// Scope mehr. Direkter Zugriff auf window.state etc. bleibt absichtlich
+// für HTML-inline-event-handler (`onclick="state.foo()"`) erlaubt, weil
+// HTML-Event-Handler-Attribute im window-Scope evaluiert werden.
+//
+// ESM-Migration bleibt hinter konkreten Triggern (siehe ADR-001).
+//
+// `AppGlobals.state` ist ein Live-Alias für die `var state` aus state.js.
+// Getter/Setter propagieren Reassignments (loadState, resetAll,
+// Cross-Tab-Sync) in beide Richtungen, sodass `AppGlobals.state` und
+// `window.state` immer dasselbe Objekt referenzieren. state.js darf beim
+// Registrieren daher NICHT `state: state` mitführen — sonst würde
+// Object.assign den Getter mit einem Plain-Property überschreiben.
+// ============================================================================
+
+var AppGlobals = window.AppGlobals = {};
+Object.defineProperty(AppGlobals, 'state', {
+    get: function () { return window.state; },
+    set: function (v) { window.state = v; },
+    configurable: true,
+    enumerable: true
+});

--- a/public/js/calculations.js
+++ b/public/js/calculations.js
@@ -51,8 +51,8 @@ function computeFahrgassenFaktor(breite) {
 // Rückgabe: number (Einheiten, immer ≥ 0)
 function getTotalEinheiten(r, koernerProEinheit) {
   if (!r || !r.hektar || !r.koerner || koernerProEinheit <= 0) return 0;
-  var fgEnabled = (r.fahrgassenEnabled !== undefined) ? r.fahrgassenEnabled : state.fahrgassenEnabled;
-  var fgBreite = (r.fahrgassenBreite !== undefined) ? r.fahrgassenBreite : state.fahrgassenBreite;
+  var fgEnabled = (r.fahrgassenEnabled !== undefined) ? r.fahrgassenEnabled : AppGlobals.state.fahrgassenEnabled;
+  var fgBreite = (r.fahrgassenBreite !== undefined) ? r.fahrgassenBreite : AppGlobals.state.fahrgassenBreite;
   var faktor = 1;
   if (fgEnabled && fgBreite > 0) {
     faktor = computeFahrgassenFaktor(fgBreite);
@@ -63,20 +63,20 @@ function getTotalEinheiten(r, koernerProEinheit) {
 
 // Berechnet die Gesamteinheiten für ein Tab-Objekt (SOLL), mit globalen Einstellungen.
 function getTabTotalEinheiten(r) {
-  return getTotalEinheiten(r, state.koernerProEinheit);
+  return getTotalEinheiten(r, AppGlobals.state.koernerProEinheit);
 }
 
 // Berechnet die IST-Einheiten basierend auf der IST-Fläche.
 // Nur wenn istHektar > 0 gesetzt ist, wird die IST-Fläche für die Berechnung verwendet.
 function getTabIstEinheiten(r) {
-  if (!r || !r.istHektar || !r.koerner || state.koernerProEinheit <= 0) return 0;
-  var fgEnabled = (r.fahrgassenEnabled !== undefined) ? r.fahrgassenEnabled : state.fahrgassenEnabled;
-  var fgBreite = (r.fahrgassenBreite !== undefined) ? r.fahrgassenBreite : state.fahrgassenBreite;
+  if (!r || !r.istHektar || !r.koerner || AppGlobals.state.koernerProEinheit <= 0) return 0;
+  var fgEnabled = (r.fahrgassenEnabled !== undefined) ? r.fahrgassenEnabled : AppGlobals.state.fahrgassenEnabled;
+  var fgBreite = (r.fahrgassenBreite !== undefined) ? r.fahrgassenBreite : AppGlobals.state.fahrgassenBreite;
   var faktor = 1;
   if (fgEnabled && fgBreite > 0) {
     faktor = computeFahrgassenFaktor(fgBreite);
   }
-  var einheiten = (r.istHektar * r.koerner) / state.koernerProEinheit;
+  var einheiten = (r.istHektar * r.koerner) / AppGlobals.state.koernerProEinheit;
   return Math.max(0, einheiten * faktor);
 }
 
@@ -164,7 +164,7 @@ function computeAllCarryovers() {
   if (_internal.carryoverCache !== null) return _internal.carryoverCache;
 
   var result = [];
-  for (let i = 0; i < state.reiter.length; i++) {
+  for (let i = 0; i < AppGlobals.state.reiter.length; i++) {
     result.push({ savedEinheit: 0, savedDuenger: 0, excessEinheit: 0, excessDuenger: 0 });
   }
 
@@ -176,8 +176,8 @@ function computeAllCarryovers() {
   var totalSavedE = 0, totalSavedD = 0;
   var totalExcessE = 0, totalExcessD = 0;
 
-  for (let i = 0; i < state.reiter.length; i++) {
-    var t = state.reiter[i];
+  for (let i = 0; i < AppGlobals.state.reiter.length; i++) {
+    var t = AppGlobals.state.reiter[i];
     var istE = getTabIstEinheiten(t);
     var solE = getTabTotalEinheiten(t);
     var usedE = getTabUsedEinheiten(t);
@@ -197,8 +197,8 @@ function computeAllCarryovers() {
   // === PHASE 1: Ersparnisse verteilen (vorwärts durch Tabs) ===
   _internal.carryoverCache = result;
   var remSavedE = totalSavedE, remSavedD = totalSavedD;
-  for (let i = 0; i < state.reiter.length && (remSavedE > 0.05 || remSavedD > 0.05); i++) {
-    var t = state.reiter[i];
+  for (let i = 0; i < AppGlobals.state.reiter.length && (remSavedE > 0.05 || remSavedD > 0.05); i++) {
+    var t = AppGlobals.state.reiter[i];
     // Need for tab i: max(0, IST - used) wenn IST > 0, sonst max(0, SOLL - used)
     var istE = getTabIstEinheiten(t);
     var solE = getTabTotalEinheiten(t);
@@ -251,8 +251,8 @@ function computeAllCarryovers() {
     return 0;
   }
   var tabOrder2 = [];
-  for (let i = 0; i < state.reiter.length; i++) {
-    var t2 = state.reiter[i];
+  for (let i = 0; i < AppGlobals.state.reiter.length; i++) {
+    var t2 = AppGlobals.state.reiter[i];
     if (!t2.entries || t2.entries.length === 0) continue;
     var istE2 = getTabIstEinheiten(t2);
     var solE2 = getTabTotalEinheiten(t2);
@@ -393,8 +393,8 @@ function getTabNextTime(r) {
 function getTabKornerGesamt(r) {
   if (!r || !r.hektar || !r.koerner) return 0;
   var k = r.hektar * r.koerner;
-  var fgEnabled = (r.fahrgassenEnabled !== undefined) ? r.fahrgassenEnabled : state.fahrgassenEnabled;
-  var fgBreite = (r.fahrgassenBreite !== undefined) ? r.fahrgassenBreite : state.fahrgassenBreite;
+  var fgEnabled = (r.fahrgassenEnabled !== undefined) ? r.fahrgassenEnabled : AppGlobals.state.fahrgassenEnabled;
+  var fgBreite = (r.fahrgassenBreite !== undefined) ? r.fahrgassenBreite : AppGlobals.state.fahrgassenBreite;
   var faktor = 1;
   if (fgEnabled && fgBreite > 0) {
     faktor = computeFahrgassenFaktor(fgBreite);
@@ -405,18 +405,43 @@ function getTabKornerGesamt(r) {
 // Berechnet Verbrauchsraten (Einheiten/ha, Dünger/ha) für einen bestimmten Tab.
 // (portiert aus Inline-Code Z. 2349-2359)
 // Argumente:
-//   tabIdx — Index in state.reiter
+//   tabIdx — Index in AppGlobals.state.reiter
 // Rückgabe: { unitsPerHa, duengerPerHa }
 function getTabRates(tabIdx) {
-  var r = state.reiter[tabIdx];
+  var r = AppGlobals.state.reiter[tabIdx];
   if (!r) return { unitsPerHa: 0, duengerPerHa: 0 };
-  var fgEnabled = (r.fahrgassenEnabled !== undefined) ? r.fahrgassenEnabled : state.fahrgassenEnabled;
-  var fgBreite = (r.fahrgassenBreite !== undefined) ? r.fahrgassenBreite : state.fahrgassenBreite;
+  var fgEnabled = (r.fahrgassenEnabled !== undefined) ? r.fahrgassenEnabled : AppGlobals.state.fahrgassenEnabled;
+  var fgBreite = (r.fahrgassenBreite !== undefined) ? r.fahrgassenBreite : AppGlobals.state.fahrgassenBreite;
   var fgFactor = 1;
   if (fgEnabled && fgBreite > 0) {
     fgFactor = computeFahrgassenFaktor(fgBreite);
   }
-  var unitsPerHa = r.koerner * fgFactor / state.koernerProEinheit;
+  var unitsPerHa = r.koerner * fgFactor / AppGlobals.state.koernerProEinheit;
   var duengerPerHa = r.duenger || 0;
   return { unitsPerHa: unitsPerHa, duengerPerHa: duengerPerHa };
 }
+
+// Register exposed globals on AppGlobals (ADR-001 Schritt 3, Issue #278).
+Object.assign(window.AppGlobals, {
+  EPSILON_QUANTITY: EPSILON_QUANTITY,
+  _internal: _internal,
+  computeFahrgassenFaktor: computeFahrgassenFaktor,
+  getTotalEinheiten: getTotalEinheiten,
+  getTabTotalEinheiten: getTabTotalEinheiten,
+  getTabIstEinheiten: getTabIstEinheiten,
+  getTotalDuenger: getTotalDuenger,
+  getTabTotalDuenger: getTabTotalDuenger,
+  getDuengerProEinheit: getDuengerProEinheit,
+  getTabIstDuenger: getTabIstDuenger,
+  getTabUsedEinheiten: getTabUsedEinheiten,
+  getTabUsedDuenger: getTabUsedDuenger,
+  computeAllCarryovers: computeAllCarryovers,
+  invalidateCarryoverCache: invalidateCarryoverCache,
+  getCarryover: getCarryover,
+  isTabDone: isTabDone,
+  getTabLastEntryTime: getTabLastEntryTime,
+  getTabIstHektar: getTabIstHektar,
+  getTabNextTime: getTabNextTime,
+  getTabKornerGesamt: getTabKornerGesamt,
+  getTabRates: getTabRates,
+});

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -79,10 +79,10 @@ window.app = {
   offStateChange: appOffStateChange,
   emit:           appEmit,
   dispatch:       dispatch,
-  invalidateCarryoverCache: function() { _internal.carryoverCache = null; },
-  migrateLegacyStorageKeys: migrateLegacyStorageKeys,
-  LEGACY_KEY_MAP:            LEGACY_KEY_MAP,
-  _internal: _internal
+  invalidateCarryoverCache: function() { AppGlobals._internal.carryoverCache = null; },
+  migrateLegacyStorageKeys: AppGlobals.migrateLegacyStorageKeys,
+  LEGACY_KEY_MAP:            AppGlobals.LEGACY_KEY_MAP,
+  _internal:                 AppGlobals._internal
 };
 
 // --- Dark Mode (portiert aus Inline-Code Z. 3415-3448) ---
@@ -160,5 +160,26 @@ document.addEventListener('input', function() {
 });
 
 document.addEventListener('DOMContentLoaded', function() {
-  initUI();
+  AppGlobals.initUI();
+});
+
+// Register exposed globals on AppGlobals (ADR-001 Schritt 3, Issue #278).
+Object.assign(window.AppGlobals, {
+  APP_VERSION: APP_VERSION,
+  APP_BUILD_DATE: APP_BUILD_DATE,
+  _stateListeners: _stateListeners,
+  _pendingKey: _pendingKey,
+  fmt: fmt,
+  fmtCompact: fmtCompact,
+  parseDE: parseDE,
+  formatEinheit: formatEinheit,
+  appOnStateChange: appOnStateChange,
+  appOffStateChange: appOffStateChange,
+  appEmit: appEmit,
+  dispatch: dispatch,
+  getStoredTheme: getStoredTheme,
+  setStoredTheme: setStoredTheme,
+  applyTheme: applyTheme,
+  toggleTheme: toggleTheme,
+  initTheme: initTheme,
 });

--- a/public/js/render-dashboard.js
+++ b/public/js/render-dashboard.js
@@ -1,8 +1,8 @@
 // ============================================================================
 // RENDER-DASHBOARD — Dashboard-Übersicht (Sheet) + openDashboard/closeDashboard
 //
-// Lade-Reihenfolge: state.js → calculations.js → ui-handlers.js → render-tabs.js
-//   → render-results.js → render-drill.js → render-dashboard.js (DIESE DATEI)
+// Lade-Reihenfolge: state (state.js) → calc (calculations.js) → ui (ui-handlers.js) → render-tabs
+//   → render-results → render-drill → render-dashboard (DIESE DATEI)
 //   → main.js
 //
 // render-dashboard.js braucht: state, calculations.js (getTabIstHektar,
@@ -15,10 +15,27 @@
     // Verwendet IST-Fläche (wenn gesetzt) als Basis für "verbleibend"-Berechnung,
     // konsistent mit renderResultCard() und renderDrillSummary().
 
+    // Erzeugt ein einzelnes Summary-Stat-Element (Label + Wert).
+    // Auf Modul-Ebene gehoben (ADR-001, Issue #278), damit es auf AppGlobals
+    // registriert werden kann (Object.assign am Dateiende).
+    function makeSummaryStat(label, value, valueClass) {
+      var stat = document.createElement('div');
+      stat.className = 'dashboard-summary-stat';
+      var lbl = document.createElement('div');
+      lbl.className = 'dashboard-summary-label';
+      lbl.textContent = label;
+      var val = document.createElement('div');
+      val.className = 'dashboard-summary-value' + (valueClass ? ' ' + valueClass : '');
+      val.textContent = value;
+      stat.appendChild(lbl);
+      stat.appendChild(val);
+      return stat;
+    }
+
     function renderDashboard() {
       var container = document.getElementById('dashboard_content');
       if (!container) return;
-      var reiter = state.reiter;
+      var reiter = AppGlobals.state.reiter;
       if (reiter.length === 0) {
         var emptyDiv = document.createElement('div');
         emptyDiv.className = 'dashboard-empty';
@@ -35,10 +52,10 @@
       var totalDuengerBasis = 0, totalDuengerUsed = 0;
       reiter.forEach(function(r, idx) {
         if (r.hektar > 0 && r.koerner > 0) {
-          var istSum = getTabIstHektar(r);
+          var istSum = AppGlobals.getTabIstHektar(r);
           totalHa += istSum > 0 ? istSum : r.hektar;
-          var basisE = istSum > 0 ? getTabIstEinheiten(r) : getTabTotalEinheiten(r);
-          var basisD = istSum > 0 ? getTabIstDuenger(r) : r.hektar * r.duenger;
+          var basisE = istSum > 0 ? AppGlobals.getTabIstEinheiten(r) : AppGlobals.getTabTotalEinheiten(r);
+          var basisD = istSum > 0 ? AppGlobals.getTabIstDuenger(r) : r.hektar * r.duenger;
           var usedE = r.entries ? r.entries.reduce(function(s, e) { return s + (e.einheit || 0); }, 0) : 0;
           var usedD = r.entries ? r.entries.reduce(function(s, e) { return s + (e.duenger || 0); }, 0) : 0;
           // remaining = max(0, basis - used) — no carryover subtraction
@@ -68,26 +85,12 @@
       var sStats = document.createElement('div');
       sStats.className = 'dashboard-summary-stats';
 
-      function makeSummaryStat(label, value, valueClass) {
-        var stat = document.createElement('div');
-        stat.className = 'dashboard-summary-stat';
-        var lbl = document.createElement('div');
-        lbl.className = 'dashboard-summary-label';
-        lbl.textContent = label;
-        var val = document.createElement('div');
-        val.className = 'dashboard-summary-value' + (valueClass ? ' ' + valueClass : '');
-        val.textContent = value;
-        stat.appendChild(lbl);
-        stat.appendChild(val);
-        return stat;
-      }
-
       var pctClass = totalPct >= 100 ? 'done' : totalPct > 0 ? 'remaining' : '';
-      sStats.appendChild(makeSummaryStat('Fläche', totalHa > 0 ? fmtCompact(totalHa) + ' ha' : '—'));
+      sStats.appendChild(makeSummaryStat('Fläche', totalHa > 0 ? AppGlobals.fmtCompact(totalHa) + ' ha' : '—'));
       // fmtCompact: integer values shown without trailing ",0" (e.g. "8" not "8,0").
       // Tests 26, 27, 40 use toBe('8') on this element; test 18-round2 uses
       // toContain('15') on it. fmt() would produce "8,0" and break those tests.
-      sStats.appendChild(makeSummaryStat('Einheiten verbl.', totalEinheitenBasis > 0 ? fmtCompact(totalEinheitRem) : '—', pctClass));
+      sStats.appendChild(makeSummaryStat('Einheiten verbl.', totalEinheitenBasis > 0 ? AppGlobals.fmtCompact(totalEinheitRem) : '—', pctClass));
       sStats.appendChild(makeSummaryStat('Dünger verbl.', totalDuengerBasis > 0 ? totalDuengerRem.toLocaleString('de-DE') + ' kg' : '—', pctClass));
       summaryCard.appendChild(sStats);
 
@@ -108,7 +111,7 @@
         var nameEl = document.createElement('div');
         nameEl.className = 'dashboard-reiter-name';
         nameEl.textContent = r.name || ('Reiter ' + (idx + 1));
-        if (idx === state.activeReiter) {
+        if (idx === AppGlobals.state.activeReiter) {
           nameEl.textContent += ' (aktiv)';
         }
         card.appendChild(nameEl);
@@ -124,11 +127,11 @@
         haDivLabel.textContent = 'Hektar';
         var haDivVal = document.createElement('div');
         haDivVal.className = 'dashboard-stat-value';
-        var istH = getTabIstHektar(r);
+        var istH = AppGlobals.getTabIstHektar(r);
         if (istH > 0 && istH !== r.hektar) {
-          haDivVal.textContent = fmtCompact(r.hektar) + ' / ' + fmtCompact(istH) + ' ha';
+          haDivVal.textContent = AppGlobals.fmtCompact(r.hektar) + ' / ' + AppGlobals.fmtCompact(istH) + ' ha';
         } else {
-          haDivVal.textContent = r.hektar > 0 ? fmtCompact(r.hektar) + ' ha' : '—';
+          haDivVal.textContent = r.hektar > 0 ? AppGlobals.fmtCompact(r.hektar) + ' ha' : '—';
         }
         haDiv.appendChild(haDivLabel);
         haDiv.appendChild(haDivVal);
@@ -157,10 +160,10 @@
         var pct = 0;
         var statusClass = 'na';
         if (r.hektar > 0 && r.koerner > 0) {
-          var istSum = getTabIstHektar(r);
-          einheiten = istSum > 0 ? getTabIstEinheiten(r) : getTabTotalEinheiten(r);
+          var istSum = AppGlobals.getTabIstHektar(r);
+          einheiten = istSum > 0 ? AppGlobals.getTabIstEinheiten(r) : AppGlobals.getTabTotalEinheiten(r);
           usedEinheit = r.entries ? r.entries.reduce(function(s, e) { return s + (e.einheit || 0); }, 0) : 0;
-          duengerTotal = istSum > 0 ? getTabIstDuenger(r) : r.hektar * r.duenger;
+          duengerTotal = istSum > 0 ? AppGlobals.getTabIstDuenger(r) : r.hektar * r.duenger;
           usedDuenger = r.entries ? r.entries.reduce(function(s, e) { return s + (e.duenger || 0); }, 0) : 0;
           einheitRem = Math.max(0, einheiten - usedEinheit);
           duengerRem = Math.max(0, duengerTotal - usedDuenger);
@@ -181,7 +184,7 @@
         eStatLabel.textContent = 'Einheiten verbl.';
         var eStatVal = document.createElement('div');
         eStatVal.className = 'dashboard-stat-value ' + statusClass;
-        eStatVal.textContent = r.hektar > 0 && r.koerner > 0 ? fmtCompact(einheitRem) : '—';
+        eStatVal.textContent = r.hektar > 0 && r.koerner > 0 ? AppGlobals.fmtCompact(einheitRem) : '—';
         eStat.appendChild(eStatLabel);
         eStat.appendChild(eStatVal);
         stats.appendChild(eStat);
@@ -272,3 +275,12 @@
         _dashboardPrevFocus = null;
       }
     }
+
+    // Register exposed globals on AppGlobals (ADR-001 Schritt 3, Issue #278).
+    Object.assign(window.AppGlobals, {
+      renderDashboard: renderDashboard,
+      makeSummaryStat: makeSummaryStat,
+      _dashboardKeyHandler: _dashboardKeyHandler,
+      openDashboard: openDashboard,
+      closeDashboard: closeDashboard,
+    });

--- a/public/js/render-drill.js
+++ b/public/js/render-drill.js
@@ -1,9 +1,8 @@
 // ============================================================================
 // RENDER-DRILL — Drill-Protokoll-Ansicht
 //
-// Lade-Reihenfolge: state.js → calculations.js → ui-handlers.js → render-tabs.js
-//   → render-results.js → render-drill.js (DIESE DATEI) → render-dashboard.js
-//   → main.js
+// Lade-Reihenfolge: state → calc → ui → render-tabs → render-results → render-drill (DIESE DATEI)
+//   → render-dashboard → main.js
 //
 // render-drill.js braucht: state, ui-handlers.js (drillRemove, drillCalcDebounced),
 //   calculations.js (getTabIstHektar, getTabTotalEinheiten, getTabIstEinheiten,
@@ -18,26 +17,26 @@
       var container = document.getElementById('drill_tab_list');
       if (!container) return;
       container.innerHTML = '';
-      state.reiter.forEach(function(r, i) {
+      AppGlobals.state.reiter.forEach(function(r, i) {
         var row = document.createElement('div');
         row.className = 'drill-tab-row';
         var prioBtn = document.createElement('button');
         prioBtn.className = 'drill-prio-btn';
         prioBtn.id = 'dtl_prio_' + i;
-        var initPrio = Object.prototype.hasOwnProperty.call(state.drillPriorities, String(i)) ? state.drillPriorities[i] : 0;
+        var initPrio = Object.prototype.hasOwnProperty.call(AppGlobals.state.drillPriorities, String(i)) ? AppGlobals.state.drillPriorities[i] : 0;
         prioBtn.textContent = initPrio === 0 ? '—' : String(initPrio);
         prioBtn.setAttribute('data-prio', String(initPrio));
         prioBtn.classList.toggle('active', initPrio > 0);
         prioBtn.onclick = function() {
           var current = parseInt(prioBtn.getAttribute('data-prio')) || 0;
-          var maxPrio = state.reiter.length;
+          var maxPrio = AppGlobals.state.reiter.length;
           var next = current >= maxPrio ? 0 : current + 1;
           prioBtn.setAttribute('data-prio', String(next));
           prioBtn.textContent = next === 0 ? '—' : String(next);
           prioBtn.classList.toggle('active', next > 0);
-          state.drillPriorities[i] = next;
-          saveState();
-          drillCalcAll();
+          AppGlobals.state.drillPriorities[i] = next;
+          AppGlobals.saveState();
+          AppGlobals.drillCalcAll();
         };
         row.appendChild(prioBtn);
         var nameWrap = document.createElement('div');
@@ -47,12 +46,12 @@
         label.textContent = r.name || ('Tab ' + (i + 1));
         nameWrap.appendChild(label);
         if (r.hektar > 0 && r.koerner > 0) {
-          var istSum = getTabIstHektar(r);
-          var totalE = istSum > 0 ? getTabIstEinheiten(r) : getTabTotalEinheiten(r);
+          var istSum = AppGlobals.getTabIstHektar(r);
+          var totalE = istSum > 0 ? AppGlobals.getTabIstEinheiten(r) : AppGlobals.getTabTotalEinheiten(r);
           var usedE = r.entries.reduce(function(s, e) { return s + e.einheit; }, 0);
-          var totalD = istSum > 0 ? getTabIstDuenger(r) : getTabTotalDuenger(r);
+          var totalD = istSum > 0 ? AppGlobals.getTabIstDuenger(r) : AppGlobals.getTabTotalDuenger(r);
           var usedD = r.entries.reduce(function(s, e) { return s + e.duenger; }, 0);
-          var co = getCarryover(i);
+          var co = AppGlobals.getCarryover(i);
           var remaining = totalE - usedE;
           var remainingD = totalD - usedD;
           var statusEl = document.createElement('div');
@@ -63,12 +62,12 @@
             statusEl.classList.add('done');
           } else if (remainingD <= 0.05) {
             // Nur Saatgut übrig — Dünger-Anteil weglassen (Issue #266)
-            statusEl.textContent = 'braucht ' + fmt(Math.max(0, remaining)) + ' Einheiten';
+            statusEl.textContent = 'braucht ' + AppGlobals.fmt(Math.max(0, remaining)) + ' Einheiten';
           } else if (remaining <= 0.05) {
             // Nur Dünger übrig (seltener Fall, abgedeckt für Vollständigkeit)
-            statusEl.textContent = 'braucht ' + fmt(Math.max(0, remainingD)) + ' kg Dünger';
+            statusEl.textContent = 'braucht ' + AppGlobals.fmt(Math.max(0, remainingD)) + ' kg Dünger';
           } else {
-            statusEl.textContent = 'braucht ' + fmt(Math.max(0, remaining)) + ' Einheiten, ' + fmt(Math.max(0, remainingD)) + ' kg Dünger';
+            statusEl.textContent = 'braucht ' + AppGlobals.fmt(Math.max(0, remaining)) + ' Einheiten, ' + AppGlobals.fmt(Math.max(0, remainingD)) + ' kg Dünger';
           }
           nameWrap.appendChild(statusEl);
         }
@@ -80,7 +79,7 @@
         einheitIn.placeholder = 'Einheiten';
         einheitIn.dataset.tabIdx = String(i);
         einheitIn.oninput = function() {
-          drillCalcDebounced();
+          AppGlobals.drillCalcDebounced();
         };
         row.appendChild(einheitIn);
         var duengerIn = document.createElement('input');
@@ -90,7 +89,7 @@
         duengerIn.placeholder = 'kg Dünger';
         duengerIn.dataset.tabIdx = String(i);
         duengerIn.oninput = function() {
-          drillCalcDebounced();
+          AppGlobals.drillCalcDebounced();
         };
         row.appendChild(duengerIn);
         container.appendChild(row);
@@ -100,23 +99,23 @@
     // --- Render: Drill Summary ---
 
     function renderDrillSummary() {
-      var r = getActiveReiter();
+      var r = AppGlobals.getActiveReiter();
       // Issue #186: IST-Fläche (vom Input-Feld) hat Vorrang vor SOLL.
-      var istSum = getTabIstHektar(r);
-      var einheiten = istSum > 0 ? getTabIstEinheiten(r) : getActiveTotalEinheiten();
-      var duengerTotal = istSum > 0 ? getTabIstDuenger(r) : getActiveTotalDuenger();
+      var istSum = AppGlobals.getTabIstHektar(r);
+      var einheiten = istSum > 0 ? AppGlobals.getTabIstEinheiten(r) : AppGlobals.getActiveTotalEinheiten();
+      var duengerTotal = istSum > 0 ? AppGlobals.getTabIstDuenger(r) : AppGlobals.getActiveTotalDuenger();
       var usedEinheit = (r && r.entries) ? r.entries.reduce(function(s, e) { return s + (e.einheit || 0); }, 0) : 0;
       var usedDuenger = (r && r.entries) ? r.entries.reduce(function(s, e) { return s + (e.duenger || 0); }, 0) : 0;
-      var istEinheiten = istSum > 0 ? getTabIstEinheiten(r) : einheiten;
-      var istDuenger = istSum > 0 ? getTabIstDuenger(r) : duengerTotal;
+      var istEinheiten = istSum > 0 ? AppGlobals.getTabIstEinheiten(r) : einheiten;
+      var istDuenger = istSum > 0 ? AppGlobals.getTabIstDuenger(r) : duengerTotal;
       var remEinheit = Math.max(0, istEinheiten - usedEinheit);
       var remDuenger = Math.max(0, istDuenger - usedDuenger);
       var dsSollE = document.getElementById('ds_saat_total');
-      if (dsSollE) dsSollE.textContent = formatEinheit(einheiten);
+      if (dsSollE) dsSollE.textContent = AppGlobals.formatEinheit(einheiten);
       var dsUsedE = document.getElementById('ds_saat_used');
-      if (dsUsedE) dsUsedE.textContent = formatEinheit(usedEinheit);
+      if (dsUsedE) dsUsedE.textContent = AppGlobals.formatEinheit(usedEinheit);
       var dsRemE = document.getElementById('ds_saat_remaining');
-      if (dsRemE) dsRemE.textContent = formatEinheit(remEinheit);
+      if (dsRemE) dsRemE.textContent = AppGlobals.formatEinheit(remEinheit);
       var dsSollD = document.getElementById('ds_duenger_total');
       if (dsSollD) dsSollD.textContent = duengerTotal > 0 ? duengerTotal.toLocaleString('de-DE') + ' kg' : '—';
       var dsUsedD = document.getElementById('ds_duenger_used');
@@ -131,10 +130,10 @@
       var dsSav = document.getElementById('ds_savings');
       if (dsSav) {
         if (istSum > 0 && r.hektar > istSum) {
-          var savE = getTabTotalEinheiten(r) - getTabIstEinheiten(r);
+          var savE = AppGlobals.getTabTotalEinheiten(r) - AppGlobals.getTabIstEinheiten(r);
           var savD = (r.hektar - istSum) * (r.duenger || 0);
           var savParts = [];
-          if (savE > 0.05) savParts.push(fmt(savE) + ' Einheiten Saatgut');
+          if (savE > 0.05) savParts.push(AppGlobals.fmt(savE) + ' Einheiten Saatgut');
           if (savD > 0.05) savParts.push(savD.toLocaleString('de-DE') + ' kg Dünger');
           if (savParts.length > 0) {
             dsSav.textContent = 'Ersparnis: ' + savParts.join(', ');
@@ -156,16 +155,16 @@
       var container = document.getElementById('drill_entries');
       if (!container) return;
       container.innerHTML = '';
-      var activeTab = state.reiter[state.activeReiter];
+      var activeTab = AppGlobals.state.reiter[AppGlobals.state.activeReiter];
       var totalSummary = document.getElementById('ds_total_summary');
       // Issue #266-B2: Per-tab carryover/savings/excess divs at the top.
       // Shown for ALL tabs that have any carryover signal (savings source,
       // excess source, or carryover received from other tabs). Tests assert
       // these classes on the #drill_entries container.
-      for (var ci = 0; ci < state.reiter.length; ci++) {
-        var ct = state.reiter[ci];
+      for (var ci = 0; ci < AppGlobals.state.reiter.length; ci++) {
+        var ct = AppGlobals.state.reiter[ci];
         if (!ct) continue;
-        var cco = getCarryover(ci);
+        var cco = AppGlobals.getCarryover(ci);
         var isSavingsSource = (ct.istHektar > 0 && ct.hektar > 0 && ct.istHektar < ct.hektar);
         var isExcessSource = (ct.istHektar > 0 && ct.hektar > 0 && ct.istHektar > ct.hektar);
         if (isSavingsSource) {
@@ -173,10 +172,10 @@
           // the carryover calculation. Use getTabTotalEinheiten - getTabIstEinheiten
           // (both already apply the per-tab FG factor) so display and
           // carryover share one formula.
-          var sE = getTabTotalEinheiten(ct) - getTabIstEinheiten(ct);
+          var sE = AppGlobals.getTabTotalEinheiten(ct) - AppGlobals.getTabIstEinheiten(ct);
           var sD = (ct.hektar - ct.istHektar) * (ct.duenger || 0);
           var sParts = [];
-          if (sE > 0.05) sParts.push(fmt(sE) + ' Einheiten Saatgut');
+          if (sE > 0.05) sParts.push(AppGlobals.fmt(sE) + ' Einheiten Saatgut');
           if (sD > 0.05) sParts.push(sD.toLocaleString('de-DE') + ' kg Dünger');
           if (sParts.length > 0) {
             var sDiv = document.createElement('div');
@@ -187,7 +186,7 @@
         }
         if (cco.savedEinheit > 0.05 || cco.savedDuenger > 0.05) {
           var cParts = [];
-          if (cco.savedEinheit > 0.05) cParts.push(fmt(cco.savedEinheit) + ' Einheiten Saatgut');
+          if (cco.savedEinheit > 0.05) cParts.push(AppGlobals.fmt(cco.savedEinheit) + ' Einheiten Saatgut');
           if (cco.savedDuenger > 0.05) cParts.push(cco.savedDuenger.toLocaleString('de-DE') + ' kg Dünger');
           var cDiv = document.createElement('div');
           cDiv.className = 'drill-carryover';
@@ -199,10 +198,10 @@
           // the carryover calculation. Use getTabIstEinheiten - getTabTotalEinheiten
           // (both already apply the per-tab FG factor) so display and
           // carryover share one formula.
-          var eE = getTabIstEinheiten(ct) - getTabTotalEinheiten(ct);
+          var eE = AppGlobals.getTabIstEinheiten(ct) - AppGlobals.getTabTotalEinheiten(ct);
           var eD = (ct.istHektar - ct.hektar) * (ct.duenger || 0);
           var eParts = [];
-          if (eE > 0.05) eParts.push(fmt(eE) + ' Einheiten Saatgut');
+          if (eE > 0.05) eParts.push(AppGlobals.fmt(eE) + ' Einheiten Saatgut');
           if (eD > 0.05) eParts.push(eD.toLocaleString('de-DE') + ' kg Dünger');
           if (eParts.length > 0) {
             var eDiv = document.createElement('div');
@@ -226,8 +225,8 @@
         var usedE = activeTab.entries.reduce(function(s, e) { return s + (e.einheit || 0); }, 0);
         var usedD = activeTab.entries.reduce(function(s, e) { return s + (e.duenger || 0); }, 0);
         var parts = [];
-        if (usedHa > 0) parts.push(fmt(usedHa) + ' ha');
-        if (usedE > 0) parts.push(fmt(usedE) + ' Einheiten');
+        if (usedHa > 0) parts.push(AppGlobals.fmt(usedHa) + ' ha');
+        if (usedE > 0) parts.push(AppGlobals.fmt(usedE) + ' Einheiten');
         if (usedD > 0) parts.push(usedD.toLocaleString('de-DE') + ' kg Dünger');
         totalSummary.textContent = parts.join(' · ');
       }
@@ -254,11 +253,11 @@
         }
         if (entry.istHektar || entry.zaehlerStand) {
           var ha = entry.istHektar || entry.zaehlerStand;
-          parts2.push(fmt(ha) + ' ha');
+          parts2.push(AppGlobals.fmt(ha) + ' ha');
         } else if (entry.hektar > 0) {
-          parts2.push('@' + fmt(entry.hektar) + 'ha');
+          parts2.push('@' + AppGlobals.fmt(entry.hektar) + 'ha');
         }
-        parts2.push(formatEinheit(entry.einheit || 0));
+        parts2.push(AppGlobals.formatEinheit(entry.einheit || 0));
         if (entry.duenger > 0) {
           parts2.push((entry.duenger).toLocaleString('de-DE') + ' kg Dünger');
         }
@@ -267,7 +266,7 @@
         var removeBtn = document.createElement('button');
         removeBtn.className = 'btn-danger';
         removeBtn.textContent = '✕';
-        removeBtn.onclick = function() { drillRemove(state.activeReiter, actualIdx); };
+        removeBtn.onclick = function() { AppGlobals.drillRemove(AppGlobals.state.activeReiter, actualIdx); };
         row.appendChild(removeBtn);
         container.appendChild(row);
       });
@@ -275,10 +274,10 @@
 
     // --- Render: Machine Log (Maschinen-Protokoll) ---
 
-    // Issue #266-A: renderResults() must populate the #drill_machine_log container
+    // renderResults() must populate the #drill_machine_log container
     // so the test in tests/16-machine-log.test.js can find the entries, header,
     // delete buttons and prognose. The machine log is a flat global list
-    // (state.machineLog), independent of the per-tab entries — each row shows
+    // (AppGlobals.state.machineLog), independent of the per-tab entries — each row shows
     // what was filled into the machine, not the per-tab allocation.
     //
     // Prognose: for each entry, the cumulative tank level (after this fill)
@@ -289,8 +288,8 @@
       var container = document.getElementById('drill_machine_log');
       if (!container) return;
       container.innerHTML = '';
-      var log = state.machineLog || [];
-      var activeTab = state.reiter[state.activeReiter];
+      var log = AppGlobals.state.machineLog || [];
+      var activeTab = AppGlobals.state.reiter[AppGlobals.state.activeReiter];
       if (log.length === 0) return;
       // Header
       var header = document.createElement('div');
@@ -301,13 +300,13 @@
       // Issue #266 (Cluster B): Fahrgassen-Faktor muss in unitsPerHa
       // berücksichtigt werden (Test 18: unitsPerHa = koerner * fgFactor /
       // koernerProEinheit). fgFactor ist 1 wenn FG aus, sonst (breite-1)/breite.
-      var fgEnabled = (activeTab && activeTab.fahrgassenEnabled !== undefined) ? activeTab.fahrgassenEnabled : state.fahrgassenEnabled;
-      var fgBreite = (activeTab && activeTab.fahrgassenBreite !== undefined) ? activeTab.fahrgassenBreite : state.fahrgassenBreite;
-      var fgFactor = (fgEnabled && fgBreite >= 2) ? computeFahrgassenFaktor(fgBreite) : 1;
+      var fgEnabled = (activeTab && activeTab.fahrgassenEnabled !== undefined) ? activeTab.fahrgassenEnabled : AppGlobals.state.fahrgassenEnabled;
+      var fgBreite = (activeTab && activeTab.fahrgassenBreite !== undefined) ? activeTab.fahrgassenBreite : AppGlobals.state.fahrgassenBreite;
+      var fgFactor = (fgEnabled && fgBreite >= 2) ? AppGlobals.computeFahrgassenFaktor(fgBreite) : 1;
       var unitsPerHa = 0;
       var duengerPerHa = 0;
       if (activeTab && activeTab.koerner > 0) {
-        unitsPerHa = activeTab.koerner * fgFactor / state.koernerProEinheit;
+        unitsPerHa = activeTab.koerner * fgFactor / AppGlobals.state.koernerProEinheit;
       }
       if (activeTab && activeTab.duenger > 0) {
         duengerPerHa = activeTab.duenger;
@@ -335,7 +334,7 @@
           var ha = entry.zaehlerStand || entry.hektar;
           parts.push(ha.toLocaleString('de-DE', { minimumFractionDigits: 1, maximumFractionDigits: 1 }) + ' ha');
         }
-        parts.push(formatEinheit(entry.einheit || 0));
+        parts.push(AppGlobals.formatEinheit(entry.einheit || 0));
         if (entry.duenger > 0) {
           parts.push(entry.duenger.toLocaleString('de-DE') + ' kg Dünger');
         }
@@ -345,7 +344,7 @@
         removeBtn.className = 'btn-danger';
         removeBtn.textContent = '✕';
         removeBtn.onclick = (function(idx) {
-          return function() { drillMachineRemove(idx); };
+          return function() { AppGlobals.drillMachineRemove(idx); };
         })(i);
         row.appendChild(removeBtn);
         container.appendChild(row);
@@ -361,11 +360,11 @@
         var prognoseParts = [];
         if (unitsPerHa > 0 && entry.einheit > 0) {
           var saatLeer = zaehler + cumEinheit / unitsPerHa;
-          prognoseParts.push('Saat leer bei ' + fmt(saatLeer) + ' ha');
+          prognoseParts.push('Saat leer bei ' + AppGlobals.fmt(saatLeer) + ' ha');
         }
         if (duengerPerHa > 0 && entry.duenger > 0) {
           var duengerLeer = zaehler + cumDuenger / duengerPerHa;
-          prognoseParts.push('Dünger leer bei ' + fmt(duengerLeer) + ' ha');
+          prognoseParts.push('Dünger leer bei ' + AppGlobals.fmt(duengerLeer) + ' ha');
         }
         if (prognoseParts.length > 0) {
           var prognose = document.createElement('div');
@@ -375,3 +374,11 @@
         }
       }
     }
+
+// Register exposed globals on AppGlobals (ADR-001 Schritt 3, Issue #278).
+Object.assign(window.AppGlobals, {
+  renderDrillTabList: renderDrillTabList,
+  renderDrillSummary: renderDrillSummary,
+  renderDrillLog: renderDrillLog,
+  renderMachineLog: renderMachineLog,
+});

--- a/public/js/render-results.js
+++ b/public/js/render-results.js
@@ -14,45 +14,45 @@
     // --- Render: Result Card ---
 
     function renderResultCard() {
-      var r = getActiveReiter();
-      var kornerGesamt = getKornerGesamt();
+      var r = AppGlobals.getActiveReiter();
+      var kornerGesamt = AppGlobals.getKornerGesamt();
       // Issue #186: IST-Fläche (vom Input-Feld) hat Vorrang vor SOLL.
       // r_einheiten/r_duenger zeigen die tatsächlichen IST-Bedarfe, wenn
       // r.istHektar > 0 — konsistent mit Dashboard, Drill-Summary, etc.
-      var istSum = getTabIstHektar(r);
-      var einheiten = istSum > 0 ? getTabIstEinheiten(r) : getActiveTotalEinheiten();
-      var duengerTotal = istSum > 0 ? getTabIstDuenger(r) : getActiveTotalDuenger();
+      var istSum = AppGlobals.getTabIstHektar(r);
+      var einheiten = istSum > 0 ? AppGlobals.getTabIstEinheiten(r) : AppGlobals.getActiveTotalEinheiten();
+      var duengerTotal = istSum > 0 ? AppGlobals.getTabIstDuenger(r) : AppGlobals.getActiveTotalDuenger();
       var rkEl = document.getElementById('r_korner');
       if (rkEl) rkEl.textContent = Math.round(kornerGesamt).toLocaleString('de-DE');
       var reEl = document.getElementById('r_einheiten');
-      if (reEl) reEl.textContent = formatEinheit(einheiten);
+      if (reEl) reEl.textContent = AppGlobals.formatEinheit(einheiten);
       var rdEl = document.getElementById('r_duenger');
       if (rdEl) rdEl.textContent = duengerTotal > 0 ? duengerTotal.toLocaleString('de-DE') + ' kg' : '—';
       var riEl = document.getElementById('r_info');
       if (riEl) {
         if (duengerTotal > 0) {
-          riEl.textContent = duengerTotal.toLocaleString('de-DE') + ' kg Dünger, ' + formatEinheit(einheiten) + ' Saat';
+          riEl.textContent = duengerTotal.toLocaleString('de-DE') + ' kg Dünger, ' + AppGlobals.formatEinheit(einheiten) + ' Saat';
         } else {
-          riEl.textContent = formatEinheit(einheiten) + ' Saat (ohne Dünger)';
+          riEl.textContent = AppGlobals.formatEinheit(einheiten) + ' Saat (ohne Dünger)';
         }
       }
       var sollHa = r.hektar;
-      var istHa = getTabIstHektar(r);
+      var istHa = AppGlobals.getTabIstHektar(r);
       var diff = istHa - sollHa;
       var sollIstSection = document.getElementById('r_soll_ist_section');
       if (sollIstSection) {
         if (sollHa > 0 && istHa > 0) {
           var rshEl = document.getElementById('r_soll_ha');
-          if (rshEl) rshEl.textContent = fmt(sollHa) + ' ha';
+          if (rshEl) rshEl.textContent = AppGlobals.fmt(sollHa) + ' ha';
           var rihEl = document.getElementById('r_ist_ha');
-          if (rihEl) rihEl.textContent = fmt(istHa) + ' ha';
+          if (rihEl) rihEl.textContent = AppGlobals.fmt(istHa) + ' ha';
           var rDiffEl = document.getElementById('r_diff_ha');
           if (rDiffEl) {
             if (diff >= 0) {
-              rDiffEl.textContent = '+' + fmt(diff) + ' ha';
+              rDiffEl.textContent = '+' + AppGlobals.fmt(diff) + ' ha';
               rDiffEl.className = 'value small positive';
             } else {
-              rDiffEl.textContent = fmt(diff) + ' ha';
+              rDiffEl.textContent = AppGlobals.fmt(diff) + ' ha';
               rDiffEl.className = 'value small negative';
             }
           }
@@ -72,12 +72,12 @@
       }
       if (carryoverHint) {
         while (carryoverHint.firstChild) carryoverHint.removeChild(carryoverHint.firstChild);
-        var activeIdx = state.activeReiter || 0;
-        var co = getCarryover(activeIdx);
+        var activeIdx = AppGlobals.state.activeReiter || 0;
+        var co = AppGlobals.getCarryover(activeIdx);
         if (co.savedEinheit > 0.05 || co.savedDuenger > 0.05) {
           var parts = [];
-          if (co.savedEinheit > 0.05) parts.push(fmt(co.savedEinheit) + ' Einheiten');
-          if (co.savedDuenger > 0.05) parts.push(fmt(co.savedDuenger) + ' kg Dünger');
+          if (co.savedEinheit > 0.05) parts.push(AppGlobals.fmt(co.savedEinheit) + ' Einheiten');
+          if (co.savedDuenger > 0.05) parts.push(AppGlobals.fmt(co.savedDuenger) + ' kg Dünger');
           var savedSpan = document.createElement('span');
           savedSpan.className = 'carryover-hint';
           savedSpan.textContent = 'Übertrag aus ersparten Flächen: +' + parts.join(', ');
@@ -85,8 +85,8 @@
         }
         if (co.excessEinheit > 0.05 || co.excessDuenger > 0.05) {
           var eparts = [];
-          if (co.excessEinheit > 0.05) eparts.push(fmt(co.excessEinheit) + ' Einheiten');
-          if (co.excessDuenger > 0.05) eparts.push(fmt(co.excessDuenger) + ' kg Dünger');
+          if (co.excessEinheit > 0.05) eparts.push(AppGlobals.fmt(co.excessEinheit) + ' Einheiten');
+          if (co.excessDuenger > 0.05) eparts.push(AppGlobals.fmt(co.excessDuenger) + ' kg Dünger');
           if (carryoverHint.firstChild) carryoverHint.appendChild(document.createElement('br'));
           var excessSpan = document.createElement('span');
           excessSpan.className = 'excess-hint';
@@ -101,18 +101,18 @@
     function renderMiniFooter() {
       var mf = document.getElementById('mini_result');
       if (!mf) return;
-      var activeR = state.reiter[state.activeReiter];
+      var activeR = AppGlobals.state.reiter[AppGlobals.state.activeReiter];
       if (!activeR) return;
       if (activeR.hektar > 0 && activeR.koerner > 0) {
-        var einheiten = getActiveTotalEinheiten();
-        var duengerTotal = getActiveTotalDuenger();
-        var kornerGesamt = getKornerGesamt();
+        var einheiten = AppGlobals.getActiveTotalEinheiten();
+        var duengerTotal = AppGlobals.getActiveTotalDuenger();
+        var kornerGesamt = AppGlobals.getKornerGesamt();
         var kornerStr = Math.round(kornerGesamt).toLocaleString('de-DE');
         var miniResult = mf.querySelector('.mini-result') || mf;
         var duengerStr = duengerTotal > 0
           ? ' / ' + duengerTotal.toLocaleString('de-DE') + ' kg'
           : '';
-        miniResult.innerHTML = 'Bedarf: <span class="mr-einheiten">' + formatEinheit(einheiten) + '</span> / ' + kornerStr + ' Körner' + duengerStr;
+        miniResult.innerHTML = 'Bedarf: <span class="mr-einheiten">' + AppGlobals.formatEinheit(einheiten) + '</span> / ' + kornerStr + ' Körner' + duengerStr;
         miniResult.classList.remove('mini-result-empty');
       } else {
         var miniResult = mf.querySelector('.mini-result') || mf;
@@ -124,12 +124,12 @@
     // --- Render: Results (Hauptergebnis) ---
 
     function renderResults() {
-      var r = getActiveReiter();
+      var r = AppGlobals.getActiveReiter();
       renderResultCard();
-      renderDrillSummary();
-      renderDrillLog();
+      AppGlobals.renderDrillSummary();
+      AppGlobals.renderDrillLog();
       renderDrillEntriesInline();
-      renderMachineLog();
+      AppGlobals.renderMachineLog();
       renderMiniFooter();
       var errHektar = document.getElementById('err_hektar');
       var errKoerner = document.getElementById('err_koerner');
@@ -158,7 +158,7 @@
         return;
       }
       if (drillSummaryEl) drillSummaryEl.style.display = 'block';
-      if (state.activeView !== 'protokoll') {
+      if (AppGlobals.state.activeView !== 'protokoll') {
         if (resultsEl) resultsEl.style.display = 'block';
       }
     }
@@ -170,7 +170,7 @@
       var container = document.getElementById('r_drill_entries');
       if (!container) return;
       container.innerHTML = '';
-      var r = getActiveReiter();
+      var r = AppGlobals.getActiveReiter();
       if (!r || !r.entries || r.entries.length === 0) {
         var rdSection = document.getElementById('r_drill_section');
         if (rdSection) rdSection.style.display = 'none';
@@ -180,14 +180,14 @@
       if (rdSection) rdSection.style.display = 'block';
       var usedE = r.entries.reduce(function(s, e) { return s + (e.einheit || 0); }, 0);
       var usedD = r.entries.reduce(function(s, e) { return s + (e.duenger || 0); }, 0);
-      var istE = getTabIstEinheiten(r) || getTabTotalEinheiten(r);
-      var istD = getTabIstDuenger(r) || getTabTotalDuenger(r);
+      var istE = AppGlobals.getTabIstEinheiten(r) || AppGlobals.getTabTotalEinheiten(r);
+      var istD = AppGlobals.getTabIstDuenger(r) || AppGlobals.getTabTotalDuenger(r);
       var remE = Math.max(0, istE - usedE);
       var remD = Math.max(0, istD - usedD);
       var usedEl = document.getElementById('r_drill_e_used');
-      if (usedEl) usedEl.textContent = formatEinheit(usedE);
+      if (usedEl) usedEl.textContent = AppGlobals.formatEinheit(usedE);
       var remEl = document.getElementById('r_drill_e_rem');
-      if (remEl) remEl.textContent = formatEinheit(remE);
+      if (remEl) remEl.textContent = AppGlobals.formatEinheit(remE);
       var dUsedEl = document.getElementById('r_drill_d_used');
       if (dUsedEl) dUsedEl.textContent = usedD > 0 ? usedD.toLocaleString('de-DE') + ' kg' : '—';
       var dRemEl = document.getElementById('r_drill_d_rem');
@@ -213,11 +213,11 @@
         }
         if (entry.istHektar || entry.zaehlerStand) {
           var ha = entry.istHektar || entry.zaehlerStand;
-          parts.push(fmt(ha) + ' ha');
+          parts.push(AppGlobals.fmt(ha) + ' ha');
         } else if (entry.hektar > 0) {
-          parts.push('@' + fmt(entry.hektar) + 'ha');
+          parts.push('@' + AppGlobals.fmt(entry.hektar) + 'ha');
         }
-        parts.push(formatEinheit(entry.einheit || 0));
+        parts.push(AppGlobals.formatEinheit(entry.einheit || 0));
         if (entry.duenger > 0) {
           parts.push((entry.duenger).toLocaleString('de-DE') + ' kg Dünger');
         }
@@ -226,8 +226,16 @@
         var removeBtn = document.createElement('button');
         removeBtn.className = 'btn-danger';
         removeBtn.textContent = '✕';
-        removeBtn.onclick = function() { drillRemove(state.activeReiter, actualIdx); };
+        removeBtn.onclick = function() { AppGlobals.drillRemove(AppGlobals.state.activeReiter, actualIdx); };
         row.appendChild(removeBtn);
         container.appendChild(row);
       });
     }
+
+// Register exposed globals on AppGlobals (ADR-001 Schritt 3, Issue #278).
+Object.assign(window.AppGlobals, {
+  renderResultCard: renderResultCard,
+  renderMiniFooter: renderMiniFooter,
+  renderResults: renderResults,
+  renderDrillEntriesInline: renderDrillEntriesInline,
+});

--- a/public/js/render-tabs.js
+++ b/public/js/render-tabs.js
@@ -15,12 +15,12 @@
     function renderTabs() {
       var bar = document.getElementById('tab_bar_left');
       bar.innerHTML = '';
-      state.reiter.forEach(function(r, i) {
-        var isActive = i === state.activeReiter && state.activeView !== 'protokoll';
+      AppGlobals.state.reiter.forEach(function(r, i) {
+        var isActive = i === AppGlobals.state.activeReiter && AppGlobals.state.activeView !== 'protokoll';
         var btn = document.createElement('button');
         btn.className = 'tab-btn field-tab' + (isActive ? ' active' : '');
         btn.setAttribute('aria-label', 'Tab ' + (i+1));
-        btn.onclick = function() { switchReiter(i); };
+        btn.onclick = function() { AppGlobals.switchReiter(i); };
         var span = document.createElement('span');
         span.className = 'tab-name';
         span.setAttribute('aria-label', 'Tab-Name');
@@ -37,7 +37,7 @@
         };
         span.onblur = function() {
           var newName = span.textContent.replace(/\n/g, ' ').trim();
-          renameReiter(i, newName);
+          AppGlobals.renameReiter(i, newName);
         };
         span.onkeydown = function(evt) {
           if (evt.key === 'Enter') { evt.preventDefault(); span.blur(); }
@@ -46,7 +46,7 @@
         };
         span.onmousedown = function(evt) { evt.stopPropagation(); };
 
-        if (state.reiter.length > 1) {
+        if (AppGlobals.state.reiter.length > 1) {
           var close = document.createElement('span');
           close.className = 'tab-close';
           close.setAttribute('role', 'button');
@@ -62,18 +62,18 @@
       var addBtn = document.createElement('button');
       addBtn.className = 'tab-add';
       addBtn.textContent = '+ Tab';
-      addBtn.onclick = function() { addReiter(); };
+      addBtn.onclick = function() { AppGlobals.addReiter(); };
       bar.appendChild(addBtn);
       var protokollBtn = document.getElementById('protokoll_tab_btn');
-      if (protokollBtn) protokollBtn.classList.toggle('active', state.activeView === 'protokoll');
+      if (protokollBtn) protokollBtn.classList.toggle('active', AppGlobals.state.activeView === 'protokoll');
     }
 
     // --- Render: View (Feld vs. Protokoll) ---
 
     function renderView() {
-      var r = getActiveReiter();
+      var r = AppGlobals.getActiveReiter();
       var hasData = r.hektar > 0 && r.koerner > 0;
-      var isProtokoll = state.activeView === 'protokoll';
+      var isProtokoll = AppGlobals.state.activeView === 'protokoll';
       var skipIds = { r_soll_ist_section: true };
       var cards = document.querySelectorAll('.card');
       cards.forEach(function(c) {
@@ -97,9 +97,9 @@
     // --- Init: UI (nach DOMContentLoaded) ---
 
     function initUI() {
-      loadState();
-      maybeShowIosInstallHint();
-      maybeShowUpdateHint();
+      AppGlobals.loadState();
+      AppGlobals.maybeShowIosInstallHint();
+      AppGlobals.maybeShowUpdateHint();
       // --- Cross-Tab-Synchronisation (portiert aus Inline-Code Z. 3394-3412) ---
       // Lauscht auf localStorage-Änderungen von anderen Tabs/Fenstern.
       // Der storage-Event feuert nur in Tabs, die den Wert NICHT selbst gesetzt haben.
@@ -107,36 +107,36 @@
         if (e.key === 'agrar_rechner' && e.newValue) {
           try {
             var remote = JSON.parse(e.newValue);
-            if (JSON.stringify(remote) !== JSON.stringify(state)) {
-              state = remote;
-              syncInputsFromState();
-              renderTabs();
+            if (JSON.stringify(remote) !== JSON.stringify(AppGlobals.state)) {
+              AppGlobals.state = remote;
+              AppGlobals.syncInputsFromState();
+              AppGlobals.renderTabs();
               renderView();
-              renderResults();
+              AppGlobals.renderResults();
             }
           } catch(err) {
             console.warn('Cross-tab sync: ungültiger State ignoriert', err);
           }
         }
       });
-      syncInputsFromState();
-      renderTabs();
+      AppGlobals.syncInputsFromState();
+      AppGlobals.renderTabs();
       // Fahrgassen-Toggle aus State restaurieren
       var fgToggle = document.getElementById('fahrgassen_toggle');
       var fgSettings = document.getElementById('fahrgassen_settings');
       if (fgToggle) {
-        fgToggle.classList.toggle('active', !!state.fahrgassenEnabled);
-        fgToggle.setAttribute('aria-pressed', state.fahrgassenEnabled ? 'true' : 'false');
+        fgToggle.classList.toggle('active', !!AppGlobals.state.fahrgassenEnabled);
+        fgToggle.setAttribute('aria-pressed', AppGlobals.state.fahrgassenEnabled ? 'true' : 'false');
       }
       if (fgSettings) {
-        fgSettings.classList.toggle('open', !!state.fahrgassenEnabled);
+        fgSettings.classList.toggle('open', !!AppGlobals.state.fahrgassenEnabled);
       }
       var fgBreite = document.getElementById('fahrgassen_breite');
       if (fgBreite) {
-        if (state.fahrgassenBreite > 0) {
+        if (AppGlobals.state.fahrgassenBreite > 0) {
           // Tests 8: rohe Ganzzahl als Input-Wert, kein ",0" für ganze Zahlen.
           // Nutze fmtCompact (Issue #266), das ",0" für ganze Zahlen weglässt.
-          fgBreite.value = fmtCompact(state.fahrgassenBreite);
+          fgBreite.value = AppGlobals.fmtCompact(AppGlobals.state.fahrgassenBreite);
         } else {
           fgBreite.value = '';
         }
@@ -147,61 +147,61 @@
       var egToggle = document.getElementById('einheit_groesse_toggle');
       var egSettings = document.getElementById('einheit_groesse_settings');
       if (egToggle) {
-        egToggle.classList.toggle('active', !!state.einheitGroesseEnabled);
-        egToggle.setAttribute('aria-pressed', state.einheitGroesseEnabled ? 'true' : 'false');
+        egToggle.classList.toggle('active', !!AppGlobals.state.einheitGroesseEnabled);
+        egToggle.setAttribute('aria-pressed', AppGlobals.state.einheitGroesseEnabled ? 'true' : 'false');
       }
       if (egSettings) {
-        egSettings.classList.toggle('open', !!state.einheitGroesseEnabled);
+        egSettings.classList.toggle('open', !!AppGlobals.state.einheitGroesseEnabled);
       }
       var kpEl = document.getElementById('koerner_pro_einheit');
-      if (kpEl && state.koernerProEinheit !== 50000) {
+      if (kpEl && AppGlobals.state.koernerProEinheit !== 50000) {
         // Tests 18, 24: rohe Ganzzahl als Input-Wert (kein Tausender-Punkt),
         // damit parseDE() in einheitGroesseUpdate() den Wert korrekt zurückschreibt.
-        kpEl.value = String(state.koernerProEinheit);
+        kpEl.value = String(AppGlobals.state.koernerProEinheit);
         kpEl.dataset.prev = kpEl.value;
         kpEl.dataset.cleaned = kpEl.value;
       }
       var egSaved = document.getElementById('einheit_groesse_saved');
       if (egSaved) {
-        egSaved.textContent = state.koernerProEinheit !== 50000
-          ? state.koernerProEinheit.toLocaleString('de-DE') + ' Körner/Einheit'
+        egSaved.textContent = AppGlobals.state.koernerProEinheit !== 50000
+          ? AppGlobals.state.koernerProEinheit.toLocaleString('de-DE') + ' Körner/Einheit'
           : '';
       }
-      if (state.reiter[state.activeReiter] && state.reiter[state.activeReiter].hektar > 0 && state.reiter[state.activeReiter].koerner > 0) {
-        renderResults();
-        if (state.activeView !== 'protokoll') {
+      if (AppGlobals.state.reiter[AppGlobals.state.activeReiter] && AppGlobals.state.reiter[AppGlobals.state.activeReiter].hektar > 0 && AppGlobals.state.reiter[AppGlobals.state.activeReiter].koerner > 0) {
+        AppGlobals.renderResults();
+        if (AppGlobals.state.activeView !== 'protokoll') {
           var resultsEl = document.getElementById('results');
           if (resultsEl) resultsEl.style.display = 'block';
         }
       }
       renderView();
-      renderDashboard();
+      AppGlobals.renderDashboard();
       var vf = document.getElementById('version_footer');
       if (vf) vf.textContent = APP_VERSION + ' · ' + APP_BUILD_DATE;
-      appOnStateChange(function(type, data) {
+      AppGlobals.appOnStateChange(function(type, data) {
         switch (type) {
           case 'TAB_CHANGED':
-            syncInputsFromState();
-            renderTabs();
-            saveState();
-            renderResults();
+            AppGlobals.syncInputsFromState();
+            AppGlobals.renderTabs();
+            AppGlobals.saveState();
+            AppGlobals.renderResults();
             break;
           case 'ENTRY_ADDED':
           case 'ENTRY_REMOVED':
           case 'ENTRY_CHANGED':
           case 'CALCULATION_DONE':
-            saveState();
-            renderTabs();
-            renderResults();
+            AppGlobals.saveState();
+            AppGlobals.renderTabs();
+            AppGlobals.renderResults();
             renderView();
             // Issue #186: Dashboard muss bei State-Änderungen mit-synchronisieren.
             // Wenn das Dashboard-Sheet offen ist, sofort neu rendern, damit
             // verbleibende Einheiten/Dünger konsistent mit Tab-Ergebnis sind.
             var dashSheet = document.getElementById('dashboard_sheet');
             if (dashSheet && dashSheet.classList.contains('open')) {
-              renderDashboard();
+              AppGlobals.renderDashboard();
             }
-            if (type === 'ENTRY_CHANGED' && state.reiter[state.activeReiter].hektar > 0 && state.reiter[state.activeReiter].koerner > 0) {
+            if (type === 'ENTRY_CHANGED' && AppGlobals.state.reiter[AppGlobals.state.activeReiter].hektar > 0 && AppGlobals.state.reiter[AppGlobals.state.activeReiter].koerner > 0) {
               var re = document.getElementById('results');
               if (re) re.style.display = 'block';
             } else if (type !== 'ENTRY_CHANGED') {
@@ -210,24 +210,24 @@
             }
             break;
           case 'STATE_LOADED':
-            syncInputsFromState();
-            renderTabs();
+            AppGlobals.syncInputsFromState();
+            AppGlobals.renderTabs();
             renderView();
-            renderResults();
-            renderDashboard();
+            AppGlobals.renderResults();
+            AppGlobals.renderDashboard();
             break;
           case 'SETTINGS_CHANGED':
-            saveState();
-            renderResults();
+            AppGlobals.saveState();
+            AppGlobals.renderResults();
             break;
           case 'TAB_RENAMED':
-            saveState();
-            renderTabs();
+            AppGlobals.saveState();
+            AppGlobals.renderTabs();
             break;
           case 'TAB_RESET':
-            saveState();
-            renderTabs();
-            renderResults();
+            AppGlobals.saveState();
+            AppGlobals.renderTabs();
+            AppGlobals.renderResults();
             var re3 = document.getElementById('results');
             if (re3) re3.style.display = 'none';
             var ds = document.getElementById('drill_section');
@@ -242,34 +242,34 @@
             if (ke) ke.style.borderColor = '';
             break;
           case 'TAB_ADDED':
-            syncInputsFromState();
-            saveState();
-            renderTabs();
+            AppGlobals.syncInputsFromState();
+            AppGlobals.saveState();
+            AppGlobals.renderTabs();
             break;
           case 'TAB_REMOVED':
-            syncInputsFromState();
-            saveState();
-            renderTabs();
-            renderResults();
+            AppGlobals.syncInputsFromState();
+            AppGlobals.saveState();
+            AppGlobals.renderTabs();
+            AppGlobals.renderResults();
             break;
           case 'VIEW_CHANGED':
-            saveState();
-            renderTabs();
+            AppGlobals.saveState();
+            AppGlobals.renderTabs();
             renderView();
-            if (state.activeView === 'protokoll') renderDrillTabList();
-            renderResults();
+            if (AppGlobals.state.activeView === 'protokoll') AppGlobals.renderDrillTabList();
+            AppGlobals.renderResults();
             break;
           case 'DRILL_ENTRY_ADDED':
-            saveState();
-            renderDrillTabList();
-            renderResults();
-            drillCalcAll();
+            AppGlobals.saveState();
+            AppGlobals.renderDrillTabList();
+            AppGlobals.renderResults();
+            AppGlobals.drillCalcAll();
             break;
           case 'DRILL_ENTRY_REMOVED':
-            saveState();
-            renderDrillTabList();
-            renderResults();
-            drillCalcAll();
+            AppGlobals.saveState();
+            AppGlobals.renderDrillTabList();
+            AppGlobals.renderResults();
+            AppGlobals.drillCalcAll();
             break;
         }
       });
@@ -278,7 +278,7 @@
     // --- Confirm Remove Tab ---
 
     function confirmRemoveReiter(idx) {
-      var tab = state.reiter[idx];
+      var tab = AppGlobals.state.reiter[idx];
       if (!tab) return;
       var hasEntries = tab.entries && tab.entries.length > 0;
       var hasData = tab.hektar > 0 || tab.koerner > 0 || tab.duenger > 0 || tab.istHektar > 0;
@@ -287,5 +287,13 @@
       } else {
         if (!confirm('Tab "' + tab.name + '" wirklich löschen? Alle Eingaben gehen verloren.')) return;
       }
-      removeReiter(idx);
+      AppGlobals.removeReiter(idx);
     }
+
+// Register exposed globals on AppGlobals (ADR-001 Schritt 3, Issue #278).
+Object.assign(window.AppGlobals, {
+  renderTabs: renderTabs,
+  renderView: renderView,
+  initUI: initUI,
+  confirmRemoveReiter: confirmRemoveReiter,
+});

--- a/public/js/reset-modal.js
+++ b/public/js/reset-modal.js
@@ -77,7 +77,7 @@
 
     function _onResetTab() {
       closeResetModal();
-      if (typeof resetActiveTab === 'function') resetActiveTab();
+      if (typeof AppGlobals.resetActiveTab === 'function') AppGlobals.resetActiveTab();
     }
 
     function _onResetAll() {
@@ -94,7 +94,7 @@
       }
       // Zweite Stufe: ausführen.
       closeResetModal();
-      if (typeof resetAll === 'function') resetAll();
+      if (typeof AppGlobals.resetAll === 'function') AppGlobals.resetAll();
     }
 
     function _onOverlayClick(e) {
@@ -138,3 +138,21 @@
       }
       _modalLastTrigger = null;
     }
+
+// Register exposed globals on AppGlobals (ADR-001 Schritt 3, Issue #278).
+Object.assign(window.AppGlobals, {
+  _modalLastTrigger: _modalLastTrigger,
+  _fullResetArmed: _fullResetArmed,
+  _getModal: _getModal,
+  _getOverlay: _getOverlay,
+  _focusableInModal: _focusableInModal,
+  _trapFocus: _trapFocus,
+  _onKeydown: _onKeydown,
+  _disarmFullReset: _disarmFullReset,
+  _onResetTab: _onResetTab,
+  _onResetAll: _onResetAll,
+  _onOverlayClick: _onOverlayClick,
+  _onCancel: _onCancel,
+  openResetModal: openResetModal,
+  closeResetModal: closeResetModal,
+});

--- a/public/js/state.js
+++ b/public/js/state.js
@@ -72,7 +72,7 @@ function migrateLegacyStorageKeys() {
 migrateLegacyStorageKeys();
 
 function saveState() {
-  invalidateCarryoverCache();
+  AppGlobals.invalidateCarryoverCache();
   try {
     localStorage.setItem('agrar_rechner', JSON.stringify(state));
   } catch(e) {
@@ -394,3 +394,38 @@ function dismissUpdateHint() {
   var banner = document.getElementById('update_banner');
   if (banner) banner.classList.remove('show');
 }
+
+// Register exposed globals on AppGlobals (ADR-001 Schritt 3, Issue #278).
+// `state` ist absichtlich NICHT hier registriert — AppGlobals.state ist
+// bereits in app-globals.js als Live-Alias für die `var state` definiert
+// (Getter/Setter). Ein hier eingefügter `state: state` würde den Getter
+// mit einem Plain-Property überschreiben und Reassignments (loadState,
+// resetAll, Cross-Tab-Sync) brechen.
+Object.assign(window.AppGlobals, {
+  LEGACY_KEY_MAP: LEGACY_KEY_MAP,
+  ALLOWED_TOP_KEYS: ALLOWED_TOP_KEYS,
+  ALLOWED_TAB_KEYS: ALLOWED_TAB_KEYS,
+  ALLOWED_ENTRY_KEYS: ALLOWED_ENTRY_KEYS,
+  ALLOWED_MACHINE_LOG_KEYS: ALLOWED_MACHINE_LOG_KEYS,
+  isIOS: isIOS,
+  isStandalone: isStandalone,
+  UPDATE_CHANGELOG: UPDATE_CHANGELOG,
+  migrateLegacyStorageKeys: migrateLegacyStorageKeys,
+  saveState: saveState,
+  showSaveError: showSaveError,
+  dismissSaveError: dismissSaveError,
+  isPlainObject: isPlainObject,
+  sanitizeNumber: sanitizeNumber,
+  sanitizeString: sanitizeString,
+  sanitizeBoolean: sanitizeBoolean,
+  sanitizeEntry: sanitizeEntry,
+  sanitizeMachineLogEntry: sanitizeMachineLogEntry,
+  sanitizeTab: sanitizeTab,
+  jsonReviver: jsonReviver,
+  parsePersistedState: parsePersistedState,
+  loadState: loadState,
+  maybeShowIosInstallHint: maybeShowIosInstallHint,
+  dismissIosInstallHint: dismissIosInstallHint,
+  maybeShowUpdateHint: maybeShowUpdateHint,
+  dismissUpdateHint: dismissUpdateHint,
+});

--- a/public/js/ui-handlers.js
+++ b/public/js/ui-handlers.js
@@ -57,62 +57,62 @@
     function addReiter() {
       syncStateFromInputs();
       var maxIdx = 0;
-      state.reiter.forEach(function(r, i) { var m = parseInt(r.name.replace(/\D+/g, '')); if (!isNaN(m) && m > maxIdx) maxIdx = m; });
-      state.reiter.push({ name: 'Tab ' + (maxIdx + 1), hektar: 0, istHektar: 0, koerner: 0, duenger: 0, entries: [], fahrgassenEnabled: state.fahrgassenEnabled, fahrgassenBreite: state.fahrgassenBreite });
-      state.activeReiter = state.reiter.length - 1;
-      appEmit('TAB_ADDED', { tabIdx: state.activeReiter });
+      AppGlobals.state.reiter.forEach(function(r, i) { var m = parseInt(r.name.replace(/\D+/g, '')); if (!isNaN(m) && m > maxIdx) maxIdx = m; });
+      AppGlobals.state.reiter.push({ name: 'Tab ' + (maxIdx + 1), hektar: 0, istHektar: 0, koerner: 0, duenger: 0, entries: [], fahrgassenEnabled: AppGlobals.state.fahrgassenEnabled, fahrgassenBreite: AppGlobals.state.fahrgassenBreite });
+      AppGlobals.state.activeReiter = AppGlobals.state.reiter.length - 1;
+      AppGlobals.appEmit('TAB_ADDED', { tabIdx: AppGlobals.state.activeReiter });
       document.getElementById('hektar').focus();
     }
 
     function removeReiter(idx) {
-      if (state.reiter.length <= 1) return;
+      if (AppGlobals.state.reiter.length <= 1) return;
       syncStateFromInputs();
-      state.reiter.splice(idx, 1);
-      if (idx < state.activeReiter) {
-        state.activeReiter -= 1; // Tab before active was removed — shift active left
-      } else if (state.activeReiter >= state.reiter.length) {
-        state.activeReiter = state.reiter.length - 1; // Active tab removed — clamp to last
+      AppGlobals.state.reiter.splice(idx, 1);
+      if (idx < AppGlobals.state.activeReiter) {
+        AppGlobals.state.activeReiter -= 1; // Tab before active was removed — shift active left
+      } else if (AppGlobals.state.activeReiter >= AppGlobals.state.reiter.length) {
+        AppGlobals.state.activeReiter = AppGlobals.state.reiter.length - 1; // Active tab removed — clamp to last
       }
       var newPriorities = {};
-      Object.keys(state.drillPriorities).forEach(function(key) {
+      Object.keys(AppGlobals.state.drillPriorities).forEach(function(key) {
         var k = parseInt(key, 10);
-        if (k < idx) newPriorities[k] = state.drillPriorities[k];
-        else if (k > idx) newPriorities[k - 1] = state.drillPriorities[k];
+        if (k < idx) newPriorities[k] = AppGlobals.state.drillPriorities[k];
+        else if (k > idx) newPriorities[k - 1] = AppGlobals.state.drillPriorities[k];
       });
-      state.drillPriorities = newPriorities;
-      appEmit('TAB_REMOVED', { tabIdx: idx });
+      AppGlobals.state.drillPriorities = newPriorities;
+      AppGlobals.appEmit('TAB_REMOVED', { tabIdx: idx });
     }
 
     function switchReiter(idx) {
-      if (idx === state.activeReiter && state.activeView !== 'protokoll') return;
+      if (idx === AppGlobals.state.activeReiter && AppGlobals.state.activeView !== 'protokoll') return;
       syncStateFromInputs();
-      state.activeReiter = idx;
-      state.activeView = null;
-      appEmit('TAB_CHANGED', { tabIdx: idx });
+      AppGlobals.state.activeReiter = idx;
+      AppGlobals.state.activeView = null;
+      AppGlobals.appEmit('TAB_CHANGED', { tabIdx: idx });
     }
 
     function renameReiter(idx, name) {
-      state.reiter[idx].name = name.substring(0, 20);
-      appEmit('TAB_RENAMED', { tabIdx: idx });
+      AppGlobals.state.reiter[idx].name = name.substring(0, 20);
+      AppGlobals.appEmit('TAB_RENAMED', { tabIdx: idx });
     }
 
     function switchToProtokoll() {
       syncStateFromInputs();
-      if (state.activeView === 'protokoll') {
-        state.activeView = null;
+      if (AppGlobals.state.activeView === 'protokoll') {
+        AppGlobals.state.activeView = null;
       } else {
-        state.activeView = 'protokoll';
-        renderDrillTabList();
+        AppGlobals.state.activeView = 'protokoll';
+        AppGlobals.renderDrillTabList();
       }
-      appEmit('VIEW_CHANGED', { view: state.activeView });
+      AppGlobals.appEmit('VIEW_CHANGED', { view: AppGlobals.state.activeView });
     }
 
     // --- Fahrgassen ---
 
     function fahrgassenToggle() {
-      state.fahrgassenEnabled = !state.fahrgassenEnabled;
+      AppGlobals.state.fahrgassenEnabled = !AppGlobals.state.fahrgassenEnabled;
       var btn = document.getElementById('fahrgassen_toggle');
-      if (state.fahrgassenEnabled) {
+      if (AppGlobals.state.fahrgassenEnabled) {
         document.getElementById('fahrgassen_settings').classList.add('open');
         btn.classList.add('active');
         btn.setAttribute('aria-pressed', 'true');
@@ -120,31 +120,31 @@
         document.getElementById('fahrgassen_settings').classList.remove('open');
         btn.classList.remove('active');
         btn.setAttribute('aria-pressed', 'false');
-        state.fahrgassenBreite = 0;
+        AppGlobals.state.fahrgassenBreite = 0;
         document.getElementById('fahrgassen_saved').textContent = '';
       }
       // 5a: per-Tab-State synchronisieren — Berechnungen lesen r.fahrgassenEnabled
-      state.reiter.forEach(function(r) {
-        r.fahrgassenEnabled = state.fahrgassenEnabled;
-        r.fahrgassenBreite = state.fahrgassenBreite;
+      AppGlobals.state.reiter.forEach(function(r) {
+        r.fahrgassenEnabled = AppGlobals.state.fahrgassenEnabled;
+        r.fahrgassenBreite = AppGlobals.state.fahrgassenBreite;
       });
-      appEmit('SETTINGS_CHANGED', { setting: 'fahrgassenEnabled' });
+      AppGlobals.appEmit('SETTINGS_CHANGED', { setting: 'fahrgassenEnabled' });
     }
 
     function fahrgassenUpdate() {
       var raw = document.getElementById('fahrgassen_breite').value;
-      var val = parseDE(raw);
+      var val = AppGlobals.parseDE(raw);
       // 5d: breite < 2 → State unverändert, Feld zurücksetzen
       if (val >= 2) {
-        state.fahrgassenBreite = val;
+        AppGlobals.state.fahrgassenBreite = val;
         // 5c: Prozent-Info anzeigen
         // Anteil produktiv mit Fahrgassen: (breite-1)/breite → 23/24 = 95.83% für breite=24
         var pct = ((val - 1) / val) * 100;
         document.getElementById('fahrgassen_saved').textContent = val + ' m -> ~' + pct.toFixed(1) + '% bestellt';
         document.getElementById('fahrgassen_breite').style.borderColor = '';
         // 5a: per-Tab-State syncen
-        state.reiter.forEach(function(r) {
-          r.fahrgassenEnabled = state.fahrgassenEnabled;
+        AppGlobals.state.reiter.forEach(function(r) {
+          r.fahrgassenEnabled = AppGlobals.state.fahrgassenEnabled;
           r.fahrgassenBreite = val;
         });
       } else {
@@ -152,34 +152,34 @@
         document.getElementById('fahrgassen_saved').textContent = '';
         document.getElementById('fahrgassen_breite').style.borderColor = '';
         if (val === 0 || isNaN(val)) {
-          state.fahrgassenBreite = 0;
+          AppGlobals.state.fahrgassenBreite = 0;
         }
         // val < 2 (aber > 0): State bleibt auf letztem gültigen Wert
         // Feld wird nicht überschrieben — User sieht Eingabe, kann korrigieren
         if (val > 0 && val < 2) {
           document.getElementById('fahrgassen_saved').textContent = 'Fahrgassenbreite muss mindestens 2m betragen';
           // Feld auf vorherigen gültigen Wert zurücksetzen (oder leer wenn State 0)
-          document.getElementById('fahrgassen_breite').value = state.fahrgassenBreite > 0
-            ? String(state.fahrgassenBreite)
+          document.getElementById('fahrgassen_breite').value = AppGlobals.state.fahrgassenBreite > 0
+            ? String(AppGlobals.state.fahrgassenBreite)
             : '';
         }
         if (val === 0 || isNaN(val)) {
-          state.reiter.forEach(function(r) {
-            r.fahrgassenEnabled = state.fahrgassenEnabled;
+          AppGlobals.state.reiter.forEach(function(r) {
+            r.fahrgassenEnabled = AppGlobals.state.fahrgassenEnabled;
             r.fahrgassenBreite = 0;
           });
         }
       }
-      appEmit('SETTINGS_CHANGED', { setting: 'fahrgassenBreite' });
+      AppGlobals.appEmit('SETTINGS_CHANGED', { setting: 'fahrgassenBreite' });
     }
 
     // --- Einheiten-Groesse ---
 
     function einheitGroesseToggle() {
-      state.einheitGroesseEnabled = !state.einheitGroesseEnabled;
+      AppGlobals.state.einheitGroesseEnabled = !AppGlobals.state.einheitGroesseEnabled;
       var btn = document.getElementById('einheit_groesse_toggle');
       var saved = document.getElementById('einheit_groesse_saved');
-      if (state.einheitGroesseEnabled) {
+      if (AppGlobals.state.einheitGroesseEnabled) {
         document.getElementById('einheit_groesse_settings').classList.add('open');
         btn.classList.add('active');
         btn.setAttribute('aria-pressed', 'true');
@@ -187,46 +187,46 @@
         document.getElementById('einheit_groesse_settings').classList.remove('open');
         btn.classList.remove('active');
         btn.setAttribute('aria-pressed', 'false');
-        state.koernerProEinheit = 50000;
+        AppGlobals.state.koernerProEinheit = 50000;
         if (saved) saved.textContent = '';
         // Clear input
         var kpEl = document.getElementById('koerner_pro_einheit');
         if (kpEl) { kpEl.value = ''; kpEl.dataset.prev = ''; kpEl.dataset.cleaned = ''; }
       }
-      appEmit('SETTINGS_CHANGED', { setting: 'einheitGroesseEnabled' });
+      AppGlobals.appEmit('SETTINGS_CHANGED', { setting: 'einheitGroesseEnabled' });
     }
 
     function einheitGroesseUpdate() {
       var raw = document.getElementById('koerner_pro_einheit').value;
-      var val = parseDE(raw);
+      var val = AppGlobals.parseDE(raw);
       var savedEl = document.getElementById('einheit_groesse_saved');
       if (val !== null && val > 0 && val <= 999999) {
-        state.koernerProEinheit = Math.round(val);
+        AppGlobals.state.koernerProEinheit = Math.round(val);
         // Show info text only for non-default values
-        if (state.koernerProEinheit === 50000) {
+        if (AppGlobals.state.koernerProEinheit === 50000) {
           if (savedEl) savedEl.textContent = '';
         } else {
-          if (savedEl) savedEl.textContent = state.koernerProEinheit.toLocaleString('de-DE') + ' Körner/Einheit';
+          if (savedEl) savedEl.textContent = AppGlobals.state.koernerProEinheit.toLocaleString('de-DE') + ' Körner/Einheit';
         }
         document.getElementById('koerner_pro_einheit').style.borderColor = '';
       } else {
         document.getElementById('koerner_pro_einheit').style.borderColor = '#c00';
       }
-      appEmit('SETTINGS_CHANGED', { setting: 'koernerProEinheit' });
+      AppGlobals.appEmit('SETTINGS_CHANGED', { setting: 'koernerProEinheit' });
     }
 
     // --- Reset ---
 
     function resetActiveTab() {
-      var active = state.activeReiter;
-      state.reiter[active] = {
-        name: state.reiter[active].name,
+      var active = AppGlobals.state.activeReiter;
+      AppGlobals.state.reiter[active] = {
+        name: AppGlobals.state.reiter[active].name,
         hektar: 0, istHektar: 0, koerner: 0, duenger: 0,
         entries: [],
-        fahrgassenEnabled: state.fahrgassenEnabled,
-        fahrgassenBreite: state.fahrgassenBreite
+        fahrgassenEnabled: AppGlobals.state.fahrgassenEnabled,
+        fahrgassenBreite: AppGlobals.state.fahrgassenBreite
       };
-      state.drillPriorities = {};
+      AppGlobals.state.drillPriorities = {};
       // Clear drill summary values (Issue #281: IDs aus DOM_IDS)
       for (var si = 0; si < DOM_IDS.drillSummary.length; si++) {
         var sEl = document.getElementById(DOM_IDS.drillSummary[si]);
@@ -250,11 +250,11 @@
       _resetInput(DOM_IDS.istHektar);
       _resetInput(DOM_IDS.koerner);
       _resetInput(DOM_IDS.duenger);
-      appEmit('TAB_RESET', { tabIdx: active });
+      AppGlobals.appEmit('TAB_RESET', { tabIdx: active });
     }
 
     function resetAll() {
-      state = {
+      AppGlobals.state = {
         reiter: [{ name: 'Tab 1', hektar: 0, istHektar: 0, koerner: 0, duenger: 0, entries: [] }],
         activeReiter: 0,
         activeView: null,
@@ -305,9 +305,9 @@
       if (kp) kp.value = '';
       var egSv = document.getElementById(DOM_IDS.einheitGroesseSaved);
       if (egSv) egSv.textContent = '';
-      state.drillPriorities = {};
-      renderTabs();
-      saveState();
+      AppGlobals.state.drillPriorities = {};
+      AppGlobals.renderTabs();
+      AppGlobals.saveState();
     }
 
     // --- Drill Protocol ---
@@ -319,9 +319,9 @@
       var duengerVal = document.getElementById('drill_duenger').value;
       var hektarVal = document.getElementById('drill_hektar').value;
       return {
-        einheit: parseDE(einheitVal) || 0,
-        duenger: parseDE(duengerVal) || 0,
-        zaehlerStand: parseDE(hektarVal) || 0
+        einheit: AppGlobals.parseDE(einheitVal) || 0,
+        duenger: AppGlobals.parseDE(duengerVal) || 0,
+        zaehlerStand: AppGlobals.parseDE(hektarVal) || 0
       };
     }
 
@@ -335,18 +335,18 @@
       var perTabE = [], perTabD = [];
       var hasPriority = false;
       var perTabHasAny = false;
-      for (var ii = 0; ii < state.reiter.length; ii++) {
+      for (var ii = 0; ii < AppGlobals.state.reiter.length; ii++) {
         var peEl = document.getElementById('dtl_e_' + ii);
         var pdEl = document.getElementById('dtl_d_' + ii);
         var peRaw = peEl && peEl.dataset && peEl.dataset.rawValue;
         var pdRaw = pdEl && pdEl.dataset && pdEl.dataset.rawValue;
         var pe = peRaw !== undefined && peRaw !== '' ? parseFloat(peRaw)
-                  : (peEl ? parseDE(peEl.value) || 0 : 0);
+                  : (peEl ? AppGlobals.parseDE(peEl.value) || 0 : 0);
         var pd = pdRaw !== undefined && pdRaw !== '' ? parseFloat(pdRaw)
-                  : (pdEl ? parseDE(pdEl.value) || 0 : 0);
+                  : (pdEl ? AppGlobals.parseDE(pdEl.value) || 0 : 0);
         perTabE.push(pe);
         perTabD.push(pd);
-        var prio = state.drillPriorities[ii] || 0;
+        var prio = AppGlobals.state.drillPriorities[ii] || 0;
         if (prio > 0) hasPriority = true;
         if (prio > 0 && (pe > 0 || pd > 0)) perTabHasAny = true;
       }
@@ -358,14 +358,14 @@
     // Push (mlIdx = -1). Berechnet die cap-bewerteten Mengen für ein Tab.
     function _buildDrillEntry(tab, unitsRaw, duengerRaw, zaehlerStand, mlIdx) {
       var fgFactor = (tab.fahrgassenEnabled && tab.fahrgassenBreite >= 2)
-        ? computeFahrgassenFaktor(tab.fahrgassenBreite) : 1;
-      var perUnit = (tab.koerner * fgFactor) / state.koernerProEinheit;
+        ? AppGlobals.computeFahrgassenFaktor(tab.fahrgassenBreite) : 1;
+      var perUnit = (tab.koerner * fgFactor) / AppGlobals.state.koernerProEinheit;
       var maxUnitsThisTab = tab.hektar * perUnit;
       var unitsForThisTab = Math.min(unitsRaw, maxUnitsThisTab);
-      var duengerPerUnit = getDuengerProEinheit(tab, state.koernerProEinheit);
+      var duengerPerUnit = AppGlobals.getDuengerProEinheit(tab, AppGlobals.state.koernerProEinheit);
       var duengerForThisTab = Math.min(duengerRaw, duengerPerUnit * unitsForThisTab);
       return {
-        time: mlIdx >= 0 ? getTabNextTime(tab) : new Date().toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' }),
+        time: mlIdx >= 0 ? AppGlobals.getTabNextTime(tab) : new Date().toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' }),
         mlIdx: mlIdx,
         einheit: Math.round(unitsForThisTab * 100) / 100,
         duenger: Math.round(duengerForThisTab * 100) / 100,
@@ -398,20 +398,20 @@
     // Hilfsfunktion: liest dtl_e_<active>/dtl_d_<active> (mit rawValue-Preferenz)
     // für den Single-Tab-Pfad. Liefert { e, d } (0 wenn nicht vorhanden).
     function _readActivePerTabValues() {
-      var activeEEl = document.getElementById('dtl_e_' + state.activeReiter);
-      var activeDEl = document.getElementById('dtl_d_' + state.activeReiter);
+      var activeEEl = document.getElementById('dtl_e_' + AppGlobals.state.activeReiter);
+      var activeDEl = document.getElementById('dtl_d_' + AppGlobals.state.activeReiter);
       var activeERaw = activeEEl && activeEEl.dataset && activeEEl.dataset.rawValue;
       var activeDRaw = activeDEl && activeDEl.dataset && activeDEl.dataset.rawValue;
       var e = activeERaw !== undefined && activeERaw !== '' ? parseFloat(activeERaw)
-              : (activeEEl ? parseDE(activeEEl.value) || 0 : 0);
+              : (activeEEl ? AppGlobals.parseDE(activeEEl.value) || 0 : 0);
       var d = activeDRaw !== undefined && activeDRaw !== '' ? parseFloat(activeDRaw)
-              : (activeDEl ? parseDE(activeDEl.value) || 0 : 0);
+              : (activeDEl ? AppGlobals.parseDE(activeDEl.value) || 0 : 0);
       return { e: e, d: d };
     }
 
     // Hilfsfunktion: setzt alle Drill-Inputs (global + per-Tab) zurück.
     function _clearDrillInputs() {
-      for (var ci = 0; ci < state.reiter.length; ci++) {
+      for (var ci = 0; ci < AppGlobals.state.reiter.length; ci++) {
         var ceEl = document.getElementById('dtl_e_' + ci);
         var cdEl = document.getElementById('dtl_d_' + ci);
         if (ceEl) ceEl.value = '';
@@ -426,25 +426,25 @@
       var input = _parseDrillInputs();
       var einheit = input.einheit, duenger = input.duenger, zaehlerStand = input.zaehlerStand;
       if (einheit <= 0 && duenger <= 0) return;
-      var activeTab = state.reiter[state.activeReiter];
+      var activeTab = AppGlobals.state.reiter[AppGlobals.state.activeReiter];
       if (!activeTab) return;
       var targetHektar = activeTab.hektar > 0 ? activeTab.hektar : 0;
       var dist = _resolvePerTabDistribution();
       var anyPushed = false;
       if (dist.hasPriority && dist.perTabHasAny) {
         // === Multi-tab mode: one entry per prioritized tab with values ===
-        for (var ti = 0; ti < state.reiter.length; ti++) {
-          if ((state.drillPriorities[ti] || 0) <= 0) continue;
+        for (var ti = 0; ti < AppGlobals.state.reiter.length; ti++) {
+          if ((AppGlobals.state.drillPriorities[ti] || 0) <= 0) continue;
           if (dist.perTabE[ti] <= 0 && dist.perTabD[ti] <= 0) continue;
-          var tab = state.reiter[ti];
-          var entry = _buildDrillEntry(tab, dist.perTabE[ti], dist.perTabD[ti], zaehlerStand, state.machineLog.length);
+          var tab = AppGlobals.state.reiter[ti];
+          var entry = _buildDrillEntry(tab, dist.perTabE[ti], dist.perTabD[ti], zaehlerStand, AppGlobals.state.machineLog.length);
           _pushEntryToTab(tab, entry);
           anyPushed = true;
         }
         // Ghost-entry fix (Issue #73): only push machineLog if at least one
         // per-tab entry was actually created.
         if (anyPushed) {
-          state.machineLog.push(_buildMachineLogEntry(einheit, duenger, zaehlerStand, targetHektar, activeTab));
+          AppGlobals.state.machineLog.push(_buildMachineLogEntry(einheit, duenger, zaehlerStand, targetHektar, activeTab));
         }
       } else if (activeTab.hektar > 0) {
         // === Single-tab mode ===
@@ -452,7 +452,7 @@
         // per-tab distribution is ambiguous in a multi-tab session → bail.
         var activeVD = _readActivePerTabValues();
         if (activeVD.e <= 0 && activeVD.d <= 0 &&
-            ((einheit <= 0 && duenger <= 0) || state.reiter.length > 1)) {
+            ((einheit <= 0 && duenger <= 0) || AppGlobals.state.reiter.length > 1)) {
           _clearDrillInputs();
           return;
         }
@@ -466,13 +466,13 @@
       }
       if (!anyPushed) { _clearDrillInputs(); return; }
       _clearDrillInputs();
-      appEmit('DRILL_ENTRY_ADDED', { tabIdx: state.activeReiter });
+      AppGlobals.appEmit('DRILL_ENTRY_ADDED', { tabIdx: AppGlobals.state.activeReiter });
     }
 
     function drillRemove(tabIdx, entryIdx) {
-      if (!state.reiter[tabIdx] || !state.reiter[tabIdx].entries) return;
-      state.reiter[tabIdx].entries.splice(entryIdx, 1);
-      appEmit('DRILL_ENTRY_REMOVED', { tabIdx: tabIdx, entryIdx: entryIdx });
+      if (!AppGlobals.state.reiter[tabIdx] || !AppGlobals.state.reiter[tabIdx].entries) return;
+      AppGlobals.state.reiter[tabIdx].entries.splice(entryIdx, 1);
+      AppGlobals.appEmit('DRILL_ENTRY_REMOVED', { tabIdx: tabIdx, entryIdx: entryIdx });
     }
 
     // Issue #277: _calcDrillDistribution ist die pure Berechnung der
@@ -486,12 +486,12 @@
     //     wenn er noch ungenutzten cap hat (Issue #266).
     function _calcDrillDistribution(totalE, totalD) {
       var priorities = [];
-      for (var pi2 = 0; pi2 < state.reiter.length; pi2++) {
-        var r = state.reiter[pi2];
+      for (var pi2 = 0; pi2 < AppGlobals.state.reiter.length; pi2++) {
+        var r = AppGlobals.state.reiter[pi2];
         if (r.hektar > 0 && r.koerner > 0) {
-          var prio = state.drillPriorities[pi2] || 0;
-          var total = getTabTotalEinheiten(r);
-          var used = getTabUsedEinheiten(r);
+          var prio = AppGlobals.state.drillPriorities[pi2] || 0;
+          var total = AppGlobals.getTabTotalEinheiten(r);
+          var used = AppGlobals.getTabUsedEinheiten(r);
           var rem = Math.max(0, total - used);
           priorities.push({ idx: pi2, prio: prio, rem: rem, r: r });
         }
@@ -501,7 +501,7 @@
         return a.idx - b.idx;
       });
       var plan = {};
-      for (var pi = 0; pi < state.reiter.length; pi++) plan[pi] = { giveE: 0, giveD: 0 };
+      for (var pi = 0; pi < AppGlobals.state.reiter.length; pi++) plan[pi] = { giveE: 0, giveD: 0 };
       if (totalE > 0 || totalD > 0) {
         var remE = totalE;
         var remD = totalD;
@@ -512,12 +512,12 @@
         for (var ipi = 0; ipi < priorities.length; ipi++) {
           var p = priorities[ipi];
           if (p.prio <= 0) continue;
-          if (remE <= EPSILON_QUANTITY && remD <= EPSILON_QUANTITY) break;
-          if (remE > EPSILON_QUANTITY) {
+          if (remE <= AppGlobals.EPSILON_QUANTITY && remD <= AppGlobals.EPSILON_QUANTITY) break;
+          if (remE > AppGlobals.EPSILON_QUANTITY) {
             plan[p.idx].giveE = Math.min(remE, p.rem);
             remE -= plan[p.idx].giveE;
           }
-          if (remD > EPSILON_QUANTITY) {
+          if (remD > AppGlobals.EPSILON_QUANTITY) {
             var tabDUsed = (p.r.entries || []).reduce(function(s, e) { return s + (e.duenger || 0); }, 0);
             var tabDNeed = Math.max(0, (p.r.hektar || 0) * (p.r.duenger || 0));
             var tabDCap = Math.max(0, tabDNeed - tabDUsed);
@@ -526,13 +526,13 @@
           }
         }
         // Leftover-Absorption im letzten priorisierten Reiter (Issue #266)
-        if (lastPrioIdx >= 0 && remE > EPSILON_QUANTITY) {
+        if (lastPrioIdx >= 0 && remE > AppGlobals.EPSILON_QUANTITY) {
           var lastPlan = plan[lastPrioIdx];
           var lastP = null;
           for (var lpf = 0; lpf < priorities.length; lpf++) {
             if (priorities[lpf].idx === lastPrioIdx) { lastP = priorities[lpf]; break; }
           }
-          if (lastP && lastPlan.giveE < lastP.rem - EPSILON_QUANTITY) {
+          if (lastP && lastPlan.giveE < lastP.rem - AppGlobals.EPSILON_QUANTITY) {
             lastPlan.giveE += remE;
           }
         }
@@ -544,16 +544,16 @@
     // dtl_e_<i>/dtl_d_<i> Felder und steckt den 2-Dezimal-Wert in
     // dataset.rawValue (Issue #266-B2). Reine DOM-Schreib-Logik.
     function _applyDrillPlan(plan) {
-      for (var ai = 0; ai < state.reiter.length; ai++) {
+      for (var ai = 0; ai < AppGlobals.state.reiter.length; ai++) {
         var p = plan[ai];
         var eEl = document.getElementById('dtl_e_' + ai);
         var dEl = document.getElementById('dtl_d_' + ai);
         if (eEl) {
-          eEl.value = p.giveE > 0 ? fmt(p.giveE) : '';
+          eEl.value = p.giveE > 0 ? AppGlobals.fmt(p.giveE) : '';
           eEl.dataset.rawValue = p.giveE > 0 ? String(Math.round(p.giveE * 100) / 100) : '';
         }
         if (dEl) {
-          dEl.value = p.giveD > 0 ? fmt(p.giveD) : '';
+          dEl.value = p.giveD > 0 ? AppGlobals.fmt(p.giveD) : '';
           dEl.dataset.rawValue = p.giveD > 0 ? String(Math.round(p.giveD * 100) / 100) : '';
         }
       }
@@ -561,34 +561,34 @@
 
     function drillCalcAll() {
       // Read user input
-      var totalE = parseDE(document.getElementById('drill_einheit').value) || 0;
-      var totalD = parseDE(document.getElementById('drill_duenger').value) || 0;
+      var totalE = AppGlobals.parseDE(document.getElementById('drill_einheit').value) || 0;
+      var totalD = AppGlobals.parseDE(document.getElementById('drill_duenger').value) || 0;
       // Pure Verteilungs-Berechnung (Issue #277) — kein DOM-Zugriff
       var plan = _calcDrillDistribution(totalE, totalD);
       // Tab-Liste neu rendern (Input-Felder werden ersetzt)
-      renderDrillTabList();
+      AppGlobals.renderDrillTabList();
       // Plan in die frischen Inputs schreiben
       _applyDrillPlan(plan);
-      renderDrillSummary();
-      renderResults();
+      AppGlobals.renderDrillSummary();
+      AppGlobals.renderResults();
     }
 
     function drillCalcDebounced() {
-      clearTimeout(_internal.drillCalcTimer);
-      _internal.drillCalcTimer = setTimeout(drillCalcAll, 150);
+      clearTimeout(AppGlobals._internal.drillCalcTimer);
+      AppGlobals._internal.drillCalcTimer = setTimeout(AppGlobals.drillCalcAll, 150);
     }
 
     function drillMachineAdd() {
       var einheitVal = document.getElementById('drill_einheit').value;
       var duengerVal = document.getElementById('drill_duenger').value;
-      var einheit = parseDE(einheitVal) || 0;
-      var duenger = parseDE(duengerVal) || 0;
-      var targetHektar = parseDE(document.getElementById('drill_hektar').value) || 0;
+      var einheit = AppGlobals.parseDE(einheitVal) || 0;
+      var duenger = AppGlobals.parseDE(duengerVal) || 0;
+      var targetHektar = AppGlobals.parseDE(document.getElementById('drill_hektar').value) || 0;
       if (einheit <= 0 && duenger <= 0) return;
-      var activeTab = state.reiter[state.activeReiter];
+      var activeTab = AppGlobals.state.reiter[AppGlobals.state.activeReiter];
       var entry = {
         time: Date.now(),
-        mlIdx: state.machineLog.length,
+        mlIdx: AppGlobals.state.machineLog.length,
         einheit: einheit,
         duenger: duenger,
         hektar: targetHektar > 0 ? targetHektar : (activeTab.hektar || 0),
@@ -598,41 +598,41 @@
         duengerRate: activeTab.duenger,
         isMachineLog: true
       };
-      state.machineLog.push(entry);
+      AppGlobals.state.machineLog.push(entry);
       var count = parseInt(document.getElementById('drill_einheit').value) || 1;
       for (var c = 0; c < count; c++) {
-        var e = { time: Date.now() + c, mlIdx: state.machineLog.length - 1, einheit: einheit / count, duenger: duenger / count, hektar: targetHektar > 0 ? targetHektar : (activeTab.hektar || 0), istHektar: 0, zaehlerStand: targetHektar, koerner: activeTab.koerner, duengerRate: activeTab.duenger };
+        var e = { time: Date.now() + c, mlIdx: AppGlobals.state.machineLog.length - 1, einheit: einheit / count, duenger: duenger / count, hektar: targetHektar > 0 ? targetHektar : (activeTab.hektar || 0), istHektar: 0, zaehlerStand: targetHektar, koerner: activeTab.koerner, duengerRate: activeTab.duenger };
         activeTab.entries.push(e);
       }
       document.getElementById('drill_einheit').value = '';
       document.getElementById('drill_duenger').value = '';
       document.getElementById('drill_hektar').value = '';
-      appEmit('DRILL_ENTRY_ADDED', { tabIdx: state.activeReiter });
+      AppGlobals.appEmit('DRILL_ENTRY_ADDED', { tabIdx: AppGlobals.state.activeReiter });
     }
 
     function drillMachineRemove(idx) {
-      if (!state.machineLog || idx < 0 || idx >= state.machineLog.length) return;
-      state.machineLog.splice(idx, 1);
-      state.reiter.forEach(function(r) {
+      if (!AppGlobals.state.machineLog || idx < 0 || idx >= AppGlobals.state.machineLog.length) return;
+      AppGlobals.state.machineLog.splice(idx, 1);
+      AppGlobals.state.reiter.forEach(function(r) {
         if (!r.entries) return;
         for (var i = r.entries.length - 1; i >= 0; i--) {
           if (r.entries[i].mlIdx === idx) r.entries.splice(i, 1);
           else if (r.entries[i].mlIdx > idx) r.entries[i].mlIdx--;
         }
       });
-      appEmit('DRILL_ENTRY_REMOVED', { mlIdx: idx });
+      AppGlobals.appEmit('DRILL_ENTRY_REMOVED', { mlIdx: idx });
     }
 
     // --- Berechnung ---
 
     function berechne() {
-      var r = getActiveReiter();
+      var r = AppGlobals.getActiveReiter();
       if (!r) return;
       // 1) Werte aus DOM lesen (Tests setzen .value direkt)
-      var h = parseDE(document.getElementById('hektar').value);
-      var k = parseDE(document.getElementById('koerner').value);
-      var d = parseDE(document.getElementById('duenger').value);
-      var ih = parseDE(document.getElementById('ist_hektar').value) || 0;
+      var h = AppGlobals.parseDE(document.getElementById('hektar').value);
+      var k = AppGlobals.parseDE(document.getElementById('koerner').value);
+      var d = AppGlobals.parseDE(document.getElementById('duenger').value);
+      var ih = AppGlobals.parseDE(document.getElementById('ist_hektar').value) || 0;
       // 2) Errors clearen
       document.getElementById('err_hektar').textContent = '';
       document.getElementById('err_koerner').textContent = '';
@@ -679,10 +679,10 @@
         // so the arg-overridden wrapper in this file doesn't return NaN when called
         // with only `r`. See getTotalEinheiten at L697 (arg version) and L52 in
         // calculations.js (the canonical impl).
-        var newEinheiten = getTabTotalEinheiten(r);
-        var newDuenger = getTabTotalDuenger(r);
-        var einheitExceeds = newEinheiten > 0 && usedEinheit > newEinheiten + EPSILON_QUANTITY;
-        var duengerExceeds = newDuenger > 0 && usedDuenger > newDuenger + EPSILON_QUANTITY;
+        var newEinheiten = AppGlobals.getTabTotalEinheiten(r);
+        var newDuenger = AppGlobals.getTabTotalDuenger(r);
+        var einheitExceeds = newEinheiten > 0 && usedEinheit > newEinheiten + AppGlobals.EPSILON_QUANTITY;
+        var duengerExceeds = newDuenger > 0 && usedDuenger > newDuenger + AppGlobals.EPSILON_QUANTITY;
         if (einheitExceeds || duengerExceeds) {
           if (_askConfirm('Die neuen Werte weichen von den eingetragenen Einheiten ab. Drill-Protokoll zurücksetzen?')) {
             // User confirmed: clear the entries so the new calculation sticks.
@@ -701,43 +701,43 @@
         }
       }
       // 7) Speichern + rendern + Ergebnisse anzeigen
-      saveState();
-      renderTabs();
-      renderResults();
+      AppGlobals.saveState();
+      AppGlobals.renderTabs();
+      AppGlobals.renderResults();
       document.getElementById('results').style.display = 'block';
-      appEmit('CALCULATION_DONE', { tabIdx: state.activeReiter });
+      AppGlobals.appEmit('CALCULATION_DONE', { tabIdx: AppGlobals.state.activeReiter });
     }
 
     // --- Input Binding (reactive writes to state) ---
 
     function onInputHektar(el) {
-      var r = getActiveReiter();
-      var v = parseDE(el.value);
-      if (r.hektar !== v) { r.hektar = v; appEmit('ENTRY_CHANGED'); }
+      var r = AppGlobals.getActiveReiter();
+      var v = AppGlobals.parseDE(el.value);
+      if (r.hektar !== v) { r.hektar = v; AppGlobals.appEmit('ENTRY_CHANGED'); }
     }
 
     function onInputIstHektar(el) {
-      var r = getActiveReiter();
-      var v = parseDE(el.value);
-      if (r.istHektar !== v) { r.istHektar = v; appEmit('ENTRY_CHANGED'); }
+      var r = AppGlobals.getActiveReiter();
+      var v = AppGlobals.parseDE(el.value);
+      if (r.istHektar !== v) { r.istHektar = v; AppGlobals.appEmit('ENTRY_CHANGED'); }
     }
 
     function onInputKoerner(el) {
-      var r = getActiveReiter();
-      var v = parseDE(el.value);
-      if (r.koerner !== v) { r.koerner = v; appEmit('ENTRY_CHANGED'); }
+      var r = AppGlobals.getActiveReiter();
+      var v = AppGlobals.parseDE(el.value);
+      if (r.koerner !== v) { r.koerner = v; AppGlobals.appEmit('ENTRY_CHANGED'); }
     }
 
     function onInputDuenger(el) {
-      var r = getActiveReiter();
-      var v = parseDE(el.value);
-      if (r.duenger !== v) { r.duenger = v; appEmit('ENTRY_CHANGED'); }
+      var r = AppGlobals.getActiveReiter();
+      var v = AppGlobals.parseDE(el.value);
+      if (r.duenger !== v) { r.duenger = v; AppGlobals.appEmit('ENTRY_CHANGED'); }
     }
 
     // --- UI Wrappers (bridge: pure calculations → active tab context) ---
     // getTabKornerGesamt is in calculations.js; getActiveReiter is in ui-handlers.js
     function getKornerGesamt() {
-      return getTabKornerGesamt(getActiveReiter());
+      return AppGlobals.getTabKornerGesamt(AppGlobals.getActiveReiter());
     }
 
     // Issue #186: Diese Wrapper schließen die Lücke zwischen calculations.js
@@ -746,11 +746,11 @@
     // WICHTIG: Andere Namen als in calculations.js, um die Funktion
     // getTotalEinheiten(r, koernerProEinheit) dort nicht zu überschreiben.
     function getActiveTotalEinheiten() {
-      return getTabTotalEinheiten(getActiveReiter());
+      return AppGlobals.getTabTotalEinheiten(AppGlobals.getActiveReiter());
     }
 
     function getActiveTotalDuenger() {
-      return getTabTotalDuenger(getActiveReiter());
+      return AppGlobals.getTabTotalDuenger(AppGlobals.getActiveReiter());
     }
 
     // No-arg API-Kompatibilitäts-Wrapper (Issue #266).
@@ -769,22 +769,22 @@
     function getTotalEinheiten(r, koernerProEinheit) {
       if (arguments.length === 0) {
         // No-arg: für aktiven Reiter berechnen
-        return getActiveTotalEinheiten();
+        return AppGlobals.getActiveTotalEinheiten();
       }
       // Arg-Version: calculations.js-Original (Issue #230)
       if (!r || !r.hektar || !r.koerner || koernerProEinheit <= 0) return 0;
-      var fgEnabled = (r.fahrgassenEnabled !== undefined) ? r.fahrgassenEnabled : state.fahrgassenEnabled;
-      var fgBreite = (r.fahrgassenBreite !== undefined) ? r.fahrgassenBreite : state.fahrgassenBreite;
+      var fgEnabled = (r.fahrgassenEnabled !== undefined) ? r.fahrgassenEnabled : AppGlobals.state.fahrgassenEnabled;
+      var fgBreite = (r.fahrgassenBreite !== undefined) ? r.fahrgassenBreite : AppGlobals.state.fahrgassenBreite;
       var faktor = 1;
       if (fgEnabled && fgBreite > 0) {
-        faktor = computeFahrgassenFaktor(fgBreite);
+        faktor = AppGlobals.computeFahrgassenFaktor(fgBreite);
       }
       var e = (r.hektar * r.koerner) / koernerProEinheit;
       return Math.max(0, e * faktor);
     }
     function getTotalDuenger(r) {
       if (arguments.length === 0) {
-        return getActiveTotalDuenger();
+        return AppGlobals.getActiveTotalDuenger();
       }
       if (!r || !r.hektar || !r.duenger) return 0;
       return Math.max(0, r.hektar * r.duenger);
@@ -895,18 +895,18 @@
     // --- Helpers ---
 
     function getActiveReiter() {
-      var r = state.reiter[state.activeReiter];
-      if (!r) return state.reiter[0];
+      var r = AppGlobals.state.reiter[AppGlobals.state.activeReiter];
+      if (!r) return AppGlobals.state.reiter[0];
       if (!r.entries) r.entries = [];
       return r;
     }
 
     function syncStateFromInputs() {
-      var r = getActiveReiter();
-      r.hektar    = parseDE(document.getElementById('hektar').value) || 0;
-      r.istHektar = parseDE(document.getElementById('ist_hektar').value) || 0;
-      r.koerner   = parseDE(document.getElementById('koerner').value) || 0;
-      r.duenger    = parseDE(document.getElementById('duenger').value) || 0;
+      var r = AppGlobals.getActiveReiter();
+      r.hektar    = AppGlobals.parseDE(document.getElementById('hektar').value) || 0;
+      r.istHektar = AppGlobals.parseDE(document.getElementById('ist_hektar').value) || 0;
+      r.koerner   = AppGlobals.parseDE(document.getElementById('koerner').value) || 0;
+      r.duenger    = AppGlobals.parseDE(document.getElementById('duenger').value) || 0;
     }
 
     function toInputValue(n) {
@@ -914,7 +914,7 @@
     }
 
     function syncInputsFromState() {
-      var r = getActiveReiter();
+      var r = AppGlobals.getActiveReiter();
       var h = document.getElementById('hektar');
       var ih = document.getElementById('ist_hektar');
       var k = document.getElementById('koerner');
@@ -928,3 +928,51 @@
       k.value = kVal;  k.dataset.prev = kVal;  k.dataset.cleaned = kVal;
       d.value = dVal;  d.dataset.prev = dVal;  d.dataset.cleaned = dVal;
     }
+
+// Register exposed globals on AppGlobals (ADR-001 Schritt 3, Issue #278).
+Object.assign(window.AppGlobals, {
+  _askConfirm: _askConfirm,
+  DOM_IDS: DOM_IDS,
+  _resetInput: _resetInput,
+  addReiter: addReiter,
+  removeReiter: removeReiter,
+  switchReiter: switchReiter,
+  renameReiter: renameReiter,
+  switchToProtokoll: switchToProtokoll,
+  fahrgassenToggle: fahrgassenToggle,
+  fahrgassenUpdate: fahrgassenUpdate,
+  einheitGroesseToggle: einheitGroesseToggle,
+  einheitGroesseUpdate: einheitGroesseUpdate,
+  resetActiveTab: resetActiveTab,
+  resetAll: resetAll,
+  _parseDrillInputs: _parseDrillInputs,
+  _resolvePerTabDistribution: _resolvePerTabDistribution,
+  _buildDrillEntry: _buildDrillEntry,
+  _pushEntryToTab: _pushEntryToTab,
+  _buildMachineLogEntry: _buildMachineLogEntry,
+  _readActivePerTabValues: _readActivePerTabValues,
+  _clearDrillInputs: _clearDrillInputs,
+  drillAdd: drillAdd,
+  drillRemove: drillRemove,
+  _calcDrillDistribution: _calcDrillDistribution,
+  _applyDrillPlan: _applyDrillPlan,
+  drillCalcAll: drillCalcAll,
+  drillCalcDebounced: drillCalcDebounced,
+  drillMachineAdd: drillMachineAdd,
+  drillMachineRemove: drillMachineRemove,
+  berechne: berechne,
+  onInputHektar: onInputHektar,
+  onInputIstHektar: onInputIstHektar,
+  onInputKoerner: onInputKoerner,
+  onInputDuenger: onInputDuenger,
+  getKornerGesamt: getKornerGesamt,
+  getActiveTotalEinheiten: getActiveTotalEinheiten,
+  getActiveTotalDuenger: getActiveTotalDuenger,
+  getTotalEinheiten: getTotalEinheiten,
+  getTotalDuenger: getTotalDuenger,
+  onInputFormat: onInputFormat,
+  getActiveReiter: getActiveReiter,
+  syncStateFromInputs: syncStateFromInputs,
+  toInputValue: toInputValue,
+  syncInputsFromState: syncInputsFromState,
+});

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,11 +1,12 @@
 // ⚠️ CACHE_VERSION muss bei jedem Release manuell gebumpet werden!
 // Bei Vergessen bekommen Nutzer die alte Version aus dem Cache.
 // alternativa: Build-Script das Hash/Zeitstempel injiziert.
-const CACHE_VERSION = 'agrar-rechner-v15';
+const CACHE_VERSION = 'agrar-rechner-v16';
 const STATIC_ASSETS = [
     '/',
     '/index.html',
     '/css/styles.css',
+    '/js/app-globals.js',
     '/js/state.js',
     '/js/calculations.js',
     '/js/ui-handlers.js',

--- a/tests/17-edge-cases.test.js
+++ b/tests/17-edge-cases.test.js
@@ -287,8 +287,8 @@ describe('resetActiveTab — UI state after reset', () => {
 
   it('calls renderDrillSummary to clear stale drill summary', () => {
     var callCount = 0;
-    var originalFn = w.renderDrillSummary;
-    w.renderDrillSummary = function() { callCount++; originalFn.call(w); };
+    var originalFn = w.AppGlobals.renderDrillSummary;
+    w.AppGlobals.renderDrillSummary = function() { callCount++; return originalFn.apply(this, arguments); };
 
     w.state.reiter[0] = {
       name: 'Tab 1', hektar: 10, koerner: 90000, duenger: 500, entries: []
@@ -298,7 +298,7 @@ describe('resetActiveTab — UI state after reset', () => {
     w.resetActiveTab();
 
     expect(callCount).toBe(1);
-    w.renderDrillSummary = originalFn;
+    w.AppGlobals.renderDrillSummary = originalFn;
   });
 
   it('clears drill section display after reset', () => {

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -70,7 +70,12 @@ export function createDom() {
   if (tabBar) tabBar.appendChild(tabAddBtn);
 
   // Build combined script from modular JS files (skip the placeholder <script> comment block)
+  // ADR-001 (Issue #278): initialise the AppGlobals namespace before any module script runs.
+  // app-globals.js declares the namespace AND installs the `state` getter/setter
+  // (Live-Alias für `var state`); the test harness loads the real file so the
+  // test scope matches production.
   const moduleScript = [
+    loadModule('app-globals.js'),
     'var _internal = { carryoverCache: null, drillCalcTimer: null, pendingKey: null };',
     loadModule('state.js'),
     loadModule('calculations.js'),
@@ -81,10 +86,13 @@ export function createDom() {
     loadModule('render-dashboard.js'),
     loadModule('reset-modal.js'),
     // Remove DOMContentLoaded auto-init from main.js (initUI is called manually below).
-    // The actual code uses an anonymous function wrapper, not the bare `initUI`
-    // identifier — match the real text so the replace actually fires.
+    // The actual code uses `AppGlobals.initUI()` (ADR-001, Issue #278) — match
+    // the real text so the replace actually fires. If we don't strip it, the
+    // DOMContentLoaded listener fires AFTER the manual call below and registers
+    // a duplicate state listener, causing double-renders (e.g. test 17-edge-cases
+    // "calls renderDrillSummary to clear stale drill summary" got 2 calls).
     loadModule('main.js').replace(
-      "document.addEventListener('DOMContentLoaded', function() {\n  initUI();\n});",
+      "document.addEventListener('DOMContentLoaded', function() {\n  AppGlobals.initUI();\n});",
       ''
     ),
   ].join('\n');


### PR DESCRIPTION
## Summary

Implements Issue #278 / ADR-001 Option B: a single `window.AppGlobals` namespace object that captures every implicit global that used to be shared across `public/js/*.js` files. `no-undef` is now enabled for the JS code with a per-file `AppGlobals:readonly` globals entry — 306 errors → 0.

Closes #278

## ADR-001 (Option B)

ADR-001 is captured inline in the module header of `public/js/app-globals.js`. TL;DR:

- Long-term target is full ESM migration (`type="module"`).
- The namespace pattern is the bridge step: registers once, reads everywhere, no build step.
- HTML inline `onclick="state.foo()"` handlers keep direct `window.X` access because HTML event-attribute evaluation runs in window scope. ESLint's `public/js/**` override is what keeps `AppGlobals` declared for the rest of the codebase; the HTML override is unchanged.

## What changed (15 files, +648 / −410)

- **`public/js/app-globals.js` (new)** — declares `AppGlobals` and a live-alias getter/setter for `var state` so re-assignments in `loadState` / `resetAll` / cross-tab-sync propagate in both directions (`AppGlobals.state === window.state` always).
- **9 module files** — each registers its exports via `Object.assign(window.AppGlobals, …)` at file end; 376 consumer callsites migrated from `state.x` / `renderTabs(...)` to `AppGlobals.state.x` / `AppGlobals.renderTabs(...)`:
  - `ui-handlers.js`, `render-tabs.js`, `render-drill.js`, `render-results.js`, `calculations.js`, `render-dashboard.js`, `main.js`, `state.js`, `reset-modal.js`
- **`public/index.html`** — loads `app-globals.js` first (before `state.js`).
- **`eslint.config.js`** — enables `no-undef` per-file with `AppGlobals:readonly` for `public/js/**`. No more `// eslint-disable-next-line no-undef` comments needed.
- **`public/sw.js`** — `CACHE_VERSION` v15 → v16, `/js/app-globals.js` added to `STATIC_ASSETS`.
- **`tests/helpers.js`** — loads `app-globals.js` first in `createDom` harness, matches `AppGlobals.initUI()` in the `DOMContentLoaded` strip.
- **`tests/17-edge-cases.test.js`** — one callsite `window.renderDrillSummary` → `window.AppGlobals.renderDrillSummary` (preserves `spy-originalFn` semantics under the new accessor path).

## Why CACHE_VERSION v15 → v16 (mandatory for SW)

The service worker precaches `STATIC_ASSETS` under `CACHE_VERSION`. Because we:

1. Added a brand-new file (`/js/app-globals.js`) that must be precached, and
2. Changed the bytes of every existing precached module file (migrated global lookups to `AppGlobals.X`),

clients on the old `v15` cache would otherwise try to load `app-globals.js` and fail (404 from cache lookup) or, worse, hit an inconsistent state where `state.js` and `ui-handlers.js` see different `AppGlobals` snapshots. Bumping the version forces `sw.js`'s activate handler (`activate` event) to delete the old `agrar-rechner-v15` cache and populate the new `v16` cache with the up-to-date asset list. Without the bump, the PWA would be broken offline for every existing user.

## Verification

- `pnpm lint` → 0 errors (was 306 with `no-undef` enforced)
- `pnpm test` → 782 / 782 pass (baseline preserved)
- Browser smoke test (PWA offline mode, see PR comments) → all UI tabs and offline functionality verified

## Out of scope (intentional)

- ESM migration (`type="module"`) — separate follow-up. The namespace pattern is the bridge; the build-step-free constraint in `AGENTS.md §5` still holds.
- HTML inline `onclick="state.foo()"` handlers — kept as-is for the reason above; a separate ticket can address consistency later if desired.

## Test plan

- [x] `pnpm install --frozen-lockfile` clean
- [x] `pnpm lint` → 0 errors
- [x] `pnpm test` → 782 / 782 pass
- [x] Browser smoke test (see PR comment) — all tabs clickable, state persists across reload, SW registered, offline mode functional
- [x] Service worker precache list contains `app-globals.js`
