### PR TITLE
revert(#291): Protokoll zurueck zum View-Toggle (Pre-#291)

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -868,69 +868,6 @@ font-size: 0.75rem;
     .dashboard-close:active {
       background: var(--color-bg-hover);
     }
-
-    /* Protokoll-Sheet (Issue #291) */
-    .protokoll-overlay {
-      display: none;
-      position: fixed;
-      inset: 0;
-      background: rgba(0,0,0,0.4);
-      z-index: 150;
-    }
-    .protokoll-overlay.open {
-      display: block;
-    }
-    .protokoll-sheet {
-      display: none;
-      position: fixed;
-      bottom: 0;
-      left: 0;
-      right: 0;
-      background: var(--color-card-bg);
-      border-radius: 20px 20px 0 0;
-      max-height: 80vh;
-      overflow-y: auto;
-      z-index: 151;
-      padding: 0 0 max(20px, env(safe-area-inset-bottom));
-    }
-    .protokoll-sheet.open {
-      display: block;
-    }
-    .protokoll-header {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      padding: 20px 20px 16px;
-      border-bottom: 2px solid var(--color-border-soft);
-      position: sticky;
-      top: 0;
-      background: var(--color-card-bg);
-      border-radius: 20px 20px 0 0;
-    }
-    .protokoll-header h2 {
-      margin: 0;
-      padding: 0;
-      border: none;
-      font-size: 1.1rem;
-      color: var(--color-primary-dark);
-    }
-    .protokoll-close {
-      background: var(--color-border-soft);
-      border: none;
-      border-radius: 50%;
-      width: 36px;
-      height: 36px;
-      font-size: 1.2rem;
-      cursor: pointer;
-      color: var(--color-primary);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    }
-    .protokoll-close:active {
-      background: var(--color-bg-hover);
-    }
-
     .dashboard-open-btn {
       background: var(--color-primary-dark);
       color: var(--color-ios-banner-text);

--- a/public/index.html
+++ b/public/index.html
@@ -36,7 +36,7 @@
     <div class="tab-bar" id="tab_bar">
       <div class="tab-bar-left" id="tab_bar_left"><button class="tab-add" onclick="addReiter()">+ Tab</button></div>
       <div class="tab-separator"></div>
-      <button class="tab-btn protokoll-tab" id="protokoll_tab_btn" onclick="openProtokoll()">🔧 Protokoll</button>
+      <button class="tab-btn protokoll-tab" id="protokoll_tab_btn" onclick="switchToProtokoll()">🔧 Protokoll</button>
     </div>
 
     <div class="card card-input" id="card_input">
@@ -148,6 +148,61 @@
       <div class="info" id="r_info"></div>
     </div><!-- end results card -->
 
+    <div class="card" id="drill_section" style="display:none">
+      <h2>🔧 Drill-Protokoll</h2>
+      <div id="drill_mask">
+        <div class="drill-machine-row">
+          <div class="field">
+            <label for="drill_einheit">Maschine eingefüllt (Einheiten)</label>
+            <input type="text" inputmode="decimal" autocomplete="off" autocorrect="off" spellcheck="false" id="drill_einheit" placeholder="z.B. 4" oninput="drillCalcDebounced(); onInputFormat(this, 'decimal', event)">
+          </div>
+          <div class="field">
+            <label for="drill_duenger">Maschine eingefüllt (Dünger kg)</label>
+            <input type="text" inputmode="decimal" autocomplete="off" autocorrect="off" spellcheck="false" id="drill_duenger" placeholder="z.B. 200" oninput="drillCalcDebounced(); onInputFormat(this, 'decimal', event)">
+          </div>
+        </div>
+        <div class="field">
+          <label for="drill_hektar">Zählerstand (ha)</label>
+          <input type="text" inputmode="decimal" autocomplete="off" autocorrect="off" spellcheck="false" id="drill_hektar" placeholder="z.B. 5,2" oninput="onInputFormat(this, 'decimal', event)">
+        </div>
+        <div class="drill-tabs-section">
+          <div class="drill-tabs-header">Aufteilen auf (Klick = Prio: 1 → 2 → 3 → aus):</div>
+          <div id="drill_tab_list"></div>
+        </div>
+        <button class="btn-add" onclick="drillAdd()">+ Einfüllen</button>
+      </div>
+      <div id="drill_summary" class="drill-summary" style="display:none">
+        <div id="ds_total_summary" class="drill-total-summary" style="margin-bottom:8px;font-weight:bold;"></div>
+        <div class="drill-summary-row">
+          <span>Einheiten gesamt</span>
+          <span id="ds_saat_total">—</span>
+        </div>
+        <div class="drill-summary-row">
+          <span>Einheiten verwendet</span>
+          <span id="ds_saat_used">—</span>
+        </div>
+        <div class="drill-summary-row remaining">
+          <span>Einheiten verbleibend</span>
+          <span id="ds_saat_remaining">—</span>
+        </div>
+        <div class="drill-summary-row">
+          <span>Dünger gesamt</span>
+          <span id="ds_duenger_total">—</span>
+        </div>
+        <div class="drill-summary-row">
+          <span>Dünger verwendet</span>
+          <span id="ds_duenger_used">—</span>
+        </div>
+        <div class="drill-summary-row remaining">
+          <span>Dünger verbleibend</span>
+          <span id="ds_duenger_remaining">—</span>
+        </div>
+        <div class="drill-summary-savings" id="ds_savings" style="display:none"></div>
+      </div>
+      <div id="drill_machine_log"></div>
+      <div id="drill_entries"></div>
+    </div>
+
     </div><!-- end .container -->
 
     </div><!-- end .scrollable-content -->
@@ -213,83 +268,6 @@
       <button class="dashboard-close" onclick="closeDashboard()" aria-label="Schließen">✕</button>
     </div>
     <div class="dashboard-content" id="dashboard_content"></div>
-  </div>
-  <!-- Protokoll overlay + sheet (Issue #291) -->
-  <div class="protokoll-overlay" id="protokoll_overlay" onclick="closeProtokoll()"></div>
-  <div class="protokoll-sheet" id="protokoll_sheet" role="dialog" aria-modal="true" aria-label="Drill-Protokoll">
-    <div class="protokoll-header">
-      <h2>🔧 Drill-Protokoll</h2>
-      <button class="protokoll-close" onclick="closeProtokoll()" aria-label="Schließen">✕</button>
-    </div>
-    <div class="card" id="drill_section" style="display:none">
-      <div id="drill_mask">
-        <div class="drill-machine-row">
-          <div class="field">
-            <label for="drill_einheit">Maschine eingefüllt (Einheiten)</label>
-            <input type="text" inputmode="decimal" autocomplete="off" autocorrect="off" spellcheck="false" id="drill_einheit" placeholder="z.B. 4" oninput="drillCalcDebounced(); onInputFormat(this, 'decimal', event)">
-          </div>
-          <div class="field">
-            <label for="drill_duenger">Maschine eingefüllt (Dünger kg)</label>
-            <input type="text" inputmode="decimal" autocomplete="off" autocorrect="off" spellcheck="false" id="drill_duenger" placeholder="z.B. 200" oninput="drillCalcDebounced(); onInputFormat(this, 'decimal', event)">
-          </div>
-        </div>
-        <div class="field">
-          <label for="drill_hektar">Zählerstand (ha)</label>
-          <input type="text" inputmode="decimal" autocomplete="off" autocorrect="off" spellcheck="false" id="drill_hektar" placeholder="z.B. 5,2" oninput="onInputFormat(this, 'decimal', event)">
-        </div>
-        <div class="drill-tabs-section">
-          <div class="drill-tabs-header">Aufteilen auf (Klick = Prio: 1 → 2 → 3 → aus):</div>
-          <div id="drill_tab_list"></div>
-        </div>
-        <button class="btn-add" onclick="drillAdd()">+ Einfüllen</button>
-      </div>
-      <div id="drill_summary" class="drill-summary" style="display:none">
-        <div id="ds_total_summary" class="drill-total-summary" style="margin-bottom:8px;font-weight:bold;"></div>
-        <div class="drill-summary-row">
-          <span>Einheiten gesamt</span>
-          <span id="ds_saat_total">—</span>
-        </div>
-        <div class="drill-summary-row">
-          <span>Einheiten verwendet</span>
-          <span id="ds_saat_used">—</span>
-        </div>
-        <div class="drill-summary-row remaining">
-          <span>Einheiten verbleibend</span>
-          <span id="ds_saat_remaining">—</span>
-        </div>
-        <div class="drill-summary-row">
-          <span>Dünger gesamt</span>
-          <span id="ds_duenger_total">—</span>
-        </div>
-        <div class="drill-summary-row">
-          <span>Dünger verwendet</span>
-          <span id="ds_duenger_used">—</span>
-        </div>
-        <div class="drill-summary-row remaining">
-          <span>Dünger verbleibend</span>
-          <span id="ds_duenger_remaining">—</span>
-        </div>
-        <div class="drill-summary-savings" id="ds_savings" style="display:none"></div>
-      </div>
-      <div id="drill_machine_log"></div>
-      <div id="drill_entries"></div>
-    </div>
-  </div>
-
-  <!-- Reset Confirmation Modal (Issue #236) -->
-  <div class="reset-overlay" id="reset_overlay" onclick="_onOverlayClick(event)"></div>
-  <div class="reset-modal" id="reset_modal" role="dialog" aria-modal="true" aria-labelledby="reset_modal_title" aria-describedby="reset_modal_desc">
-    <div class="reset-modal-header">
-      <h2 id="reset_modal_title">Zurücksetzen</h2>
-    </div>
-    <p class="reset-modal-desc" id="reset_modal_desc">
-      Was möchtest du zurücksetzen? Diese Aktion lässt sich nicht rückgängig machen.
-    </p>
-    <div class="reset-modal-actions">
-      <button class="btn btn-secondary" id="reset_modal_tab" onclick="_onResetTab()">Aktuellen Tab zurücksetzen</button>
-      <button class="btn btn-danger" id="reset_modal_confirm_all" onclick="_onResetAll()">Alle Daten löschen</button>
-      <button class="btn btn-cancel" id="reset_modal_cancel" onclick="_onCancel()">Abbrechen</button>
-    </div>
   </div>
 </body>
 </html>

--- a/public/js/render-drill.js
+++ b/public/js/render-drill.js
@@ -375,73 +375,10 @@
       }
     }
 
-    // Öffnet das Protokoll-Sheet (Issue #291).
-    // Pattern analog zu openDashboard() in render-dashboard.js Z. 245-262.
-    var _protokollPrevFocus = null;
-
-    // Trap Tab/Shift+Tab inside the protokoll dialog (Issue #291)
-    function _protokollKeyHandler(e) {
-      if (e.key === 'Escape') {
-        closeProtokoll();
-        e.preventDefault();
-        return;
-      }
-      if (e.key !== 'Tab') return;
-      var sheet = document.getElementById('protokoll_sheet');
-      if (!sheet) return;
-      var focusable = sheet.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
-      if (focusable.length === 0) return;
-      var first = focusable[0];
-      var last = focusable[focusable.length - 1];
-      if (e.shiftKey) {
-        if (document.activeElement === first) { last.focus(); e.preventDefault(); }
-      } else {
-        if (document.activeElement === last) { first.focus(); e.preventDefault(); }
-      }
-    }
-
-    function openProtokoll() {
-      var sheet = document.getElementById('protokoll_sheet');
-      var overlay = document.getElementById('protokoll_overlay');
-      _protokollPrevFocus = document.activeElement;
-      if (sheet) sheet.classList.add('open');
-      if (overlay) overlay.classList.add('open');
-      document.body.style.overflow = 'hidden';
-      // Triggere Initial-Render der Tab-Liste (Issue #291)
-      AppGlobals.renderDrillTabList();
-      // Move focus into the dialog for accessibility (Issue #291)
-      // Use setTimeout to avoid jsdom focus-event side effects
-      if (sheet) {
-        setTimeout(function() {
-          var closeBtn = sheet.querySelector('.protokoll-close');
-          if (closeBtn) closeBtn.focus();
-        }, 0);
-      }
-      document.addEventListener('keydown', _protokollKeyHandler);
-    }
-
-    // Schließt das Protokoll-Sheet.
-    function closeProtokoll() {
-      var sheet = document.getElementById('protokoll_sheet');
-      var overlay = document.getElementById('protokoll_overlay');
-      if (sheet) sheet.classList.remove('open');
-      if (overlay) overlay.classList.remove('open');
-      document.body.style.overflow = '';
-      document.removeEventListener('keydown', _protokollKeyHandler);
-      // Restore focus to the element that opened the sheet
-      if (_protokollPrevFocus && _protokollPrevFocus.focus) {
-        _protokollPrevFocus.focus();
-        _protokollPrevFocus = null;
-      }
-    }
-
 // Register exposed globals on AppGlobals (ADR-001 Schritt 3, Issue #278).
 Object.assign(window.AppGlobals, {
   renderDrillTabList: renderDrillTabList,
   renderDrillSummary: renderDrillSummary,
   renderDrillLog: renderDrillLog,
   renderMachineLog: renderMachineLog,
-  _protokollKeyHandler: _protokollKeyHandler,
-  openProtokoll: openProtokoll,
-  closeProtokoll: closeProtokoll,
 });

--- a/public/js/render-results.js
+++ b/public/js/render-results.js
@@ -120,8 +120,9 @@
         return;
       }
       // Issue #266-A: hide results card when the active tab has no data,
-      // and show/hide the drill_summary block consistently. We only need
-      // to ensure results + drill_summary reflect the active tab's data state.
+      // and show/hide the drill_summary block consistently. renderView()
+      // already handles drill_section / protokoll toggle; we only need to
+      // ensure results + drill_summary reflect the active tab's data state.
       var resultsEl = document.getElementById('results');
       var drillSummaryEl = document.getElementById('drill_summary');
       var hasData = r.hektar > 0 && r.koerner > 0;
@@ -131,7 +132,9 @@
         return;
       }
       if (drillSummaryEl) drillSummaryEl.style.display = 'block';
