### PR TITLE
chore(#311): bump CACHE_VERSION v22→v23 so PR #310 fix reaches cached users

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // ⚠️ CACHE_VERSION muss bei jedem Release manuell gebumpet werden!
 // Bei Vergessen bekommen Nutzer die alte Version aus dem Cache.
 // alternativa: Build-Script das Hash/Zeitstempel injiziert.
-const CACHE_VERSION = 'agrar-rechner-v22';
+const CACHE_VERSION = 'agrar-rechner-v23';
 const STATIC_ASSETS = [
     '/',
     '/index.html',


### PR DESCRIPTION
## What & Why

PR **#310** fixed the Ersparnis/Übertrag/Mehrbedarf tab-assignment bug in `public/js/render-drill.js`, but deliberately did **not** bump `CACHE_VERSION` in `public/sw.js` — AGENTS.md §6 lists `sw.js` as a "stop and ask" red flag, so the bump was intentionally split out.

**Problem:** without the bump, the service worker keeps serving the **old** `render-drill.js` from cache. The activate-handler only purges old caches when `CACHE_VERSION` changes (`keys.filter(k => k !== CACHE_VERSION)`), so PR #310's fix only reaches cached users after a manual reload / cache wipe.

This is the deliberate, human-authorized follow-up bump (**issue #311**) so the SW:
1. activates the new version (`skipWaiting()`),
2. purges the `agrar-rechner-v22` cache,
3. caches the updated `render-drill.js` under `agrar-rechner-v23` on the next load.

## Change

Surgical one-line change in `public/sw.js` — nothing else touched:

```diff
-const CACHE_VERSION = 'agrar-rechner-v22';
+const CACHE_VERSION = 'agrar-rechner-v23';
```

## Verification

- `pnpm test` → **776 passed (776)** across 42 files, incl. `tests/37-deploy-sanity.test.js` (12 tests). That test only asserts `CACHE_VERSION` is present & non-empty — it does **not** pin a specific version number, so the bump stays green. ✔️
- `pnpm lint` → **green** (eslint `public/js/ tests/`, exit 0). ✔️

Closes #311
Refs #310