### PR TITLE
fix(#307): correct renderMachineLog prognose — zaehlerStand=0 + per-entry condition

### DIFF
--- a/public/js/render-drill.js
+++ b/public/js/render-drill.js
@@ -428,9 +428,13 @@
           var t = typeof entry.time === 'number' ? new Date(entry.time).toLocaleString('de-DE') : entry.time;
           parts.push(t + ' –');
         }
-        if (entry.hektar || entry.zaehlerStand) {
-          var ha = entry.zaehlerStand || entry.hektar;
-          parts.push(ha.toLocaleString('de-DE', { minimumFractionDigits: 1, maximumFractionDigits: 1 }) + ' ha');
+        // Issue #307: `zaehlerStand` starts at 0; `||` would silently fall through
+        // to `entry.hektar` (the target). For display, prefer an explicit `!= null`
+        // check so a freshly-started log (zaehlerStand=0) shows "0,0 ha" instead of
+        // the misleading target-hektar.
+        var displayHa = entry.zaehlerStand != null ? entry.zaehlerStand : entry.hektar;
+        if (entry.zaehlerStand != null || entry.hektar) {
+          parts.push(displayHa.toLocaleString('de-DE', { minimumFractionDigits: 1, maximumFractionDigits: 1 }) + ' ha');
         }
         parts.push(AppGlobals.formatEinheit(entry.einheit || 0));
         if (entry.duenger > 0) {
@@ -447,7 +451,13 @@
         row.appendChild(removeBtn);
         container.appendChild(row);
         // Update cumulative tank-level: subtract driven ha since last fill, then add this fill.
-        var zaehler = entry.zaehlerStand || entry.hektar || 0;
+        // Issue #307: `zaehlerStand` is the drill's meter counter and starts at 0;
+        // `||` falls through 0 to `entry.hektar` (the target), so `driven = zaehler - lastZaehler`
+        // would phantom-inflate by the full target on the first entry. Use an explicit
+        // `!= null` check so a `zaehlerStand=0` entry correctly reports `driven = 0`.
+        var zaehler = entry.zaehlerStand != null
+          ? entry.zaehlerStand
+          : (entry.hektar != null ? entry.hektar : 0);
         var driven = Math.max(0, zaehler - lastZaehler);
         if (unitsPerHa > 0) cumEinheit = Math.max(0, cumEinheit - driven * unitsPerHa);
         if (duengerPerHa > 0) cumDuenger = Math.max(0, cumDuenger - driven * duengerPerHa);
@@ -455,12 +465,16 @@
         cumDuenger += entry.duenger || 0;
         lastZaehler = zaehler;
         // Prognose row (one per entry that has rates)
+        // Issue #307: per-entry check (`entry.einheit > 0`) suppresses the Saat
+        // prognose on a follow-up entry that only refilled Dünger — even though
+        // the cumulative tank is still > 0. Switch to `cumEinheit > 0` so the
+        // prognose is correct for every entry as long as some Saat remains.
         var prognoseParts = [];
-        if (unitsPerHa > 0 && entry.einheit > 0) {
+        if (unitsPerHa > 0 && cumEinheit > 0) {
           var saatLeer = zaehler + cumEinheit / unitsPerHa;
           prognoseParts.push('Saat leer bei ' + AppGlobals.fmt(saatLeer) + ' ha');
         }
-        if (duengerPerHa > 0 && entry.duenger > 0) {
+        if (duengerPerHa > 0 && cumDuenger > 0) {
           var duengerLeer = zaehler + cumDuenger / duengerPerHa;
           prognoseParts.push('Dünger leer bei ' + AppGlobals.fmt(duengerLeer) + ' ha');
         }

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // ⚠️ CACHE_VERSION muss bei jedem Release manuell gebumpet werden!
 // Bei Vergessen bekommen Nutzer die alte Version aus dem Cache.
 // alternativa: Build-Script das Hash/Zeitstempel injiziert.
-const CACHE_VERSION = 'agrar-rechner-v21';
+const CACHE_VERSION = 'agrar-rechner-v22';
 const STATIC_ASSETS = [
     '/',
     '/index.html',

--- a/tests/16-machine-log.test.js
+++ b/tests/16-machine-log.test.js
@@ -266,4 +266,60 @@ describe('machineLog prognose', () => {
     // Second prognose should say saat leer bei ~5,7 ha
     expect(prognose[1].textContent).toContain('5,7');
   });
+
+  // Issue #307 — Pattern #1 (falsy-fallback through valid 0): when `zaehlerStand=0`,
+  // the buggy `entry.zaehlerStand || entry.hektar` falls through to the target
+  // hectares, inflating `driven` by the full target. A single freshly-logged entry
+  // (`zaehlerStand=0`, `hektar=15`, `einheit=24`, `duenger=2000`) should NOT show
+  // phantom prognose of "Saat leer bei 28,3 ha · Dünger leer bei 25,0 ha".
+  //
+  // Tab: koerner=90000, koernerProEinheit=50000 (default) → unitsPerHa=1,8.
+  // Tab: duenger=200 → duengerPerHa=200.
+  // After fix: driven=0, cumEinheit=24, cumDuenger=2000.
+  // → saatLeer = 0 + 24/1.8 = 13,3 ha
+  // → duengerLeer = 0 + 2000/200 = 10,0 ha
+  it('Issue #307 Pattern #1: zaehlerStand=0 reports driven=0 (no phantom-ha inflation)', () => {
+    w.state.reiter[0] = { ...w.state.reiter[0], hektar: 15, koerner: 90000, duenger: 200, entries: [] };
+    w.state.machineLog = [
+      { einheit: 24, zaehlerStand: 0, duenger: 2000, hektar: 15, time: '10:00' },
+    ];
+    w.renderResults();
+
+    var mlContainer = w.document.getElementById('drill_machine_log');
+    var prognose = mlContainer.querySelectorAll('.drill-prognose');
+    expect(prognose.length).toBe(1);
+    var txt = prognose[0].textContent;
+    // Must NOT contain the buggy phantom values (28,3 / 25,0)
+    expect(txt).not.toContain('28,3');
+    expect(txt).not.toContain('25,0');
+    // Must contain the corrected values (13,3 / 10,0)
+    expect(txt).toContain('13,3');
+    expect(txt).toContain('10,0');
+  });
+
+  // Issue #307 — Pattern #2 (per-entry condition instead of cumulative):
+  // a follow-up entry that refills ONLY Dünger (entry.einheit=0) must still
+  // show the "Saat leer bei" prognose, because `cumEinheit` is still > 0 from
+  // the previous fill. The buggy `entry.einheit > 0` check silently drops the
+  // Saat prognose on every entry that doesn't add Saat.
+  it('Issue #307 Pattern #2: Saat prognose survives a Dünger-only follow-up entry', () => {
+    w.state.reiter[0] = { ...w.state.reiter[0], hektar: 15, koerner: 90000, duenger: 200, entries: [] };
+    w.state.machineLog = [
+      { einheit: 24, zaehlerStand: 0, duenger: 2000, hektar: 15, time: '10:00' },
+      { einheit: 0,  zaehlerStand: 0, duenger: 1000, hektar: 15, time: '11:00' },
+    ];
+    w.renderResults();
+
+    var mlContainer = w.document.getElementById('drill_machine_log');
+    var prognose = mlContainer.querySelectorAll('.drill-prognose');
+    // Both entries must render a prognose row.
+    expect(prognose.length).toBe(2);
+    // The second entry (Dünger-only refill) must STILL show the Saat prognose,
+    // because the cumulative Saat tank is still > 0 after the first fill.
+    expect(prognose[1].textContent).toContain('Saat leer bei');
+    expect(prognose[1].textContent).toContain('13,3');
+    // And of course the Dünger prognose accumulates too.
+    expect(prognose[1].textContent).toContain('Dünger leer bei');
+    expect(prognose[1].textContent).toContain('15,0');
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #307 — `renderMachineLog()` in `public/js/render-drill.js` produces two related prognose bugs:

1. **Pattern #1 (falsy-fallback through valid 0):** `entry.zaehlerStand || entry.hektar || 0` silently falls through `zaehlerStand=0` (the legitimate starting value of the drill's meter counter) to `entry.hektar` (the target). The first entry's `driven` value is inflated by the full target — a freshly-logged 0-ha entry shows "Saat leer bei 28,3 ha · Dünger leer bei 25,0 ha" instead of the correct "Saat leer bei 13,3 ha · Dünger leer bei 10,0 ha".
2. **Pattern #2 (per-entry condition instead of cumulative):** `entry.einheit > 0` and `entry.duenger > 0` in the prognose predicates suppress the Saat/Dünger prognose on every follow-up entry that doesn't add that resource — even though the cumulative tank is still > 0 from earlier fills. A Dünger-only refill entry (e.g. `einheit=0, duenger=1000`) loses the Saat prognose entirely.

## Changes

### `public/js/render-drill.js` — `renderMachineLog()` (lines ~431, ~450, ~459, ~463)

- **Line 450 (zaehler calc):** replace `entry.zaehlerStand || entry.hektar || 0` with explicit `!= null` checks so `zaehlerStand=0` is respected and `driven=0` on the first entry.
- **Lines 459 / 463 (prognose predicates):** replace `entry.einheit > 0` / `entry.duenger > 0` with `cumEinheit > 0` / `cumDuenger > 0` so the prognose is correct for every entry as long as some tank remains.
- **Lines 431-432 (display "X ha" in same row):** same bug class — `zaehlerStand=0, hektar=15` showed "15,0 ha" instead of the honest "0,0 ha". Fixed in the same patch for consistency (same function, same call site, same variable).

### `public/sw.js`

- `CACHE_VERSION` bumped `agrar-rechner-v21` → `agrar-rechner-v22` (mandatory: `public/js/render-drill.js` is in `STATIC_ASSETS`, so the SW would otherwise serve the stale cached file).

### `tests/16-machine-log.test.js`

- **+2 new tests** covering both bug patterns:
  - Pattern #1 — single `zaehlerStand=0` entry reports `Saat leer bei 13,3 ha · Dünger leer bei 10,0 ha` (and explicitly asserts absence of the buggy `28,3` / `25,0` values).
  - Pattern #2 — two-entry sequence where the second entry refills only Dünger still shows the Saat prognose on BOTH entries (`13,3 ha`) and the Dünger prognose accumulates correctly (`15,0 ha` on the second entry).

## Sibling scan

`search_files` over `public/js/` for additional `|| entry.` / `|| r.` chains where the first operand is a 0-valid field (`zaehlerStand`, `istHektar`, `koerner`, `duenger`):

| Location | Pattern | Bug class? | Decision |
|---|---|---|---|
| `public/js/render-drill.js:431` | `entry.hektar \|\| entry.zaehlerStand` (display) | Pattern #1 (display) | **Fixed in this PR** (same function, same row, same variable — surgical) |
| `public/js/render-drill.js:450` | `entry.zaehlerStand \|\| entry.hektar \|\| 0` (math) | Pattern #1 (math) | **Fixed in this PR** (this is the headline bug) |
| `public/js/render-drill.js:346` | `entry.istHektar \|\| entry.zaehlerStand` (display) | Pattern #1 (display only) | Out of scope — drill-protocol entry ha display, different code path |
| `public/js/render-results.js:192` | `entry.istHektar \|\| entry.zaehlerStand` (display) | Pattern #1 (display only) | Out of scope — drill-entries inline display, different code path |

The two out-of-scope sites are display-only, contained in different code paths (drill-protocol rendering), and not part of the machine-log prognose that #307 reports. They show the same misleading display ("X ha" when the drill has actually drilled 0) but the user's bug report is scoped to the Maschinen-Protokoll. Leaving them for a separate PR keeps this one surgical — recommend a follow-up issue if display correctness there is wanted.

## Test-Status

- Branch: `Test Files 42 passed (42) / Tests 772 passed (772)`
- `dev` (baseline): `Test Files 42 passed (42) / Tests 770 passed (770)`
- Delta: **+2 passed, 0 failed**

No pre-existing tests broken. Lint clean (`./node_modules/.bin/eslint public/js tests`).

Closes #307
