### PR TITLE
fix(#315): remove Dünger-Cap in _buildDrillEntry, respect raw user input

### DIFF
--- a/public/js/ui-handlers.js
+++ b/public/js/ui-handlers.js
@@ -358,19 +358,32 @@
     // Issue #276: _buildDrillEntry erzeugt das Entry-Objekt für einen
     // Multi-Tab-Drill-Push (mit machineLog-Index) oder einen Single-Tab-
     // Push (mlIdx = -1). Berechnet die cap-bewerteten Mengen für ein Tab.
+    //
+    // Issue #315: Dünger-Cap entfernt. Saatgut wird weiterhin auf die
+    // Tab-Fläche gecappt (unitsForThisTab = min(input, maxUnitsThisTab)),
+    // aber entry.duenger respektiert jetzt den Roh-User-Wert. Der vorherige
+    // Math.min(duengerRaw, duengerPerUnit * unitsForThisTab)-Cap verschluckte
+    // stillschweigend Dünger-Mengen, die von der Tab-Zielmenge abweichen,
+    // und produzierte falsche Verbleibend-Werte.
+    //
+    // Begründung: kg/ha in den Tab-Einstellungen ist eine Zielsetzung des
+    // Landwirts, kein physikalisches Limit. Der Landwirt kann legitimerweise
+    // mehr oder weniger Dünger pro Einheit ausbringen als geplant — die App
+    // soll das respektieren.
+    //
+    // Der Single-Tab-Pfad in drillAdd() überschreibt ohnehin entry.duenger
+    // mit dem Roh-Input, was die Inkonsistenz noch verschärft hat.
     function _buildDrillEntry(tab, unitsRaw, duengerRaw, zaehlerStand, mlIdx) {
       var fgFactor = (tab.fahrgassenEnabled && tab.fahrgassenBreite >= 2)
         ? AppGlobals.computeFahrgassenFaktor(tab.fahrgassenBreite) : 1;
       var perUnit = (tab.koerner * fgFactor) / AppGlobals.state.koernerProEinheit;
       var maxUnitsThisTab = tab.hektar * perUnit;
       var unitsForThisTab = Math.min(unitsRaw, maxUnitsThisTab);
-      var duengerPerUnit = AppGlobals.getDuengerProEinheit(tab, AppGlobals.state.koernerProEinheit);
-      var duengerForThisTab = Math.min(duengerRaw, duengerPerUnit * unitsForThisTab);
       return {
         time: mlIdx >= 0 ? AppGlobals.getTabNextTime(tab) : new Date().toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' }),
         mlIdx: mlIdx,
         einheit: Math.round(unitsForThisTab * 100) / 100,
-        duenger: Math.round(duengerForThisTab * 100) / 100,
+        duenger: Math.round(duengerRaw * 100) / 100,
         hektar: tab.hektar, istHektar: 0, zaehlerStand: zaehlerStand,
         koerner: tab.koerner, duengerRate: tab.duenger
       };

--- a/tests/14-drill-multitab.test.js
+++ b/tests/14-drill-multitab.test.js
@@ -334,4 +334,65 @@ describe('priority button cycling', () => {
     prioBtn.onclick(); // 3 → maxPrio=3 → 0
     expect(prioBtn.getAttribute('data-prio')).toBe('0');
   });
+
+  // Issue #315 regression: _buildDrillEntry() previously capped entry.duenger
+  // with Math.min(duengerRaw, duengerPerUnit * unitsForThisTab), which silently
+  // truncated the user's duenger input whenever it exceeded the tab's
+  // planned kg/E ratio. User-reported bug (2026-06-20): filling 2x 2000 kg
+  // Dünger across tabs with 12 Einheiten + 2000 kg in a tab whose
+  // duengerPerUnit was 111,11 kg/E → cap reduced the second entry's
+  // duenger to 1333,33 kg → display showed 3.333,33 kg used / 1.266,67 kg
+  // verbleibend instead of expected 4.000 kg / 500 kg.
+  //
+  // Fix: Dünger-Cap removed. entry.duenger now stores the raw user value.
+  // Saatgut-Cap (unitsForThisTab = min(input, maxUnitsThisTab)) is preserved
+  // because it prevents overflowing the tab's planned area.
+  //
+  // We test _buildDrillEntry directly because the multi-tab distribution
+  // path (_calcDrillDistribution) caps separately on tab SOLL duenger —
+  // that cap is a different concern (plan-vs-act) and is preserved.
+  describe('Issue #315 — entry.duenger respects raw user input', () => {
+    function userTab() {
+      // User-Report-Szenario: 10 ha, koerner=90000, duenger=200 kg/ha.
+      // duengerPerUnit = 200 × 50000 / 90000 = 111,11 kg/E.
+      // Max-Einheiten via Saatgut-Cap = 10 × 90000 / 50000 = 18 E.
+      return {
+        name: 'Tab 2', hektar: 10, istHektar: 10.5, koerner: 90000, duenger: 200,
+        entries: [], fahrgassenEnabled: false, fahrgassenBreite: 0
+      };
+    }
+
+    it('drillAdd pushes entry.duenger = raw user value (no cap)', () => {
+      // User-Reported-Szenario: 12 E + 2000 kg Dünger in Tab 2.
+      // duengerPerUnit = 111,11 kg/E, so 111,11 × 12 = 1333,33 (would-be cap).
+      // Post-#315: entry.duenger must be 2000 (raw), not 1333,33.
+      var tab = userTab();
+      var entry = w._buildDrillEntry(tab, 12, 2000, 0, -1);
+
+      expect(entry.einheit).toBe(12);
+      expect(entry.duenger).toBe(2000);  // raw, not 1333,33
+    });
+
+    it('extreme case: 1 E + 99999 kg → entry.duenger = 99999 (no cap)', () => {
+      // 1 E × 111,11 kg/E = 111,11 — would have been capped from 99999 to 111,11.
+      // Post-#315: full 99999 stored. Use case: "I filled a lot of fertilizer
+      // but only 1 sack of seed because I'm top-dressing."
+      var tab = userTab();
+      var entry = w._buildDrillEntry(tab, 1, 99999, 0, -1);
+
+      expect(entry.einheit).toBe(1);
+      expect(entry.duenger).toBe(99999);
+    });
+
+    it('Saatgut-Cap bleibt erhalten (unitsForThisTab = min(input, maxUnitsThisTab))', () => {
+      // Tab hat 10 ha, koerner=90000 → maxUnitsThisTab = 18 E. User tippt 24 E.
+      // Saatgut-Cap greift: entry.einheit = 18, nicht 24.
+      // Dünger-Cap ist weg: entry.duenger = 2000 (raw).
+      var tab = userTab();
+      var entry = w._buildDrillEntry(tab, 24, 2000, 0, -1);
+
+      expect(entry.einheit).toBe(18);     // gecappt auf maxUnitsThisTab
+      expect(entry.duenger).toBe(2000);   // nicht gecappt
+    });
+  });
 });


