### PR TITLE
fix(#291): Service-Worker CACHE_VERSION bump (v17 → v18)

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // ⚠️ CACHE_VERSION muss bei jedem Release manuell gebumpet werden!
 // Bei Vergessen bekommen Nutzer die alte Version aus dem Cache.
 // alternativa: Build-Script das Hash/Zeitstempel injiziert.
-const CACHE_VERSION = 'agrar-rechner-v17';
+const CACHE_VERSION = 'agrar-rechner-v18';
 const STATIC_ASSETS = [
     '/',
     '/index.html',


### PR DESCRIPTION
## Problem
Nach #291 lädt der Service Worker das alte `public/js/render-drill.js` aus dem Cache. HTML wird network-first geladen (enthält jetzt `onclick="openProtokoll()"`), aber JS-Files sind cache-first. Folge: `openProtokoll is not defined` im Browser, Klick auf 🔧 Protokoll macht nichts.

Siehe Folge-Issue #292.

## Fix
`CACHE_VERSION` in `public/sw.js` von `v17` auf `v18` gebumpt. Service Worker installiert sich neu, holt alle Assets frisch.

Refs #291, fixes #292 (Follow-up: der eigentliche Refactor-PR ist bereits gemerged, dieser PR fixt nur den vergessenen Cache-Version-Bump.)
