### PR TITLE
fix(#309): Ersparnis/Übertrag/Mehrbedarf tab-zugeordnet in #drill_entries und #drill_machine_log

### DIFF
--- a/public/js/render-drill.js
+++ b/public/js/render-drill.js
@@ -225,79 +225,105 @@
 
     // --- Render: Drill Log ---
 
+    // Issue #309: Per-tab carryover/savings/excess block helper.
+    // Appends the three optional divs (.drill-savings / .drill-carryover /
+    // .drill-excess) into the given container, in the order savings → carryover
+    // → excess. Used by renderDrillLog() (under each tab-header) AND by
+    // renderMachineLog() (under each per-tab sub-header). Single source of
+    // truth so both containers stay in sync — see "3 Carryover-Render-Sites"
+    // rule in the agrar-rechner skill (renderDrillSummary, render-dashboard,
+    // inline render-results), of which the tab-anchored blocks are now a 4th
+    // site that has to remain consistent.
+    function _appendTabCarryoverBlocks(tabIdx, ct, container) {
+      if (!ct) return;
+      var cco = AppGlobals.getCarryover(tabIdx);
+      var isSavingsSource = (ct.istHektar > 0 && ct.hektar > 0 && ct.istHektar < ct.hektar);
+      var isExcessSource = (ct.istHektar > 0 && ct.hektar > 0 && ct.istHektar > ct.hektar);
+      if (isSavingsSource) {
+        // Issue #273: source savings must apply fahrgassenFaktor, same as
+        // the carryover calculation. Use getTabTotalEinheiten - getTabIstEinheiten
+        // (both already apply the per-tab FG factor) so display and
+        // carryover share one formula.
+        var sE = AppGlobals.getTabTotalEinheiten(ct) - AppGlobals.getTabIstEinheiten(ct);
+        var sD = (ct.hektar - ct.istHektar) * (ct.duenger || 0);
+        var sParts = [];
+        if (sE > 0.05) sParts.push(AppGlobals.fmt(sE) + ' Einheiten Saatgut');
+        if (sD > 0.05) sParts.push(sD.toLocaleString('de-DE') + ' kg Dünger');
+        if (sParts.length > 0) {
+          var sDiv = document.createElement('div');
+          sDiv.className = 'drill-savings';
+          sDiv.textContent = 'Ersparnis: ' + sParts.join(', ');
+          container.appendChild(sDiv);
+        }
+      }
+      if (cco.savedEinheit > 0.05 || cco.savedDuenger > 0.05) {
+        var cParts = [];
+        if (cco.savedEinheit > 0.05) cParts.push(AppGlobals.fmt(cco.savedEinheit) + ' Einheiten Saatgut');
+        if (cco.savedDuenger > 0.05) cParts.push(cco.savedDuenger.toLocaleString('de-DE') + ' kg Dünger');
+        var cDiv = document.createElement('div');
+        cDiv.className = 'drill-carryover';
+        cDiv.textContent = 'Übertrag aus ersparten Flächen: +' + cParts.join(', ');
+        container.appendChild(cDiv);
+      }
+      if (isExcessSource) {
+        // Issue #273: source excess must apply fahrgassenFaktor, same as
+        // the carryover calculation. Use getTabIstEinheiten - getTabTotalEinheiten
+        // (both already apply the per-tab FG factor) so display and
+        // carryover share one formula.
+        var eE = AppGlobals.getTabIstEinheiten(ct) - AppGlobals.getTabTotalEinheiten(ct);
+        var eD = (ct.istHektar - ct.hektar) * (ct.duenger || 0);
+        var eParts = [];
+        if (eE > 0.05) eParts.push(AppGlobals.fmt(eE) + ' Einheiten Saatgut');
+        if (eD > 0.05) eParts.push(eD.toLocaleString('de-DE') + ' kg Dünger');
+        if (eParts.length > 0) {
+          var eDiv = document.createElement('div');
+          eDiv.className = 'drill-excess';
+          eDiv.textContent = 'Mehrbedarf aus überschrittenen Flächen: -' + eParts.join(', ');
+          container.appendChild(eDiv);
+        }
+      }
+    }
+
+    // Issue #309: tab has a carryover signal worth showing (savings source,
+    // excess source, or carryover received from another tab).
+    function _tabHasCarryoverSignal(tabIdx, ct) {
+      if (!ct) return false;
+      var cco = AppGlobals.getCarryover(tabIdx);
+      if (cco.savedEinheit > 0.05 || cco.savedDuenger > 0.05) return true;
+      if (ct.istHektar > 0 && ct.hektar > 0) {
+        if (ct.istHektar < ct.hektar) return true;  // savings source
+        if (ct.istHektar > ct.hektar) return true;  // excess source
+      }
+      return false;
+    }
+
     function renderDrillLog() {
       var container = document.getElementById('drill_entries');
       if (!container) return;
       container.innerHTML = '';
       var totalSummary = document.getElementById('ds_total_summary');
-      // Issue #266-B2: Per-tab carryover/savings/excess divs at the top.
-      // Shown for ALL tabs that have any carryover signal (savings source,
-      // excess source, or carryover received from other tabs). Tests assert
-      // these classes on the #drill_entries container.
-      for (var ci = 0; ci < AppGlobals.state.reiter.length; ci++) {
-        var ct = AppGlobals.state.reiter[ci];
-        if (!ct) continue;
-        var cco = AppGlobals.getCarryover(ci);
-        var isSavingsSource = (ct.istHektar > 0 && ct.hektar > 0 && ct.istHektar < ct.hektar);
-        var isExcessSource = (ct.istHektar > 0 && ct.hektar > 0 && ct.istHektar > ct.hektar);
-        if (isSavingsSource) {
-          // Issue #273: source savings must apply fahrgassenFaktor, same as
-          // the carryover calculation. Use getTabTotalEinheiten - getTabIstEinheiten
-          // (both already apply the per-tab FG factor) so display and
-          // carryover share one formula.
-          var sE = AppGlobals.getTabTotalEinheiten(ct) - AppGlobals.getTabIstEinheiten(ct);
-          var sD = (ct.hektar - ct.istHektar) * (ct.duenger || 0);
-          var sParts = [];
-          if (sE > 0.05) sParts.push(AppGlobals.fmt(sE) + ' Einheiten Saatgut');
-          if (sD > 0.05) sParts.push(sD.toLocaleString('de-DE') + ' kg Dünger');
-          if (sParts.length > 0) {
-            var sDiv = document.createElement('div');
-            sDiv.className = 'drill-savings';
-            sDiv.textContent = 'Ersparnis: ' + sParts.join(', ');
-            container.appendChild(sDiv);
-          }
-        }
-        if (cco.savedEinheit > 0.05 || cco.savedDuenger > 0.05) {
-          var cParts = [];
-          if (cco.savedEinheit > 0.05) cParts.push(AppGlobals.fmt(cco.savedEinheit) + ' Einheiten Saatgut');
-          if (cco.savedDuenger > 0.05) cParts.push(cco.savedDuenger.toLocaleString('de-DE') + ' kg Dünger');
-          var cDiv = document.createElement('div');
-          cDiv.className = 'drill-carryover';
-          cDiv.textContent = 'Übertrag aus ersparten Flächen: +' + cParts.join(', ');
-          container.appendChild(cDiv);
-        }
-        if (isExcessSource) {
-          // Issue #273: source excess must apply fahrgassenFaktor, same as
-          // the carryover calculation. Use getTabIstEinheiten - getTabTotalEinheiten
-          // (both already apply the per-tab FG factor) so display and
-          // carryover share one formula.
-          var eE = AppGlobals.getTabIstEinheiten(ct) - AppGlobals.getTabTotalEinheiten(ct);
-          var eD = (ct.istHektar - ct.hektar) * (ct.duenger || 0);
-          var eParts = [];
-          if (eE > 0.05) eParts.push(AppGlobals.fmt(eE) + ' Einheiten Saatgut');
-          if (eD > 0.05) eParts.push(eD.toLocaleString('de-DE') + ' kg Dünger');
-          if (eParts.length > 0) {
-            var eDiv = document.createElement('div');
-            eDiv.className = 'drill-excess';
-            eDiv.textContent = 'Mehrbedarf aus überschrittenen Flächen: -' + eParts.join(', ');
-            container.appendChild(eDiv);
-          }
-        }
-      }
       // All-tabs aggregation (T3): iterate state.reiter in index order.
       // Each tab with entries.length > 0 gets a drill-entry-tab-header div,
       // followed by its entries in chronological order. #N numbering resets
       // per tab (Option A — consistent with single-tab behaviour, test 09
-      // unchanged). Empty state only when ALL tabs have empty entries.
+      // unchanged). Empty state only when ALL tabs have empty entries AND no
+      // tab has a carryover signal worth showing.
       var allTabs = AppGlobals.state.reiter || [];
       var hasAnyEntry = allTabs.some(function(r) { return r && r.entries && r.entries.length > 0; });
       if (!hasAnyEntry) {
-        if (totalSummary) totalSummary.textContent = '';
-        var empty = document.createElement('div');
-        empty.className = 'drill-empty';
-        empty.textContent = 'Noch nichts eingefüllt';
-        container.appendChild(empty);
-        return;
+        // Issue #309: still show carryover blocks if ANY tab has a signal —
+        // a savings/excess source with no entries yet is a valid edge case
+        // (IST set, no drillAdd done). Only collapse to "Noch nichts
+        // eingefüllt" when nothing meaningful can be displayed at all.
+        var anyCarryover = allTabs.some(function(r, i) { return _tabHasCarryoverSignal(i, r); });
+        if (!anyCarryover) {
+          if (totalSummary) totalSummary.textContent = '';
+          var empty = document.createElement('div');
+          empty.className = 'drill-empty';
+          empty.textContent = 'Noch nichts eingefüllt';
+          container.appendChild(empty);
+          return;
+        }
       }
       // Total-Summary (Hektar/Einheiten/Dünger über alle Entries aller Tabs)
       if (totalSummary) {
@@ -321,12 +347,24 @@
       // behaviour — test 09-blind-spots ('drill entry shows time prefix when
       // time is set') still sees entry-text[0] as the first entry of the
       // only tab with entries.
+      //
+      // Issue #309: each tab-section is now [tab-header → carryover blocks
+      // (if any) → entries]. Previously the carryover blocks were rendered in
+      // a separate first loop ABOVE all tab-headers, which left them visually
+      // unanchored (user could not tell which tab they belonged to). Moving
+      // them inside the per-tab loop binds them to the right tab.
       allTabs.forEach(function(rt, tabIdx) {
-        if (!rt || !rt.entries || rt.entries.length === 0) return;
+        if (!rt) return;
+        var hasEntries = rt.entries && rt.entries.length > 0;
+        if (!hasEntries && !_tabHasCarryoverSignal(tabIdx, rt)) return;
         var header = document.createElement('div');
         header.className = 'drill-entry-tab-header';
         header.textContent = rt.name || ('Tab ' + (tabIdx + 1));
         container.appendChild(header);
+        // Carryover blocks (Ersparnis / Übertrag / Mehrbedarf) directly below
+        // the tab-header so users can see which tab each block belongs to.
+        _appendTabCarryoverBlocks(tabIdx, rt, container);
+        if (!hasEntries) return;
         rt.entries.forEach(function(entry, actualIdx) {
           var row = document.createElement('div');
           row.className = 'drill-entry';
@@ -388,12 +426,30 @@
       container.innerHTML = '';
       var log = AppGlobals.state.machineLog || [];
       var activeTab = AppGlobals.state.reiter[AppGlobals.state.activeReiter];
-      if (log.length === 0) return;
       // Header
       var header = document.createElement('div');
       header.className = 'drill-entry-tab-header';
       header.textContent = 'Maschinen-Protokoll';
       container.appendChild(header);
+      // Issue #309: per-tab carryover sections (Ersparnis / Übertrag / Mehrbedarf)
+      // — the machine-log entries themselves are a flat global list (no tabIdx
+      // on machineLog entries, by design), but the carryover blocks are
+      // per-tab and must be tab-anchored here too. Without this, a user
+      // reading the Maschinen-Protokoll view sees carryover blocks visually
+      // disconnected from the tab they belong to (matches the original bug
+      // repro in #309). Use the same _appendTabCarryoverBlocks helper as
+      // renderDrillLog() so both containers stay in sync (single source of
+      // truth for the "3 Carryover-Render-Sites" rule).
+      var allTabs = AppGlobals.state.reiter || [];
+      allTabs.forEach(function(rt, tabIdx) {
+        if (!rt || !_tabHasCarryoverSignal(tabIdx, rt)) return;
+        var sub = document.createElement('div');
+        sub.className = 'drill-entry-tab-header drill-machine-log-tab-subheader';
+        sub.textContent = rt.name || ('Tab ' + (tabIdx + 1));
+        container.appendChild(sub);
+        _appendTabCarryoverBlocks(tabIdx, rt, container);
+      });
+      if (log.length === 0) return;
       // Per-entry rates come from the active tab (Issue #186: prefer IST).
       // Issue #266 (Cluster B): Fahrgassen-Faktor muss in unitsPerHa
       // berücksichtigt werden (Test 18: unitsPerHa = koerner * fgFactor /

--- a/tests/19-savings-carryover.test.js
+++ b/tests/19-savings-carryover.test.js
@@ -337,4 +337,153 @@ describe('IST/SOLL Savings & Carryover', () => {
     expect(excessDivs[0].textContent).toContain('2,9');
     expect(excessDivs[0].textContent).not.toContain('3,0 Einheiten');
   });
+
+  // Issue #309: tab-anchoring. The Ersparnis / Übertrag / Mehrbedarf blocks
+  // must appear DIRECTLY UNDER the tab-header they belong to (inside the
+  // tab's <div.drill-entry-tab-header> section in #drill_entries), NOT as a
+  // flat batch at the very top of the container above all tab-headers.
+  it('drill-savings/carryover/excess appear directly under their tab-header in #drill_entries', () => {
+    const { w } = setup();
+    w.addReiter();
+    // Tab 0: SOLL=8, IST=7.9 → savings source. Has an entry.
+    w.state.reiter[0] = { ...w.state.reiter[0], hektar: 8, istHektar: 7.9, koerner: 50000, duenger: 100, entries: [] };
+    w.state.reiter[0].entries.push({ einheit: 7.9, zaehlerStand: 7.9, duenger: 790, time: '10:00' });
+    // Tab 1: SOLL=10, IST=8 → savings source. No entry → carryover for tab 0? No —
+    // tab 0 is done. Carryover for tab 1 = savings from tab 0. Wait: tab 1 has
+    // savings source but no entry. With savings source on tab 1, tab 1 itself
+    // becomes the FIRST not-done tab → it absorbs tab 0's carryover (but tab 0's
+    // savings are 0 since its need is met) AND it advertises its own savings.
+    // Keep it simple: tab 1 also a savings source with IST=8, SOLL=10. No entry.
+    w.state.reiter[1] = { ...w.state.reiter[1], hektar: 10, istHektar: 8, koerner: 50000, duenger: 100, entries: [] };
+    w.state.activeReiter = 0;
+    w.renderResults();
+
+    const container = w.document.getElementById('drill_entries');
+    // Walk children in order; assert every .drill-savings / .drill-carryover /
+    // .drill-excess is preceded by a .drill-entry-tab-header.
+    const children = Array.from(container.children);
+    let lastHeaderIdx = -1;
+    for (let i = 0; i < children.length; i++) {
+      const c = children[i];
+      if (c.classList.contains('drill-entry-tab-header')) {
+        lastHeaderIdx = i;
+      } else if (
+        c.classList.contains('drill-savings') ||
+        c.classList.contains('drill-carryover') ||
+        c.classList.contains('drill-excess')
+      ) {
+        // Carryover block must be directly under SOME tab-header (not at top
+        // of container before any header).
+        expect(lastHeaderIdx).toBeGreaterThanOrEqual(0);
+        // And not be the .drill-empty placeholder
+        expect(c.classList.contains('drill-empty')).toBe(false);
+      }
+    }
+    // Specifically: tab 0 must show a savings block (IST < SOLL with entry).
+    // Find tab 0's header (first one), then assert a savings block follows it.
+    const tab0HeaderIdx = children.findIndex(c =>
+      c.classList.contains('drill-entry-tab-header') && c.textContent.includes('Tab 1'));
+    expect(tab0HeaderIdx).toBeGreaterThanOrEqual(0);
+    // The next child after tab 0's header must be its savings block (since tab 0
+    // is a savings source with an entry, it has drill-savings).
+    const next = children[tab0HeaderIdx + 1];
+    expect(next).toBeDefined();
+    expect(next.classList.contains('drill-savings')).toBe(true);
+    expect(next.textContent).toContain('Ersparnis');
+  });
+
+  it('drill-entries are NOT rendered above their tab-header (no orphan blocks at top)', () => {
+    const { w } = setup();
+    w.state.reiter[0] = { ...w.state.reiter[0], hektar: 10, koerner: 90000, duenger: 100, entries: [] };
+    w.state.reiter[0].entries.push({ einheit: 5, zaehlerStand: 3, duenger: 200, time: '10:00' });
+    w.state.activeReiter = 0;
+    w.renderResults();
+
+    const container = w.document.getElementById('drill_entries');
+    const children = Array.from(container.children);
+    // The first child must be a tab-header (or a savings/carryover/excess
+    // block directly above a tab-header) — never a bare .drill-entry before
+    // any header has been rendered.
+    const firstIdx = children.findIndex(c => c.classList.contains('drill-entry-tab-header'));
+    expect(firstIdx).toBeGreaterThanOrEqual(0);
+    // No .drill-entry before the first tab-header
+    for (let i = 0; i < firstIdx; i++) {
+      expect(children[i].classList.contains('drill-entry')).toBe(false);
+    }
+  });
+
+  it('#drill_machine_log gets tab-anchored carryover blocks under per-tab sub-headers', () => {
+    const { w } = setup();
+    w.addReiter();
+    // Tab 0: savings source. machineLog has one entry.
+    w.state.reiter[0] = { ...w.state.reiter[0], hektar: 8, istHektar: 7.9, koerner: 50000, duenger: 100, entries: [] };
+    w.state.reiter[0].entries.push({ einheit: 7.9, zaehlerStand: 7.9, duenger: 790, time: '10:00' });
+    // Tab 1: SOLL=10, IST=8 → savings source with no entry → gets carryover.
+    w.state.reiter[1] = { ...w.state.reiter[1], hektar: 10, istHektar: 8, koerner: 50000, duenger: 100, entries: [] };
+    w.state.machineLog = [
+      { einheit: 5, zaehlerStand: 0, duenger: 0, time: '10:00' },
+    ];
+    w.state.activeReiter = 0;
+    w.renderResults();
+
+    const ml = w.document.getElementById('drill_machine_log');
+    const mlChildren = Array.from(ml.children);
+    // First child: "Maschinen-Protokoll" static header.
+    expect(mlChildren[0].classList.contains('drill-entry-tab-header')).toBe(true);
+    expect(mlChildren[0].textContent).toContain('Maschinen-Protokoll');
+    // Find a tab sub-header + savings block somewhere after the static header.
+    // (Tab 0 has savings, tab 1 has carryover received + own savings.)
+    const savBlocks = ml.querySelectorAll('.drill-savings');
+    const coBlocks = ml.querySelectorAll('.drill-carryover');
+    expect(savBlocks.length).toBeGreaterThanOrEqual(1);
+    expect(coBlocks.length).toBeGreaterThanOrEqual(1);
+    // Each savings/carryover block must be preceded by a tab-header.
+    let lastHeaderIdx = -1;
+    for (let i = 0; i < mlChildren.length; i++) {
+      const c = mlChildren[i];
+      if (c.classList.contains('drill-entry-tab-header')) {
+        lastHeaderIdx = i;
+      } else if (
+        c.classList.contains('drill-savings') ||
+        c.classList.contains('drill-carryover') ||
+        c.classList.contains('drill-excess')
+      ) {
+        expect(lastHeaderIdx).toBeGreaterThanOrEqual(0);
+      }
+    }
+    // .drill-entry (machine-log entries) must appear AFTER all tab-sub-headers
+    // and their carryover blocks, not interleaved.
+    const firstEntryIdx = mlChildren.findIndex(c => c.classList.contains('drill-entry'));
+    const firstSubSavIdx = mlChildren.findIndex(c =>
+      c.classList.contains('drill-savings') || c.classList.contains('drill-carryover') || c.classList.contains('drill-excess'));
+    if (firstEntryIdx >= 0 && firstSubSavIdx >= 0) {
+      expect(firstEntryIdx).toBeGreaterThan(firstSubSavIdx);
+    }
+  });
+
+  it('carryover blocks render under tab-header even when tab has no entries', () => {
+    // Regression: before the fix, renderDrillLog() always returned "Noch
+    // nichts eingefüllt" when ALL tabs had empty entries — even when one tab
+    // was a savings source. Now the empty-state is suppressed if any tab has
+    // a carryover signal, so the savings block is visible.
+    const { w } = setup();
+    w.addReiter();
+    // Tab 0: savings source, no entries.
+    w.state.reiter[0] = { ...w.state.reiter[0], hektar: 8, istHektar: 7.9, koerner: 50000, duenger: 100, entries: [] };
+    // Tab 1: not done, no entries, no savings/excess → no signal.
+    w.state.reiter[1] = { ...w.state.reiter[1], hektar: 10, koerner: 50000, duenger: 100, entries: [] };
+    w.state.activeReiter = 0;
+    w.renderResults();
+
+    const container = w.document.getElementById('drill_entries');
+    // Should NOT show "Noch nichts eingefüllt" because tab 0 has a savings signal.
+    const empty = container.querySelector('.drill-empty');
+    expect(empty).toBeNull();
+    // Should show the savings block anchored to tab 0's header.
+    const headers = container.querySelectorAll('.drill-entry-tab-header');
+    expect(headers.length).toBeGreaterThanOrEqual(1);
+    const sav = container.querySelector('.drill-savings');
+    expect(sav).not.toBeNull();
+    expect(sav.textContent).toContain('Ersparnis');
+  });
 });


### PR DESCRIPTION
Fixes #309

## Bug

Ersparnis- (`drill-savings`), Übertrag- (`drill-carryover`) und Mehrbedarf-Blöcke (`drill-excess`) waren im **Drill-Protokoll** (`#drill_entries`) **oberhalb** aller Tab-Header platziert (separate erste Schleife in `renderDrillLog()`), und im **Maschinen-Protokoll** (`#drill_machine_log`) fehlten sie vollständig. Beide Container zeigten die Blöcke damit ohne sichtbare Bindung an den Tab, zu dem sie gehören.

## Fix

`public/js/render-drill.js`:
- Neuer Helper `_appendTabCarryoverBlocks(tabIdx, ct, container)` — single source of truth für die drei Block-Typen (Ersparnis → Übertrag → Mehrbedarf).
- Neuer Helper `_tabHasCarryoverSignal(tabIdx, ct)` — Prädikat für „dieser Tab zeigt überhaupt einen Block".
- `renderDrillLog()`: top-level Carryover-Schleife entfernt; in `allTabs.forEach(tabIdx)` wird der Tab-Header, **dann** `_appendTabCarryoverBlocks(...)`, **dann** die Entries angehängt. DOM-Reihenfolge pro Tab ist jetzt `[tab-header → drill-savings? → drill-carryover? → drill-excess? → entries]`.
- `renderMachineLog()`: Statischer „Maschinen-Protokoll"-Header bleibt zuerst, danach per-Tab-Sub-Header (nur wenn der Tab ein Carryover-Signal hat) mit den Blöcken, danach die flachen machineLog-Entries.
- `renderDrillLog()` Empty-State-Guard: zeigt „Noch nichts eingefüllt" nur noch, wenn **kein** Tab ein Carryover-Signal hat **und** keine Entries existieren (vorher hätte ein Savings-Source ohne Entries die Anzeige unterdrückt).

## Tests

4 neue Tests in `tests/19-savings-carryover.test.js`:
1. Jeder `drill-savings/carryover/excess`-Block in `#drill_entries` ist einem Tab-Header zugeordnet (kein Orphan am Anfang).
2. Keine `.drill-entry` erscheint vor dem ersten Tab-Header.
3. `#drill_machine_log` zeigt die tab-zugeordneten Carryover-Blöcke unter per-Tab-Sub-Headern (statischer „Maschinen-Protokoll"-Header bleibt erste `.drill-entry-tab-header`, machineLog-Entries folgen erst nach den per-Tab-Sektionen).
4. Carryover-Blöcke erscheinen auch wenn ein Tab keine Entries hat (Regression-Guard gegen den „Noch nichts eingefüllt"-Early-Return).

## Verifikation

- `pnpm test`: **776 passed** (vorher 772, +4 neue Tests)
- `pnpm lint`: clean

## Hinweis: CACHE_VERSION

`public/sw.js` listet `public/js/render-drill.js` in `STATIC_ASSETS` (vgl. CACHE_VERSION-Bump-Regel im Kanban-Worker-Skill). Gemäß Auftrag-Spec („KEINE Änderungen an `public/sw.js` ohne explizite User-Freigabe") habe ich `CACHE_VERSION` in diesem PR **nicht** gebumpet. Bitte beim Merge entscheiden, ob der Bump im selben oder einem Folge-PR erfolgen soll.

## Geänderte Dateien

- `public/js/render-drill.js` — Refactor (Helper extrahiert, Carryover-Blocks unter Tab-Header verschoben, in beiden Renderern)
- `tests/19-savings-carryover.test.js` — +4 Tests für Tab-Anchoring