### PR TITLE
refactor(#291): CSS — Protokoll-Sheet analog Dashboard

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1020,6 +1020,73 @@ font-size: 0.75rem;
     .dashboard-close:active {
       background: var(--color-bg-hover);
     }
+
+    /* Protokoll (Issue #291)
+       Z-Index: Protokoll-Overlay/Sheet eine Stufe unter Dashboard (148/149 vs. 150/151).
+       Grund: Dashboard hat Priorität — wenn beide Sheets versehentlich gleichzeitig
+       geöffnet werden, verdeckt das Dashboard das Protokoll-Sheet, damit die
+       jüngste User-Aktion (Dashboard) zu sehen ist. */
+    .protokoll-overlay {
+      display: none;
+      position: fixed;
+      inset: 0;
+      background: rgba(0,0,0,0.4);
+      z-index: 148;
+    }
+    .protokoll-overlay.open {
+      display: block;
+    }
+    .protokoll-sheet {
+      display: none;
+      position: fixed;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      background: var(--color-card-bg);
+      border-radius: 20px 20px 0 0;
+      max-height: 80vh;
+      overflow-y: auto;
+      z-index: 149;
+      padding: 0 0 max(20px, env(safe-area-inset-bottom));
+    }
+    .protokoll-sheet.open {
+      display: block;
+    }
+    .protokoll-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 20px 20px 16px;
+      border-bottom: 2px solid var(--color-border-soft);
+      position: sticky;
+      top: 0;
+      background: var(--color-card-bg);
+      border-radius: 20px 20px 0 0;
+    }
+    .protokoll-header h2 {
+      margin: 0;
+      padding: 0;
+      border: none;
+      font-size: 1.1rem;
+      color: var(--color-primary-dark);
+    }
+    .protokoll-close {
+      background: var(--color-border-soft);
+      border: none;
+      border-radius: 50%;
+      width: 36px;
+      height: 36px;
+      font-size: 1.2rem;
+      cursor: pointer;
+      color: var(--color-primary);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .protokoll-close:active {
+      background: var(--color-bg-hover);
+    }
+
     .dashboard-open-btn {
       background: var(--color-primary-dark);
       color: var(--color-ios-banner-text);

--- a/public/index.html
+++ b/public/index.html
@@ -36,7 +36,7 @@
     <div class="tab-bar" id="tab_bar">
       <div class="tab-bar-left" id="tab_bar_left"><button class="tab-add" onclick="addReiter()">+ Tab</button></div>
       <div class="tab-separator"></div>
-      <button class="tab-btn protokoll-tab" id="protokoll_tab_btn" onclick="switchToProtokoll()">🔧 Protokoll</button>
+      <button class="tab-btn protokoll-tab" id="protokoll_tab_btn" onclick="openProtokoll()">🔧 Protokoll</button>
     </div>
 
     <div class="card card-input" id="card_input">
@@ -148,61 +148,6 @@
       <div class="info" id="r_info"></div>
     </div><!-- end results card -->
 
-    <div class="card" id="drill_section" style="display:none">
-      <h2>🔧 Drill-Protokoll</h2>
-      <div id="drill_mask">
-        <div class="drill-machine-row">
-          <div class="field">
-            <label for="drill_einheit">Maschine eingefüllt (Einheiten)</label>
-            <input type="text" inputmode="decimal" autocomplete="off" autocorrect="off" spellcheck="false" id="drill_einheit" placeholder="z.B. 4" oninput="drillCalcDebounced(); onInputFormat(this, 'decimal', event)">
-          </div>
-          <div class="field">
-            <label for="drill_duenger">Maschine eingefüllt (Dünger kg)</label>
-            <input type="text" inputmode="decimal" autocomplete="off" autocorrect="off" spellcheck="false" id="drill_duenger" placeholder="z.B. 200" oninput="drillCalcDebounced(); onInputFormat(this, 'decimal', event)">
-          </div>
-        </div>
-        <div class="field">
-          <label for="drill_hektar">Zählerstand (ha)</label>
-          <input type="text" inputmode="decimal" autocomplete="off" autocorrect="off" spellcheck="false" id="drill_hektar" placeholder="z.B. 5,2" oninput="onInputFormat(this, 'decimal', event)">
-        </div>
-        <div class="drill-tabs-section">
-          <div class="drill-tabs-header">Aufteilen auf (Klick = Prio: 1 → 2 → 3 → aus):</div>
-          <div id="drill_tab_list"></div>
-        </div>
-        <button class="btn-add" onclick="drillAdd()">+ Einfüllen</button>
-      </div>
-      <div id="drill_summary" class="drill-summary" style="display:none">
-        <div id="ds_total_summary" class="drill-total-summary" style="margin-bottom:8px;font-weight:bold;"></div>
-        <div class="drill-summary-row">
-          <span>Einheiten gesamt</span>
-          <span id="ds_saat_total">—</span>
-        </div>
-        <div class="drill-summary-row">
-          <span>Einheiten verwendet</span>
-          <span id="ds_saat_used">—</span>
-        </div>
-        <div class="drill-summary-row remaining">
-          <span>Einheiten verbleibend</span>
-          <span id="ds_saat_remaining">—</span>
-        </div>
-        <div class="drill-summary-row">
-          <span>Dünger gesamt</span>
-          <span id="ds_duenger_total">—</span>
-        </div>
-        <div class="drill-summary-row">
-          <span>Dünger verwendet</span>
-          <span id="ds_duenger_used">—</span>
-        </div>
-        <div class="drill-summary-row remaining">
-          <span>Dünger verbleibend</span>
-          <span id="ds_duenger_remaining">—</span>
-        </div>
-        <div class="drill-summary-savings" id="ds_savings" style="display:none"></div>
-      </div>
-      <div id="drill_machine_log"></div>
-      <div id="drill_entries"></div>
-    </div>
-
     </div><!-- end .container -->
 
     <!-- Sticky footer -->
@@ -283,6 +228,68 @@
       <button class="dashboard-close" onclick="closeDashboard()" aria-label="Schließen">✕</button>
     </div>
     <div class="dashboard-content" id="dashboard_content"></div>
+  </div>
+
+  <!-- Protokoll overlay + sheet (Issue #291) -->
+  <div class="protokoll-overlay" id="protokoll_overlay" onclick="closeProtokoll()"></div>
+  <div class="protokoll-sheet" id="protokoll_sheet" role="dialog" aria-modal="true" aria-label="Drill-Protokoll">
+    <div class="protokoll-header">
+      <h2>🔧 Drill-Protokoll</h2>
+      <button class="protokoll-close" onclick="closeProtokoll()" aria-label="Schließen">✕</button>
+    </div>
+    <div class="card" id="drill_section" style="display:none">
+      <div id="drill_mask">
+        <div class="drill-machine-row">
+          <div class="field">
+            <label for="drill_einheit">Maschine eingefüllt (Einheiten)</label>
+            <input type="text" inputmode="decimal" autocomplete="off" autocorrect="off" spellcheck="false" id="drill_einheit" placeholder="z.B. 4" oninput="drillCalcDebounced(); onInputFormat(this, 'decimal', event)">
+          </div>
+          <div class="field">
+            <label for="drill_duenger">Maschine eingefüllt (Dünger kg)</label>
+            <input type="text" inputmode="decimal" autocomplete="off" autocorrect="off" spellcheck="false" id="drill_duenger" placeholder="z.B. 200" oninput="drillCalcDebounced(); onInputFormat(this, 'decimal', event)">
+          </div>
+        </div>
+        <div class="field">
+          <label for="drill_hektar">Zählerstand (ha)</label>
+          <input type="text" inputmode="decimal" autocomplete="off" autocorrect="off" spellcheck="false" id="drill_hektar" placeholder="z.B. 5,2" oninput="onInputFormat(this, 'decimal', event)">
+        </div>
+        <div class="drill-tabs-section">
+          <div class="drill-tabs-header">Aufteilen auf (Klick = Prio: 1 → 2 → 3 → aus):</div>
+          <div id="drill_tab_list"></div>
+        </div>
+        <button class="btn-add" onclick="drillAdd()">+ Einfüllen</button>
+      </div>
+      <div id="drill_summary" class="drill-summary" style="display:none">
+        <div id="ds_total_summary" class="drill-total-summary" style="margin-bottom:8px;font-weight:bold;"></div>
+        <div class="drill-summary-row">
+          <span>Einheiten gesamt</span>
+          <span id="ds_saat_total">—</span>
+        </div>
+        <div class="drill-summary-row">
+          <span>Einheiten verwendet</span>
+          <span id="ds_saat_used">—</span>
+        </div>
+        <div class="drill-summary-row remaining">
+          <span>Einheiten verbleibend</span>
+          <span id="ds_saat_remaining">—</span>
+        </div>
+        <div class="drill-summary-row">
+          <span>Dünger gesamt</span>
+          <span id="ds_duenger_total">—</span>
+        </div>
+        <div class="drill-summary-row">
+          <span>Dünger verwendet</span>
+          <span id="ds_duenger_used">—</span>
+        </div>
+        <div class="drill-summary-row remaining">
+          <span>Dünger verbleibend</span>
+          <span id="ds_duenger_remaining">—</span>
+        </div>
+        <div class="drill-summary-savings" id="ds_savings" style="display:none"></div>
+      </div>
+      <div id="drill_machine_log"></div>
+      <div id="drill_entries"></div>
+    </div>
   </div>
 
   <!-- Reset Confirmation Modal (Issue #236) -->


### PR DESCRIPTION
Closes #291 (CSS-Teil).

## Kontext
HTML-Markup in T1 (`406b24f`) hat die Protokoll-Card in `protokoll_sheet` + `protokoll_overlay` umgebaut. Diese CSS-Klassen fehlten noch.

## Was
- `public/css/styles.css`: `.protokoll-overlay`, `.protokoll-sheet`, `.protokoll-header`, `.protokoll-close` (analog zu `.dashboard-*`)
- Z-Index **148/149** (eine Stufe unter Dashboard 150/151), damit Dashboard bei versehentlich gleichzeitig geöffneten Sheets Priorität hat
- Kommentar im CSS dokumentiert die Z-Index-Wahl
- Keine Style-Overrides für innere Cards (`.drill-section`, `#drill_mask`, `#drill_summary`, `#drill_tab_list` etc.) — die hängen jetzt nur unter `.protokoll-content` und nutzen ihre bestehenden Regeln

## Verify
- `pnpm lint` → 0 errors
- `pnpm test` → 782/782 grün
- Diff: nur CSS-Adds, keine funktionalen Änderungen

## Commits
- `a1967d1` refactor(#291): CSS — .protokoll-sheet/.protokoll-overlay analog Dashboard
- `406b24f` refactor(#291): HTML — Protokoll-Card in protokoll_sheet ausgelagert (T1)