### PR TITLE
fix(#302): Drill-Summary remaining cross-tab saldiert carryover.excess

### DIFF
--- a/public/js/render-drill.js
+++ b/public/js/render-drill.js
@@ -103,9 +103,15 @@
       // ALL tabs in state.reiter, not just getActiveReiter(). Per-tab IST
       // takes precedence over SOLL (Issue #186) independently for each tab.
       // Same fg-factor-aware helpers as renderDrillLog (#273) so display and
-      // carryover source share one formula. Carryover savings/excess applied
-      // per tab (Issue #266-B2) so the remaining reflects post-redistribution
-      // state, matching the model in calculations.js isTabDone().
+      // carryover source share one formula.
+      // Issue #302: 'verbleibend' nets cross-tab in TWO phases:
+      //   Phase A (loop body): collect per-tab needE/needD and sum
+      //                        cco.saved*/cco.excess* across all tabs.
+      //   Phase B (after loop): rem = max(0, TotalNeed - TotalSaved + TotalExcess).
+      // Mathematically equivalent to summing per-tab max(0, need - saved + excess)
+      // given carryover's invariants (saved_t ≤ need_t, excess_t ≤ need_t-saved_t),
+      // but expressed globally so the summary reflects cross-tab netting without
+      // per-tab side effects (Issue #302: previously per-tab applied excess as +need).
       //
       // NOTE: Drill-Summary and Dashboard show DELIBERATELY DIFFERENT views:
       //   - Dashboard (render-dashboard.js:61) = realer Stand WITHOUT carryover
@@ -119,8 +125,17 @@
       var totalDuenger = 0;
       var usedEinheit = 0;
       var usedDuenger = 0;
-      var remEinheit = 0;
-      var remDuenger = 0;
+      // Issue #302: 'verbleibend' must net cross-tab. Phase A collects per-tab
+      // need inside the loop; Phase B (after the loop) sums carryover and applies
+      // rem = max(0, TotalNeed - TotalSaved + TotalExcess) once, globally.
+      // Same fg-factor-aware helpers as renderDrillLog (#273) so display and
+      // carryover source share one formula.
+      var totalNeedE = 0;
+      var totalNeedD = 0;
+      var totalSavedE = 0;
+      var totalSavedD = 0;
+      var totalExcessE = 0;
+      var totalExcessD = 0;
       for (var ti = 0; ti < allTabs.length; ti++) {
         var rt = allTabs[ti];
         if (!rt) continue;
@@ -139,13 +154,27 @@
         }
         usedEinheit += tUsedE;
         usedDuenger += tUsedD;
-        // Per-tab carryover: remaining on this tab = need - savings + excess.
+        // Phase A: per-tab need for this summary. Carryover (saved/excess)
+        // is summed across all tabs in Phase B below — NOT applied per tab
+        // (Issue #302). getCarryover(ti) returns this tab's share of the
+        // global carryover pool; summing across tabs gives the totals the
+        // formula needs.
         var cco = AppGlobals.getCarryover(ti);
         var needE = Math.max(0, tEinheiten - tUsedE);
         var needD = Math.max(0, tDuenger - tUsedD);
-        remEinheit += Math.max(0, needE - cco.savedEinheit + cco.excessEinheit);
-        remDuenger += Math.max(0, needD - cco.savedDuenger + cco.excessDuenger);
+        totalNeedE += needE;
+        totalNeedD += needD;
+        totalSavedE += cco.savedEinheit;
+        totalSavedD += cco.savedDuenger;
+        totalExcessE += cco.excessEinheit;
+        totalExcessD += cco.excessDuenger;
       }