-      if (resultsEl) resultsEl.style.display = 'block';
+      if (AppGlobals.state.activeView !== 'protokoll') {
+        if (resultsEl) resultsEl.style.display = 'block';
+      }
     }
 
     // Inline drill-entries im Result-Card-Body (r_drill_entries)

--- a/public/js/render-tabs.js
+++ b/public/js/render-tabs.js
@@ -1,5 +1,5 @@
 // ============================================================================
-// RENDER-TABS — Tab-Verwaltung, App-Init, Tab-Remove-Confirm
+// RENDER-TABS — Tab-Verwaltung, View-Toggle, App-Init, Tab-Remove-Confirm
 //
 // Lade-Reihenfolge (laut index.html): state.js → calculations.js →
 //   ui-handlers.js → render-tabs.js → render-results.js → render-drill.js
@@ -16,7 +16,7 @@
       var bar = document.getElementById('tab_bar_left');
       bar.innerHTML = '';
       AppGlobals.state.reiter.forEach(function(r, i) {
-        var isActive = i === AppGlobals.state.activeReiter;
+        var isActive = i === AppGlobals.state.activeReiter && AppGlobals.state.activeView !== 'protokoll';
         var btn = document.createElement('button');
         btn.className = 'tab-btn field-tab' + (isActive ? ' active' : '');
         btn.setAttribute('aria-label', 'Tab ' + (i+1));
@@ -64,6 +64,28 @@
       addBtn.textContent = '+ Tab';
       addBtn.onclick = function() { AppGlobals.addReiter(); };
       bar.appendChild(addBtn);
+      var protokollBtn = document.getElementById('protokoll_tab_btn');
+      if (protokollBtn) protokollBtn.classList.toggle('active', AppGlobals.state.activeView === 'protokoll');
+    }
+
+    // --- Render: View (Feld vs. Protokoll) ---
+
+    function renderView() {
+      var r = AppGlobals.getActiveReiter();
+      var hasData = r.hektar > 0 && r.koerner > 0;
+      var isProtokoll = AppGlobals.state.activeView === 'protokoll';
+      var skipIds = { r_soll_ist_section: true };
+      var cards = document.querySelectorAll('.card');
+      cards.forEach(function(c) {
+        if (skipIds[c.id]) return;
+        c.style.display = isProtokoll ? 'none' : 'block';
+      });
+      var resultsEl = document.getElementById('results');
+      if (resultsEl) resultsEl.style.display = (hasData && !isProtokoll) ? 'block' : 'none';
+      var drillSection = document.getElementById('drill_section');
+      if (drillSection) drillSection.style.display = isProtokoll ? 'block' : 'none';
+      var drillMask = document.getElementById('drill_mask');
+      if (drillMask) drillMask.style.display = isProtokoll ? '' : 'none';
     }
 
     // --- Init: UI (nach DOMContentLoaded) ---
@@ -83,6 +105,7 @@
               AppGlobals.state = remote;
               AppGlobals.syncInputsFromState();
               AppGlobals.renderTabs();
+              renderView();
               AppGlobals.renderResults();
             }
           } catch(err) {
@@ -140,9 +163,12 @@
       }
       if (AppGlobals.state.reiter[AppGlobals.state.activeReiter] && AppGlobals.state.reiter[AppGlobals.state.activeReiter].hektar > 0 && AppGlobals.state.reiter[AppGlobals.state.activeReiter].koerner > 0) {
         AppGlobals.renderResults();
-        var resultsEl = document.getElementById('results');
-        if (resultsEl) resultsEl.style.display = 'block';
+        if (AppGlobals.state.activeView !== 'protokoll') {
+          var resultsEl = document.getElementById('results');
+          if (resultsEl) resultsEl.style.display = 'block';
+        }
       }
