### PR TITLE
fix(#291): drill_section im offenen Protokoll-Sheet sichtbar schalten

### DIFF
--- a/public/js/render-drill.js
+++ b/public/js/render-drill.js
@@ -406,6 +406,11 @@
       _protokollPrevFocus = document.activeElement;
       if (sheet) sheet.classList.add('open');
       if (overlay) overlay.classList.add('open');
+      // Show drill_section content inside the sheet (Issue #291 follow-up:
+      // inline style="display:none" on drill_section is the default; we toggle
+      // it on open so the inputs are visible, and toggle off on close).
+      var drillSection = document.getElementById('drill_section');
+      if (drillSection) drillSection.style.display = '';
       document.body.style.overflow = 'hidden';
       // Triggere Initial-Render der Tab-Liste (Issue #291)
       AppGlobals.renderDrillTabList();
@@ -426,6 +431,10 @@
       var overlay = document.getElementById('protokoll_overlay');
       if (sheet) sheet.classList.remove('open');
       if (overlay) overlay.classList.remove('open');
+      // Hide drill_section again so it doesn't bleed into the main view
+      // when the sheet is closed (Issue #291 follow-up).
+      var drillSection = document.getElementById('drill_section');
+      if (drillSection) drillSection.style.display = 'none';
       document.body.style.overflow = '';
       document.removeEventListener('keydown', _protokollKeyHandler);
       // Restore focus to the element that opened the sheet

--- a/tests/22-protocol-view.test.js
+++ b/tests/22-protocol-view.test.js
@@ -123,14 +123,15 @@ describe('drill_section visibility', () => {
     expect(drillSection.style.display).toBe('none');
   });
 
-  it('drill_section is still hidden when the sheet is open (sheet slides over the page; drill is rendered inside)', () => {
-    // The protokoll sheet is a slide-in overlay; drill_section visibility
-    // is driven by renderResults/renderDrillSummary, not by openProtokoll.
-    // This test guards against a regression where opening the sheet
-    // accidentally toggles drill_section.style.display.
+  it('drill_section is shown when the sheet is open (Issue #291 follow-up: inline display:none toggled by openProtokoll/closeProtokoll)', () => {
+    // After the Refactor, the protokoll sheet is a slide-in overlay; the
+    // inline style="display:none" on drill_section is toggled off in
+    // openProtokoll() so the inputs are visible inside the sheet. This
+    // guards against a regression where the sheet opens but the content
+    // stays hidden (empty-header bug seen in the mobile screenshot).
     w.openProtokoll();
     const drillSection = w.document.getElementById('drill_section');
-    expect(drillSection.style.display).toBe('none');
+    expect(drillSection.style.display).not.toBe('none');
   });
 
   it('drill_section is hidden after closeProtokoll()', () => {


### PR DESCRIPTION
## Problem
Nach #291 (Protokoll-Sheet) öffnete sich beim Klick auf den Protokoll-Tab nur der Header "🔧 Drill-Protokoll" + Close-Button, der Inhalt (drill_mask, Tab-Liste, Summary) fehlte komplett.

## Ursache
`<div class="card" id="drill_section" style="display:none">` in index.html Z. 224 — inline-Style aus der alten renderView()-Architektur, die in T4 entfernt wurde. Inline-Style gewinnt gegen jede CSS-Regel, auch .open. Folge: Sheet offen, drill_section unsichtbar, Sheet kollabiert auf Header-Höhe.

## Fix
- openProtokoll() setzt drill_section.style.display = ''
- closeProtokoll() setzt drill_section.style.display = 'none'
- Test 22 von 'bleibt none' auf 'ist sichtbar' umgeschrieben (alter Test war Spec-Bug, der den empty-header-Bug festschrieb)

## Verifikation
- pnpm test: 736/736 grün
- pnpm lint: 0 errors

Closes #291 (follow-up)

## Cache-Hinweis
Nach dem Merge in dev einmal Hard-Reload (Ctrl+Shift+R). Der Service-Worker wurde in #293 bereits auf CACHE_VERSION v18 gebumpt, also reicht das in den allermeisten Fällen. Falls trotzdem alte Inhalte auftauchen: DevTools → Application → Service Workers → Unregister.