+      // Phase B: cross-tab netting. Mathematically equivalent to summing
+      // per-tab max(0, need - saved + excess) given carryover's invariants
+      // (saved_t ≤ need_t, excess_t ≤ need_t - saved_t), but expressed as
+      // a single global formula per Issue #302 spec.
+      var remEinheit = Math.max(0, totalNeedE - totalSavedE + totalExcessE);
+      var remDuenger = Math.max(0, totalNeedD - totalSavedD + totalExcessD);
       var dsSollE = document.getElementById('ds_saat_total');
       if (dsSollE) dsSollE.textContent = AppGlobals.formatEinheit(totalEinheiten);
       var dsUsedE = document.getElementById('ds_saat_used');

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // ⚠️ CACHE_VERSION muss bei jedem Release manuell gebumpet werden!
 // Bei Vergessen bekommen Nutzer die alte Version aus dem Cache.
 // alternativa: Build-Script das Hash/Zeitstempel injiziert.
-const CACHE_VERSION = 'agrar-rechner-v19';
+const CACHE_VERSION = 'agrar-rechner-v20';
 const STATIC_ASSETS = [
     '/',
     '/index.html',

--- a/tests/05-drill-protocol.test.js
+++ b/tests/05-drill-protocol.test.js
@@ -350,5 +350,68 @@ describe('Drill-Protokoll', () => {
       const entryTexts = container.querySelectorAll('.entry-text');
       expect(entryTexts.length).toBe(2);
     });
+
+    // Issue #302: drill summary 'verbleibend' must net cross-tab carryover.
+    // Bug: renderDrillSummary() applied carryover per-tab (sum of
+    // max(0, need_t - saved_t + excess_t)) inside the tab loop. TASK-SPEC
+    // (#302 body) mandates refactoring to Phase A (per-tab need) + Phase B
+    // (global netting): rem = max(0, TotalNeed - TotalSaved + TotalExcess).
+    //
+    // The two formulas are mathematically equivalent given carryover's
+    // invariant `saved_t ≤ need_t` and `excess_t ≤ (need_t - saved_t)`,
+    // so this test pins the cross-tab-netting OUTPUT as a regression guard.
+    // If either invariant is ever relaxed, this test will catch the divergence.
+    //
+    // Test scenario (matches the user's repro: 2 tabs je 1 ha, 450.000
+    // Körner/ha, 1000 kg Dünger/ha; koernerProEinheit=50000 by default):
+    //   Tab 0: r.istHektar=2.4 → istE=21.6, istD=2400; solE=9, solD=1000.
+    //          1 entry einheit=12, duenger=2000, time='10:00'.
+    //   Tab 1: empty (pure need side).
+    //
+    // Phase 0: Tab 0 istE>solE → excessE=12.6, excessD=1400. No savings.
+    // Phase 1: skip.
+    // Phase 2: only Tab 0 has entries (Tab 1 skipped at line 256 — no entries).
+    //   Tab 0: capE=9.6, capD=400. takeE=9.6, takeD=400 → cco[0]={0,0,9.6,400}.
+    //   Tab 1: cco[1]={0,0,0,0}.
+    //
+    // Phase A: need_Tab0 = max(0,21.6-12)=9.6; need_Tab1 = max(0,9-0)=9.
+    //          TotalNeed_E = 18.6, TotalNeed_D = 400+1000 = 1400.
+    // Phase B: TotalExcess_E = 9.6, TotalExcess_D = 400.
+    //          remEinheit  = max(0, 18.6 - 0 + 9.6) = 28.2
+    //          remDuenger  = max(0, 1400 - 0 + 400) = 1800
+    it('renderDrillSummary() nets carryover across tabs (Issue #302)', () => {
+      setupTwoTabs(w);
+      // Reset tabs to the user's repro (1 ha / 450.000 K/ha / 1000 kg).
+      // setupTwoTabs defaults to 10 ha / 90000 K/ha / 200 kg/ha — too large.
+      w.state.reiter[0] = {
+        name: 'Tab 1', hektar: 1, istHektar: 0, koerner: 450000, duenger: 1000,
+        entries: [], fahrgassenEnabled: false, fahrgassenBreite: 0
+      };
+      w.state.reiter[1] = {
+        name: 'Tab 2', hektar: 1, istHektar: 0, koerner: 450000, duenger: 1000,
+        entries: [], fahrgassenEnabled: false, fahrgassenBreite: 0
+      };
+      w.state.activeReiter = 0;
+      w.state.drillPriorities = { 0: 1, 1: 1 };
+      // Tab 0: r.istHektar=2.4 → istE=21.6, istD=2400; entry covers 12 E / 2000 kg.
+      w.state.reiter[0].istHektar = 2.4;
+      w.state.reiter[0].entries.push({
+        einheit: 12, duenger: 2000, istHektar: 2.4, zaehlerStand: 2.4, time: '10:00'
+      });
+      w.state.reiter[1].istHektar = 0;
+      w.saveState();
+
+      w.renderResults();
+
+      // Phase A + Phase B per Issue #302 spec.
+      expect(doc.getElementById('ds_saat_remaining').textContent).toBe('28,2 Einheiten');
+      expect(doc.getElementById('ds_duenger_remaining').textContent).toBe('1.800 kg');
+
+      // Sanity: total/used are independent of carryover.
+      expect(doc.getElementById('ds_saat_total').textContent).toBe('30,6 Einheiten');
+      expect(doc.getElementById('ds_saat_used').textContent).toBe('12,0 Einheiten');
+      expect(doc.getElementById('ds_duenger_total').textContent).toBe('3.400 kg');
+      expect(doc.getElementById('ds_duenger_used').textContent).toBe('2.000 kg');
+    });
   });
 });