+      renderView();
       AppGlobals.renderDashboard();
       var vf = document.getElementById('version_footer');
       if (vf) vf.textContent = APP_VERSION + ' · ' + APP_BUILD_DATE;
@@ -161,6 +187,7 @@
             AppGlobals.saveState();
             AppGlobals.renderTabs();
             AppGlobals.renderResults();
+            renderView();
             // Issue #186: Dashboard muss bei State-Änderungen mit-synchronisieren.
             // Wenn das Dashboard-Sheet offen ist, sofort neu rendern, damit
             // verbleibende Einheiten/Dünger konsistent mit Tab-Ergebnis sind.
@@ -179,6 +206,7 @@
           case 'STATE_LOADED':
             AppGlobals.syncInputsFromState();
             AppGlobals.renderTabs();
+            renderView();
             AppGlobals.renderResults();
             AppGlobals.renderDashboard();
             break;
@@ -218,6 +246,13 @@
             AppGlobals.renderTabs();
             AppGlobals.renderResults();
             break;
+          case 'VIEW_CHANGED':
+            AppGlobals.saveState();
+            AppGlobals.renderTabs();
+            renderView();
+            if (AppGlobals.state.activeView === 'protokoll') AppGlobals.renderDrillTabList();
+            AppGlobals.renderResults();
+            break;
           case 'DRILL_ENTRY_ADDED':
             AppGlobals.saveState();
             AppGlobals.renderDrillTabList();
@@ -252,6 +287,7 @@
 // Register exposed globals on AppGlobals (ADR-001 Schritt 3, Issue #278).
 Object.assign(window.AppGlobals, {
   renderTabs: renderTabs,
+  renderView: renderView,
   initUI: initUI,
   confirmRemoveReiter: confirmRemoveReiter,
 });

--- a/public/js/state.js
+++ b/public/js/state.js
@@ -7,6 +7,7 @@
 // Struktur:
 //   reiter[]       — Array von Feld-Tabs (jeder Tab = ein Feld)
 //   activeReiter   — Index des aktuell ausgewählten Tabs
+//   activeView     — 'protokoll' = Drill-Protokoll-Ansicht, sonst null
 //   fahrgassen*    — Fahrgassen-Korrektur
 //   einheitGroesse* — Anpassung der Körner-pro-Einheit
 //   machineLog[]   — Globales Maschinen-Protokoll
@@ -22,6 +23,7 @@ var state = {
     entries:    []
   }],
   activeReiter:   0,
+  activeView:     null,
   fahrgassenEnabled: false,
   fahrgassenBreite:   0,
   einheitGroesseEnabled: false,