### PR DESCRIPTION
## Summary

`_buildDrillEntry()` in `public/js/ui-handlers.js:368` cappt `entry.duenger` mit `Math.min(duengerRaw, duengerPerUnit * unitsForThisTab)`. Der Cap verschluckt stillschweigend Dünger-Mengen, die von der Tab-Zielmenge abweichen.

## User-Report (2026-06-20)

Setup: Tab 1 (5 ha, IST=4,5), Tab 2 (10 ha, IST=10,5), Tab 3 (7,5 ha, IST=0), alle mit 90000 Körner/ha, 200 kg/ha. User füllte 2x je 2.000 kg Dünger ein.

- Erwartet: **4.000 kg used, 500 kg verbleibend**
- Anzeige: **3.333,33 kg used, 1.266,67 kg verbleibend**

666,67 kg verschwinden stillschweigend.

## Root Cause

```js
duengerPerUnit = 200 × 50000 / 90000 = 111,11 kg/E
duengerForThisTab = Math.min(2000, 111,11 × 12) = Math.min(2000, 1333,33) = 1333,33
```

Für Tab 2 mit 12 eingefüllten Einheiten reduziert der Cap die 2000 kg auf 1333,33 kg.

Tab 1 (24 E + 2000 kg) hat keinen Cap (`min(2000, 2666,67) = 2000`). Summe `2000 + 1333,33 = 3333,33` kg — exakt die User-Anzeige.

## Warum der Cap falsch ist

Der Saatgut-Cap (`unitsForThisTab = min(input, maxUnitsThisTab)`) hat einen klaren Zweck: die eingegebene Einheiten-Menge darf die Tab-Fläche nicht überschreiten.

Beim Dünger gibt es diesen Zweck nicht: `kg/ha` in den Tab-Einstellungen ist eine Zielsetzung des Landwirts, kein physikalisches Limit. Der Landwirt kann legitimerweise mehr oder weniger Dünger pro Einheit ausbringen als geplant.

Der Single-Tab-Pfad in `drillAdd:458-461` überschreibt bereits `singleEntry.duenger = duenger` (Roh-Input) — der Multi-Tab-Pfad war damit die einzige inkonsistente Stelle.

## Fix

Dünger-Cap entfernt. `entry.duenger = Math.round(duengerRaw * 100) / 100` (Roh-Input). Saatgut-Cap bleibt unverändert.

## Was bewusst NICHT geändert wurde

`_calcDrillDistribution` (`ui-handlers.js:523-528`) cappt weiterhin auf `tabDCap = max(0, tabDNeed - tabDUsed)` für die Multi-Tab-Verteilung. Das ist eine andere Logik (plan-vs-act: wenn die Tab-Plan-Düngermenge schon überschritten ist, wird kein Dünger mehr auf diesen Tab verteilt). Beibehalten weil separate Sorge.

## Verifikation

- `pnpm test`: **782/782 grün** (3 neue Regression-Tests in `tests/14-drill-multitab.test.js`)
- `pnpm lint`: clean
- Browser-Reproduktion: User-Szenario liefert jetzt 4.000 kg used / 500 kg verbleibend (vorher 3.333,33 / 1.266,67)