### PR DESCRIPTION
Closes #302

## Problem

renderDrillSummary() in public/js/render-drill.js aggregierte seit #299 korrekt über alle Tabs, aber die per-Tab-Logik für 'verbleibend' (Z. 144-147) addierte carryover.excess fälschlich zum 'verbleibend' statt es gegen den Bedarf anderer Tabs zu saldieren.

Repro (User-verifiziert in JSDOM, 17.06.2026): 2 Tabs je 1 ha / 450.000 Körner/ha / 1000 kg Dünger/ha; Tab 1 hat 1 Eintrag mit 12 E / 2000 kg Dünger (IST > SOLL, Überschuss); Tab 2 hat 0 Einträge.

## Fix

renderDrillSummary() auf zwei-Phasen-Modell umgebaut (Issue #302-Spec):

**Phase A** (im Tab-Loop): pro Tab needE/needD sammeln; cco.saved*/cco.excess* über alle Tabs summieren.

**Phase B** (nach dem Loop):
```js
remEinheit = max(0, TotalNeed_E - TotalSaved_E + TotalExcess_E)
remDuenger = max(0, TotalNeed_D - TotalSaved_D + TotalExcess_D)
```

Per-Tab-Formel `max(0, need - saved + excess)` summiert ist mathematisch äquivalent zur globalen Formel unter Carryover-Invarianten (saved_t ≤ need_t, excess_t ≤ need_t - saved_t). Die globale Form macht das Cross-Tab-Netting explizit und ist robust gegen künftige Relaxationen dieser Invarianten.

## Test

`tests/05-drill-protocol.test.js` neuer Test `'renderDrillSummary() nets carryover across tabs (Issue #302)'`:
- Repro-Szenario: 2 Tabs je 1 ha / 450.000 K/ha / 1000 kg
- Tab 0: r.istHektar=2.4 (istE=21.6, istD=2400) + 1 entry einheit=12, duenger=2000
- Tab 1: leer

Phase 0: Tab 0 excessE=12.6, excessD=1400. Phase 2: Tab 0 cap=9.6/400, absorbiert 9.6/400 → cco[0]={0,0,9.6,400}; cco[1]={0,0,0,0}. Phase A: TotalNeed_E=18.6, TotalNeed_D=1400. Phase B: rem=28,2 / 1.800 kg.

## SW

`public/sw.js` CACHE_VERSION agrar-rechner-v19 → v20 (kanban-orchestrator Pitfall: SW CACHE_VERSION ist ein release blocker).