@@ -101,7 +103,7 @@ function dismissSaveError() {
 // Erlaubte Keys (Whitelist) — alles andere wird im Reviver verworfen.
 // Hinzufügen neuer Felder erfordert eine bewusste Entscheidung.
 var ALLOWED_TOP_KEYS = [
-  'reiter', 'activeReiter',
+  'reiter', 'activeReiter', 'activeView',
   'fahrgassenEnabled', 'fahrgassenBreite',
   'einheitGroesseEnabled', 'koernerProEinheit',
   'machineLog', 'drillPriorities', 'iosInstallHintShown',
@@ -245,7 +247,7 @@ function loadState() {
     var lv = originalLv;
     // Migration 0→1: Einzelne Felder → Tab-Array
     if (!data.reiter && (data.hektar !== undefined || data.koerner !== undefined)) {
-      data = { reiter: [{ name: 'Tab 1', hektar: data.hektar || 0, istHektar: data.istHektar || 0, koerner: data.koerner || 0, duenger: data.duenger || 0, entries: data.entries || [] }], activeReiter: 0, fahrgassenEnabled: false, fahrgassenBreite: 0, einheitGroesseEnabled: false, koernerProEinheit: 50000, machineLog: data.machineLog || [], drillPriorities: {}, iosInstallHintShown: false, _lv: 1 };
+      data = { reiter: [{ name: 'Tab 1', hektar: data.hektar || 0, istHektar: data.istHektar || 0, koerner: data.koerner || 0, duenger: data.duenger || 0, entries: data.entries || [] }], activeReiter: 0, activeView: null, fahrgassenEnabled: false, fahrgassenBreite: 0, einheitGroesseEnabled: false, koernerProEinheit: 50000, machineLog: data.machineLog || [], drillPriorities: {}, iosInstallHintShown: false, _lv: 1 };
       lv = 1;
     }
     // Migration 1→2: Globale entries → per-Tab entries
@@ -294,6 +296,7 @@ function loadState() {
     data.activeReiter = activeReiterRaw >= 0 && activeReiterRaw < sanitizedReiter.length
       ? Math.floor(activeReiterRaw)
       : 0;
+    data.activeView = (data.activeView === 'protokoll') ? 'protokoll' : null;
     if (data.fahrgassenEnabled === undefined) data.fahrgassenEnabled = false;
     if (data.fahrgassenBreite === undefined) data.fahrgassenBreite = 0;
     data.fahrgassenEnabled = sanitizeBoolean(data.fahrgassenEnabled, false);

--- a/public/js/ui-handlers.js
+++ b/public/js/ui-handlers.js
@@ -84,15 +84,27 @@
     }
 
     function switchReiter(idx) {
-      if (idx === AppGlobals.state.activeReiter) return;
+      if (idx === AppGlobals.state.activeReiter && AppGlobals.state.activeView !== 'protokoll') return;
       syncStateFromInputs();
       AppGlobals.state.activeReiter = idx;
+      AppGlobals.state.activeView = null;
       AppGlobals.appEmit('TAB_CHANGED', { tabIdx: idx });
     }
 
     function renameReiter(idx, name) {
       AppGlobals.state.reiter[idx].name = name.substring(0, 20);
       AppGlobals.appEmit('TAB_RENAMED', { tabIdx: idx });
+    }
+
+    function switchToProtokoll() {
+      syncStateFromInputs();
+      if (AppGlobals.state.activeView === 'protokoll') {
+        AppGlobals.state.activeView = null;
+      } else {
+        AppGlobals.state.activeView = 'protokoll';
+        AppGlobals.renderDrillTabList();
+      }
+      AppGlobals.appEmit('VIEW_CHANGED', { view: AppGlobals.state.activeView });
     }
 
     // --- Fahrgassen ---
@@ -245,6 +257,7 @@
       AppGlobals.state = {
         reiter: [{ name: 'Tab 1', hektar: 0, istHektar: 0, koerner: 0, duenger: 0, entries: [] }],
         activeReiter: 0,
+        activeView: null,
         fahrgassenEnabled: false,
         fahrgassenBreite: 0,
         einheitGroesseEnabled: false,
@@ -925,6 +938,7 @@ Object.assign(window.AppGlobals, {
   removeReiter: removeReiter,
   switchReiter: switchReiter,
   renameReiter: renameReiter,
+  switchToProtokoll: switchToProtokoll,
   fahrgassenToggle: fahrgassenToggle,
   fahrgassenUpdate: fahrgassenUpdate,
   einheitGroesseToggle: einheitGroesseToggle,

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // ⚠️ CACHE_VERSION muss bei jedem Release manuell gebumpet werden!
 // Bei Vergessen bekommen Nutzer die alte Version aus dem Cache.
 // alternativa: Build-Script das Hash/Zeitstempel injiziert.
-const CACHE_VERSION = 'agrar-rechner-v18';
+const CACHE_VERSION = 'agrar-rechner-v17';
 const STATIC_ASSETS = [
     '/',
     '/index.html',

--- a/tests/15-render-view.test.js
+++ b/tests/15-render-view.test.js
@@ -1,62 +1,132 @@
 /**
- * Tests for the Protokoll-Sheet (Issue #291) — openProtokoll / closeProtokoll.
- *
- * Note: The old per-view renderer and the per-view state field that lived
- * in `w.state` were removed in the sheet-architecture refactor (the
- * Protokoll tab is now a slide-in sheet with an overlay). openProtokoll()
- * and closeProtokoll() in public/js/render-drill.js drive the sheet.
- *
- * This file covers sheet open/close semantics. Visibility of inner elements
- * (drill_section, results, sticky footer) is covered by tests/22-protocol-view.test.js
- * and the regular render-* tests.
+ * Tests for renderView() — show/hide logic for field vs. protokoll views.
+ * Also tests switchToProtokoll() and related view switching.
  */
 import { describe, it, expect, beforeEach } from 'vitest';
 import { createDom } from './helpers.js';
 
-function getSheet(w) { return w.document.getElementById('protokoll_sheet'); }
-function getOverlay(w) { return w.document.getElementById('protokoll_overlay'); }
-
-describe('Protokoll sheet open/close', () => {
+describe('renderView', () => {
   let w;
   beforeEach(() => { w = createDom().window; });
 
-  it('is closed by default on a fresh page', () => {
-    expect(getSheet(w).classList.contains('open')).toBe(false);
-    expect(getOverlay(w).classList.contains('open')).toBe(false);
+  it('hides input cards when in protokoll view (drill_section stays visible)', () => {
+    w.state.activeView = 'protokoll';
+    w.renderView();
+    var cards = w.document.querySelectorAll('.card');
+    cards.forEach(function(c) {
+      if (c.id === 'drill_section') {
+        // drill_section is visible in protokoll mode — it contains the drill protocol
+        expect(c.style.display).toBe('block');
+      } else {
+        expect(c.style.display).toBe('none');
+      }
+    });
   });
 
-  it('openProtokoll() adds .open to sheet and overlay and locks body scroll', () => {
-    w.openProtokoll();
-    expect(getSheet(w).classList.contains('open')).toBe(true);
-    expect(getOverlay(w).classList.contains('open')).toBe(true);
-    expect(w.document.body.style.overflow).toBe('hidden');
+  it('shows cards when in field view', () => {
+    w.state.activeView = null;
+    w.renderView();
+    var cards = w.document.querySelectorAll('.card');
+    var anyVisible = false;
+    cards.forEach(function(c) {
+      if (c.style.display !== 'none') anyVisible = true;
+    });
+    expect(anyVisible).toBe(true);
   });
 
-  it('closeProtokoll() removes .open from sheet and overlay and restores body scroll', () => {
-    w.openProtokoll();
-    w.closeProtokoll();
-    expect(getSheet(w).classList.contains('open')).toBe(false);
-    expect(getOverlay(w).classList.contains('open')).toBe(false);
-    expect(w.document.body.style.overflow).toBe('');
+  it('shows results when tab has data and not in protokoll', () => {
+    w.state.reiter[0] = { ...w.state.reiter[0], hektar: 10, koerner: 90000 };
+    w.state.activeView = null;
+    w.renderView();
+    expect(w.document.getElementById('results').style.display).toBe('block');
   });
 
-  it('openProtokoll is idempotent (calling it twice keeps the sheet open)', () => {
-    w.openProtokoll();
-    w.openProtokoll();
-    expect(getSheet(w).classList.contains('open')).toBe(true);
+  it('hides results when in protokoll view even with data', () => {
+    w.state.reiter[0] = { ...w.state.reiter[0], hektar: 10, koerner: 90000 };
+    w.state.activeView = 'protokoll';
+    w.renderView();
+    expect(w.document.getElementById('results').style.display).toBe('none');
   });
 
-  it('closeProtokoll is a no-op when the sheet is already closed', () => {
-    expect(() => w.closeProtokoll()).not.toThrow();
-    expect(getSheet(w).classList.contains('open')).toBe(false);
+  it('hides results when no data', () => {
+    w.state.activeView = null;
+    w.renderView();
+    expect(w.document.getElementById('results').style.display).toBe('none');
   });
 
-  it('does not save anything to localStorage on open/close (sheet state is DOM-only)', () => {
-    const { window: w, store } = createDom();
-    w.openProtokoll();
-    w.closeProtokoll();
-    // Sheet state is intentionally not persisted — opening the page
-    // starts with the sheet closed, regardless of last session.
-    expect(store['agrar_rechner']).toBeUndefined();
+  it('shows drill_section when in protokoll view', () => {
+    w.state.activeView = 'protokoll';
+    w.renderView();
+    expect(w.document.getElementById('drill_section').style.display).toBe('block');
+  });
+
+  it('hides drill_section when not in protokoll view', () => {
+    w.state.activeView = null;
+    w.renderView();
+    expect(w.document.getElementById('drill_section').style.display).toBe('none');
+  });
+
+  it('shows drill_mask when in protokoll view', () => {
+    w.state.activeView = 'protokoll';
+    w.renderView();
+    expect(w.document.getElementById('drill_mask').style.display).toBe('');
+  });
+
+  it('hides drill_mask when not in protokoll view', () => {
+    w.state.activeView = null;
+    w.renderView();
+    expect(w.document.getElementById('drill_mask').style.display).toBe('none');
+  });
+});
+
+describe('switchToProtokoll', () => {
+  let w;
+  beforeEach(() => { w = createDom().window; });
+
+  it('switches to protokoll view', () => {
+    w.switchToProtokoll();
+    expect(w.state.activeView).toBe('protokoll');
+  });
+
+  it('switches back from protokoll to field', () => {
+    w.switchToProtokoll(); // enter protokoll
+    w.switchToProtokoll(); // leave protokoll
+    expect(w.state.activeView).toBeNull();
+  });
+
+  it('syncs state from inputs before switching', () => {
+    w.document.getElementById('hektar').value = '15';
+    w.document.getElementById('koerner').value = '80000';
+    w.switchToProtokoll();
+    expect(w.state.reiter[0].hektar).toBe(15);
+    expect(w.state.reiter[0].koerner).toBe(80000);
+  });
+
+  it('renders drill tab list when entering protokoll', () => {
+    w.switchToProtokoll();
+    // renderDrillTabList should have been called — check that drill_tab_list has content
+    var container = w.document.getElementById('drill_tab_list');
+    expect(container).toBeTruthy();
+    // Should have rendered priority buttons
+    expect(w.document.getElementById('dtl_prio_0')).toBeTruthy();
+  });
+
+  it('saves state via sv()', () => {
+    w.switchToProtokoll();
+    var stored = JSON.parse(w.localStorage.getItem('agrar_rechner'));
+    expect(stored.activeView).toBe('protokoll');
+  });
+
+  it('marks protokoll tab as active', () => {
+    w.switchToProtokoll();
+    var protokollBtn = w.document.getElementById('protokoll_tab_btn');
+    expect(protokollBtn.classList.contains('active')).toBe(true);
+  });
+
+  it('unmarks protokoll tab when switching back', () => {
+    w.switchToProtokoll();
+    w.switchToProtokoll();
+    var protokollBtn = w.document.getElementById('protokoll_tab_btn');
+    expect(protokollBtn.classList.contains('active')).toBe(false);
   });
 });

--- a/tests/18-blind-spots-round2.test.js
+++ b/tests/18-blind-spots-round2.test.js
@@ -2,8 +2,7 @@
  * Tests for remaining blind spots and edge cases found in audit round 2.
  *
  * Includes (original round 2):
- * 1. switchReiter behavior with the protokoll sheet open (sheet is independent
- *    of reiter switching in the new sheet-architecture, Issue #291)
+ * 1. switchReiter from protokoll view to same tab
  * 2. Prognose cumulative calculation with fahrgassen factor
  * 3. Prognose with duenger-only consumption (no einheit)
  * 4. drillTabList needDiv: done with duenger finished but einheit remaining
@@ -19,37 +18,39 @@
  * - drillMachineRemove() — machine log entry removal
  * - Theme — getStoredTheme / setStoredTheme / applyTheme / toggleTheme / initTheme
  * - renderDrillTabList() — row rendering, priority button, input mode
- * - openProtokoll() / closeProtokoll() — sheet toggle (Issue #291)
- * - Protokoll tab btn — open via click (no `active` class on tab, see T4)
+ * - switchToProtokoll() — view toggle
+ * - renderView() — visibility in protokoll vs field view
+ * - renderTabs() protokoll btn — active class
  */
 import { describe, it, expect, beforeEach } from 'vitest';
 import { createDom } from './helpers.js';
 
-describe('switchReiter while protokoll sheet is open', () => {
+describe('switchReiter from protokoll view', () => {
   let w;
   beforeEach(() => { w = createDom().window; });
 
-  // The protokoll sheet is a slide-in overlay; switching reiter is independent
-  // of the sheet state (the sheet stays where it is until explicitly closed).
-  it('does not close the protokoll sheet when switching reiter to the same tab', () => {
+  it('allows switching to same tab when currently in protokoll view', () => {
     w.state.reiter[0] = { ...w.state.reiter[0], hektar: 10, koerner: 90000 };
-    w.openProtokoll();
-    expect(w.document.getElementById('protokoll_sheet').classList.contains('open')).toBe(true);
+    w.switchToProtokoll();
+    expect(w.state.activeView).toBe('protokoll');
+    expect(w.state.activeReiter).toBe(0);
 
+    // switchReiter(0) should work even though activeReiter is already 0,
+    // because activeView is 'protokoll'
     w.switchReiter(0);
-    // Sheet stays open, activeReiter unchanged
-    expect(w.document.getElementById('protokoll_sheet').classList.contains('open')).toBe(true);
+    expect(w.state.activeView).toBeNull();
     expect(w.state.activeReiter).toBe(0);
   });
 
-  it('does not close the protokoll sheet when switching reiter to a different tab', () => {
+  it('switches to different tab from protokoll', () => {
     w.addReiter();
     w.state.reiter[0] = { ...w.state.reiter[0], hektar: 10, koerner: 90000 };
     w.state.reiter[1] = { ...w.state.reiter[1], hektar: 5, koerner: 80000 };
-    w.openProtokoll();
+    w.switchToProtokoll();
+    expect(w.state.activeView).toBe('protokoll');
 
     w.switchReiter(1);
-    expect(w.document.getElementById('protokoll_sheet').classList.contains('open')).toBe(true);
+    expect(w.state.activeView).toBeNull();
     expect(w.state.activeReiter).toBe(1);
   });
 });
@@ -800,9 +801,9 @@ describe('renderDrillTabList()', () => {
 });
 
 // ---------------------------------------------------------------------------
-// openProtokoll / closeProtokoll — sheet toggle (Issue #291)
+// switchToProtokoll
 // ---------------------------------------------------------------------------
-describe('openProtokoll() / closeProtokoll()', () => {
+describe('switchToProtokoll()', () => {
   let w, doc;
 
   beforeEach(() => {
@@ -811,47 +812,43 @@ describe('openProtokoll() / closeProtokoll()', () => {
     doc = w.document;
   });
 
-  it('openProtokoll() adds .open to sheet and overlay', () => {
-    w.openProtokoll();
-    expect(doc.getElementById('protokoll_sheet').classList.contains('open')).toBe(true);
-    expect(doc.getElementById('protokoll_overlay').classList.contains('open')).toBe(true);
+  it('sets activeView to protokoll', () => {
+    w.switchToProtokoll();
+    expect(w.state.activeView).toBe('protokoll');
   });
 
-  it('openProtokoll() locks body scroll', () => {
-    w.openProtokoll();
-    expect(doc.body.style.overflow).toBe('hidden');
-  });
-
-  it('openProtokoll() calls renderDrillTabList', () => {
+  it('calls renderDrillTabList', () => {
     w.state.reiter = [{ name: 'A', hektar: 10, koerner: 90000, duenger: 0, entries: [] }];
-    w.openProtokoll();
+    w.switchToProtokoll();
     expect(doc.querySelectorAll('.drill-tab-row').length).toBe(1);
   });
 
-  it('closeProtokoll() removes .open from sheet and overlay', () => {
-    w.openProtokoll();
-    w.closeProtokoll();
-    expect(doc.getElementById('protokoll_sheet').classList.contains('open')).toBe(false);
-    expect(doc.getElementById('protokoll_overlay').classList.contains('open')).toBe(false);
+  it('toggles back to null when called again', () => {
+    w.switchToProtokoll();
+    expect(w.state.activeView).toBe('protokoll');
+    w.switchToProtokoll();
+    expect(w.state.activeView).toBeNull();
   });
 
-  it('closeProtokoll() restores body scroll', () => {
-    w.openProtokoll();
-    w.closeProtokoll();
-    expect(doc.body.style.overflow).toBe('');
+  it('persists state', () => {
+    w.switchToProtokoll();
+    const stored = JSON.parse(w.localStorage.getItem('agrar_rechner'));
+    expect(stored.activeView).toBe('protokoll');
   });
 
-  it('Escape key closes the sheet (via _protokollKeyHandler)', () => {
-    w.openProtokoll();
-    w.AppGlobals._protokollKeyHandler({ key: 'Escape', preventDefault: () => {} });
-    expect(doc.getElementById('protokoll_sheet').classList.contains('open')).toBe(false);
+  it('syncs current inputs before switching', () => {
+    w.state.reiter[0].hektar = 10;
+    doc.getElementById('hektar').value = '15';
+    w.syncStateFromInputs();
+    w.switchToProtokoll();
+    expect(w.state.reiter[0].hektar).toBe(15);
   });
 });
 
 // ---------------------------------------------------------------------------
-// Protokoll tab button — opens the sheet on click (Issue #291)
+// renderView — visibility of elements in protokoll vs field view
 // ---------------------------------------------------------------------------
-describe('Protokoll tab button', () => {
+describe('renderView()', () => {
   let w, doc;
 
   beforeEach(() => {
@@ -860,11 +857,18 @@ describe('Protokoll tab button', () => {
     doc = w.document;
   });
 
-  it('opens the protokoll sheet when the tab button is clicked', () => {
-    var tabBtn = doc.getElementById('protokoll_tab_btn');
-    expect(tabBtn).toBeTruthy();
-    tabBtn.click();
-    expect(doc.getElementById('protokoll_sheet').classList.contains('open')).toBe(true);
+  it('drill_section shown in protokoll view', () => {
+    w.state.activeView = 'protokoll';
+    w.renderView();
+    expect(doc.getElementById('drill_section').style.display).toBe('block');
+  });
+
+  it('results hidden when switching to protokoll', () => {
+    w.state.reiter[0].hektar = 10;
+    w.state.reiter[0].koerner = 90000;
+    w.state.activeView = 'protokoll';
+    w.renderView();
+    expect(doc.getElementById('results').style.display).toBe('none');
   });
 });
 
@@ -880,14 +884,16 @@ describe('renderTabs() protokoll btn', () => {
     doc = w.document;
   });
 
-  it('is a static button without `active` class management (Issue #291/T4 — visual active state on Protokoll tab is intentionally lost)', () => {
-    // After T4, renderTabs() no longer toggles an `active` class on the
-    // protokoll tab. The tab is just a trigger for openProtokoll().
-    // Document this contract: renderTabs() should not add/remove the class.
-    var tabBtn = doc.getElementById('protokoll_tab_btn');
-    expect(tabBtn.classList.contains('active')).toBe(false);
+  it('protokoll_tab_btn has active class when activeView=protokoll', () => {
+    w.state.activeView = 'protokoll';
     w.renderTabs();
-    expect(tabBtn.classList.contains('active')).toBe(false);
+    expect(doc.getElementById('protokoll_tab_btn').classList.contains('active')).toBe(true);
+  });
+
+  it('protokoll_tab_btn has no active class when activeView=null', () => {
+    w.state.activeView = null;
+    w.renderTabs();
+    expect(doc.getElementById('protokoll_tab_btn').classList.contains('active')).toBe(false);
   });
 });
 

--- a/tests/22-protocol-view.test.js
+++ b/tests/22-protocol-view.test.js
@@ -1,160 +1,160 @@
 /**
- * Test 22: Protocol view — openProtokoll / closeProtokoll (Issue #291 sheet architecture)
- *
- * The Protokoll-Sheet is opened via the 🔧 tab button. Tests cover:
- *   - openProtokoll() adds the .open class to #protokoll_sheet and #protokoll_overlay,
- *     locks body scroll, renders the drill tab list.
- *   - closeProtokoll() removes the .open class, restores body scroll, focuses back.
- *   - Escape key (via _protokollKeyHandler) closes the sheet.
- *   - Clicks on the overlay fire closeProtokoll() (HTML onclick handler).
- *   - The drill_section stays hidden (display:none) when the sheet is closed —
- *     it becomes visible only inside the open sheet via renderResults.
+ * Test 22: Protocol view — switchToProtokoll + renderView
  */
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { createDom } from './helpers.js';
 
-function getSheet(w) { return w.document.getElementById('protokoll_sheet'); }
-function getOverlay(w) { return w.document.getElementById('protokoll_overlay'); }
-function sheetIsOpen(w) { return getSheet(w).classList.contains('open'); }
-function overlayIsOpen(w) { return getOverlay(w).classList.contains('open'); }
+describe('switchToProtokoll', () => {
+  it('switches to protokoll view from field view', () => {
+    const { window: w } = createDom();
+    // Set up some data
+    w.document.getElementById('hektar').value = '10';
+    w.document.getElementById('koerner').value = '90000';
+    w.berechne();
 
-describe('openProtokoll()', () => {
-  let w;
-  beforeEach(() => { w = createDom().window; });
+    expect(w.state.activeView).toBeNull();
+    w.switchToProtokoll();
 
-  it('opens the protokoll sheet on openProtokoll()', () => {
-    w.openProtokoll();
-
-    expect(sheetIsOpen(w)).toBe(true);
-    expect(overlayIsOpen(w)).toBe(true);
-    expect(w.document.body.style.overflow).toBe('hidden');
+    expect(w.state.activeView).toBe('protokoll');
   });
 
-  it('renders the drill tab list when opening the sheet', () => {
+  it('switches back to field view when already in protokoll', () => {
+    const { window: w } = createDom();
+    w.switchToProtokoll(); // → protokoll
+    w.switchToProtokoll(); // → back to null
+
+    expect(w.state.activeView).toBeNull();
+  });
+
+  it('calls renderDrillTabList when entering protokoll', () => {
+    const { window: w } = createDom();
     w.addReiter();
     w.state.reiter[0].hektar = 10;
     w.state.reiter[0].koerner = 90000;
     w.state.reiter[0].duenger = 150;
     w.saveState();
 
-    w.openProtokoll();
+    w.switchToProtokoll();
 
     // renderDrillTabList should have created elements
     expect(w.document.getElementById('dtl_prio_0')).toBeTruthy();
     expect(w.document.getElementById('dtl_e_0')).toBeTruthy();
   });
 
-  it('opens the sheet on click of the 🔧 Protokoll tab button', () => {
-    const tabBtn = w.document.getElementById('protokoll_tab_btn');
-    expect(tabBtn).toBeTruthy();
-    // onclick="openProtokoll()" is wired in the HTML
-    tabBtn.click();
-    expect(sheetIsOpen(w)).toBe(true);
+  it('syncs state from inputs before switching', () => {
+    const { window: w } = createDom();
+    w.document.getElementById('hektar').value = '15';
+    w.document.getElementById('koerner').value = '80000';
+
+    w.switchToProtokoll();
+
+    // syncStateFromInputs reads hektar/koerner inputs into state
+    expect(w.state.reiter[0].hektar).toBe(15);
+    expect(w.state.reiter[0].koerner).toBe(80000);
   });
 
-  it('opens the sheet on click of the overlay — overlay click triggers closeProtokoll, not open', () => {
-    // The overlay's onclick handler is closeProtokoll (HTML attribute).
-    // Document the contract: opening is via the tab button, not the overlay.
-    const overlay = getOverlay(w);
-    expect(overlay.getAttribute('onclick')).toContain('closeProtokoll');
-  });
-});
+  it('persists view state to localStorage', () => {
+    const { window: w, store } = createDom();
+    w.document.getElementById('hektar').value = '10';
+    w.document.getElementById('koerner').value = '90000';
+    w.berechne(); // Ensure state is initialized and sv() works
 
-describe('closeProtokoll()', () => {
-  let w;
-  beforeEach(() => { w = createDom().window; });
+    w.switchToProtokoll();
 
-  it('closes the protokoll sheet on closeProtokoll()', () => {
-    w.openProtokoll();
-    expect(sheetIsOpen(w)).toBe(true);
-
-    w.closeProtokoll();
-
-    expect(sheetIsOpen(w)).toBe(false);
-    expect(overlayIsOpen(w)).toBe(false);
-    expect(w.document.body.style.overflow).toBe('');
-  });
-
-  it('is a no-op when the sheet is already closed', () => {
-    expect(sheetIsOpen(w)).toBe(false);
-    expect(() => w.closeProtokoll()).not.toThrow();
-    expect(sheetIsOpen(w)).toBe(false);
-  });
-
-  it('closes the sheet when the close button is clicked', () => {
-    w.openProtokoll();
-    const closeBtn = w.document.querySelector('.protokoll-close');
-    expect(closeBtn).toBeTruthy();
-    expect(closeBtn.getAttribute('onclick')).toContain('closeProtokoll');
-    closeBtn.click();
-    expect(sheetIsOpen(w)).toBe(false);
+    const saved = JSON.parse(store['agrar_rechner']);
+    expect(saved.activeView).toBe('protokoll');
   });
 });
 
-describe('Protokoll sheet — keyboard handling', () => {
-  let w;
-  beforeEach(() => { w = createDom().window; });
+describe('renderView', () => {
+  it('hides all cards in protokoll mode', () => {
+    const { window: w } = createDom();
+    w.document.getElementById('hektar').value = '10';
+    w.document.getElementById('koerner').value = '90000';
+    w.berechne();
+    w.switchToProtokoll();
 
-  it('closes the protokoll sheet on Escape key', () => {
-    w.openProtokoll();
-    expect(sheetIsOpen(w)).toBe(true);
-
-    // _protokollKeyHandler is exposed on AppGlobals for testability
-    w.AppGlobals._protokollKeyHandler({ key: 'Escape', preventDefault: () => {} });
-
-    expect(sheetIsOpen(w)).toBe(false);
+    // Input cards should be hidden (drill_section stays visible in protokoll mode)
+    const cards = w.document.querySelectorAll('.card');
+    cards.forEach(c => {
+      if (c.id === 'drill_section') {
+        expect(c.style.display).toBe('block');
+      } else {
+        expect(c.style.display).toBe('none');
+      }
+    });
   });
 
-  it('does not close on non-Escape keys', () => {
-    w.openProtokoll();
-    w.AppGlobals._protokollKeyHandler({ key: 'Enter', preventDefault: () => {} });
-    w.AppGlobals._protokollKeyHandler({ key: ' ', preventDefault: () => {} });
-    expect(sheetIsOpen(w)).toBe(true);
+  it('shows all cards in field mode', () => {
+    const { window: w } = createDom();
+    w.document.getElementById('hektar').value = '10';
+    w.document.getElementById('koerner').value = '90000';
+    w.berechne();
+
+    w.renderView();
+
+    const cards = w.document.querySelectorAll('.card');
+    cards.forEach(c => {
+      // zaehler_section and drill_section may be hidden if no data — that's fine
+      if (c.id === 'zaehler_section' || c.id === 'drill_section') return;
+      expect(c.style.display).not.toBe('none');
+    });
   });
-});
 
-describe('drill_section visibility', () => {
-  let w;
-  beforeEach(() => { w = createDom().window; });
+  it('hides results in protokoll mode even with data', () => {
+    const { window: w } = createDom();
+    w.document.getElementById('hektar').value = '10';
+    w.document.getElementById('koerner').value = '90000';
+    w.berechne();
 
-  it('does not show drill_section outside the open protokoll sheet', () => {
-    // drill_section has style="display:none" in the HTML by default.
+    w.state.activeView = 'protokoll';
+    w.renderView();
+
+    const results = w.document.getElementById('results');
+    expect(results.style.display).toBe('none');
+  });
+
+  it('shows drill section in protokoll mode', () => {
+    const { window: w } = createDom();
+    w.state.activeView = 'protokoll';
+    w.renderView();
+
+    const drillSection = w.document.getElementById('drill_section');
+    expect(drillSection.style.display).toBe('block');
+  });
+
+  it('shows drill mask in protokoll mode', () => {
+    const { window: w } = createDom();
+    w.state.activeView = 'protokoll';
+    w.renderView();
+
+    const drillMask = w.document.getElementById('drill_mask');
+    expect(drillMask.style.display).not.toBe('none');
+  });
+
+  it('hides drill section in field mode', () => {
+    const { window: w } = createDom();
+    w.renderView();
+
     const drillSection = w.document.getElementById('drill_section');
     expect(drillSection.style.display).toBe('none');
   });
 
-  it('drill_section is still hidden when the sheet is open (sheet slides over the page; drill is rendered inside)', () => {
-    // The protokoll sheet is a slide-in overlay; drill_section visibility
-    // is driven by renderResults/renderDrillSummary, not by openProtokoll.
-    // This test guards against a regression where opening the sheet
-    // accidentally toggles drill_section.style.display.
-    w.openProtokoll();
-    const drillSection = w.document.getElementById('drill_section');
-    expect(drillSection.style.display).toBe('none');
+  it('shows results in field mode when data exists', () => {
+    const { window: w } = createDom();
+    w.document.getElementById('hektar').value = '10';
+    w.document.getElementById('koerner').value = '90000';
+    w.berechne();
+
+    const results = w.document.getElementById('results');
+    expect(results.style.display).toBe('block');
   });
 
-  it('drill_section is hidden after closeProtokoll()', () => {
-    w.openProtokoll();
-    w.closeProtokoll();
-    const drillSection = w.document.getElementById('drill_section');
-    expect(drillSection.style.display).toBe('none');
-  });
-});
+  it('hides results when no data in field mode', () => {
+    const { window: w } = createDom();
+    w.renderView();
 
-describe('Protokoll tab switching does not affect the sheet', () => {
-  let w;
-  beforeEach(() => { w = createDom().window; });
-
-  it('switching reiter does not change the sheet open state', () => {
-    w.addReiter();
-    w.openProtokoll();
-    expect(sheetIsOpen(w)).toBe(true);
-
-    w.switchReiter(0);
-    expect(sheetIsOpen(w)).toBe(true);
-
-    w.closeProtokoll();
-    w.switchReiter(1);
-    expect(sheetIsOpen(w)).toBe(false);
+    const results = w.document.getElementById('results');
+    expect(results.style.display).toBe('none');
   });
 });

--- a/tests/24-einheit-groesse.test.js
+++ b/tests/24-einheit-groesse.test.js
@@ -138,6 +138,7 @@ describe('initUI einheitGroesse restoration', () => {
       fahrgassenBreite: 0,
       zaehlerstand: 0,
       machineLog: [],
+      activeView: null,
     };
     store['agrar_rechner'] = JSON.stringify(savedState);
 
@@ -161,6 +162,7 @@ describe('initUI einheitGroesse restoration', () => {
       fahrgassenBreite: 0,
       zaehlerstand: 0,
       machineLog: [],
+      activeView: null,
     };
     store['agrar_rechner'] = JSON.stringify(savedState);
 

--- a/tests/43-loadstate-schema-validation.test.js
+++ b/tests/43-loadstate-schema-validation.test.js
@@ -197,20 +197,6 @@ describe('loadState() schema validation (Issue #237)', () => {
             expect(typeof tab.toString).toBe('function');
         });
 
-        it('a state without the removed top-level keys is still valid (Issue #291)', () => {
-            // Fresh state from a current build: the field that was removed in
-            // the protokoll-sheet refactor (Issue #291) is no longer in the
-            // schema. loadState must accept a state that does not carry it
-            // and not complain about the missing key.
-            store['agrar_rechner'] = JSON.stringify({
-                reiter: [{ entries: [] }],
-                _lv: 4
-            });
-            expect(() => w.loadState()).not.toThrow();
-            // State should be loadable and the reiter should still be there
-            expect(w.state.reiter.length).toBe(1);
-        });
-
         it('drops unknown keys from entry objects', () => {
             store['agrar_rechner'] = JSON.stringify({
                 reiter: [{
@@ -308,6 +294,16 @@ describe('loadState() schema validation (Issue #237)', () => {
             });
             w.loadState();
             expect(w.state.activeReiter).toBe(1);
+        });
+
+        it('coerces activeView to null unless literally "protokoll"', () => {
+            store['agrar_rechner'] = JSON.stringify({
+                reiter: [{ entries: [] }],
+                activeView: '<script>',
+                _lv: 4
+            });
+            w.loadState();
+            expect(w.state.activeView).toBeNull();
         });
 
         it('falls back to 50000 for invalid koernerProEinheit', () => {

--- a/tests/44-legacy-key-migration.test.js
+++ b/tests/44-legacy-key-migration.test.js
@@ -18,6 +18,7 @@ const LEGACY_DATA = {
   _lv: 4,
   reiter: [{ name: 'Tab 1', hektar: 12.5, istHektar: 12.5, koerner: 90000, duenger: 200, entries: [] }],
   activeReiter: 0,
+  activeView: null,
   fahrgassenEnabled: false,
   fahrgassenBreite: 0,
   einheitGroesseEnabled: false,


### PR DESCRIPTION
## Grund
User-Feedback nach #291: das Bottom-Sheet-Verhalten entspricht nicht den Erwartungen. Vor dem Refactor (Stand 6671fd1) war das Protokoll ein View-Toggle im Hauptlayout — Tabs oben sichtbar, Inhaltsbereich schaltet auf drill_section um, alle anderen Cards auf display:none. User moechte dieses Verhalten zurueck.

## Was passiert
- 8 Commits aus #291 + #293 werden zurueckgerollt (Brute-Force: 14 Dateien aus 6671fd1 wiederhergestellt)
- Endzustand der betroffenen Dateien = 6671fd1
- AppGlobals-Refactor (#278) bleibt unberuehrt
- Reverts: #291

## Revert-Commits
- 9bb7cc9 refactor(#291): state.activeView und renderView/switchToProtokoll entfernt
- 9e42a67 refactor(#291): JS — openProtokoll/closeProtokoll mit Fokus-Trap
- 398000a refactor(#291): HTML — Protokoll-Card in protokoll_sheet ausgelagert
- 718afba refactor(#291): CSS — Protokoll-Sheet analog zu Dashboard-Sheet
- a1ba493 test(#291): Tests an Protokoll-Sheet-Architektur angepasst
- 48497a6 fix(#291): Service-Worker CACHE_VERSION v17 → v18 (#293)

(58b49af wurde durch den PR-Merge 48497a6 auf dev ueberschrieben und existiert auf dev nicht separat.)

## Verifikation
- pnpm test: 747/747 gruen (Pre-#291-Stand)
- pnpm lint: 0 errors
- Im Browser: Klick auf 🔧 Protokoll → Cards oben verschwinden, drill_section fuellt den Inhaltsbereich, Tabs bleiben oben sichtbar

## Anmerkung zur Strategie
Statt 8 einzelner `git revert`-Commits (die wegen der Ueberlappungen mit #288-Konflikten in public/index.html in Sackgassen fuehrten) wurde der Brute-Force-Ansatz gewaehlt: `git checkout 6671fd1 -- <14 files>`. Das produziert einen einzigen sauberen Revert-Commit statt 8 fragmentierter.