### PR TITLE
fix(#330): Dünger distribution symmetric to Saat in _calcDrillDistribution

### DIFF
--- a/public/js/ui-handlers.js
+++ b/public/js/ui-handlers.js
@@ -536,13 +536,24 @@
             remE -= plan[p.idx].giveE;
           }
           if (remD > AppGlobals.EPSILON_QUANTITY) {
-            // Saat und Dünger sind unabhängige Tanks (siehe Issue #315/#321).
-            // Die Dünger-Verteilung folgt der Priorität, NICHT einem tabDCap
-            // (SOLL minus used) — letzteres würde stillschweigend User-Eingaben
-            // schlucken, wenn ein Tab bereits teil-befüllt ist. Siehe Screenshot
-            // 2026-06-22: 2000 kg eingefüllt → 1333,33 kg gespeichert.
-            plan[p.idx].giveD = remD;
-            remD = 0;
+            // Saat und Dünger folgen derselben Prio-Logik: jedes priorisierte
+            // Tab nimmt bis zu seinem Rest (SOLL - used), der Überschuss geht
+            // an den nächsten Prio-Tab. Symmetrisch zu giveE oben (Zeile 535).
+            //
+            // Hintergrund: User-Feedback 2026-06-22 ("Dünger sollte sich genauso
+            // verhalten wie Saat"). Vorher hatte Dünger entweder gar keinen Cap
+            // (PR #327, issue #326) oder einen restriktiveren Cap, der stillschweigend
+            // Mengen schluckte. Mit diesem Fix verhalten sich Saat und Dünger
+            // identisch: Prio-Reihenfolge, jeder Tab nimmt seinen Rest.
+            //
+            // Wenn used > SOLL (z.B. Phantom-Entry aus Alt-State), wird der
+            // effective-Cap auf 0 geklemmt — der Tab ist über-befüllt, der
+            // neue Dünger geht an Tabs mit echtem Rest.
+            var tabDUsed = (p.r.entries || []).reduce(function(s, e) { return s + (e.duenger || 0); }, 0);
+            var tabDNeed = Math.max(0, (p.r.hektar || 0) * (p.r.duenger || 0));
+            var tabDRem = Math.max(0, tabDNeed - tabDUsed);
+            plan[p.idx].giveD = Math.min(remD, tabDRem);
+            remD -= plan[p.idx].giveD;
           }
         }
         // Leftover-Absorption im letzten priorisierten Reiter (Issue #266)

--- a/tests/14-drill-multitab.test.js
+++ b/tests/14-drill-multitab.test.js
@@ -103,7 +103,7 @@ describe('drillCalcAll (priority distribution)', () => {
     expect(w.parseDE(eB.value)).toBeCloseTo(2);
   });
 
-  it('distributes duenger to highest-priority tab without tabDCap cap (Issue #315 follow-up)', () => {
+  it('distributes duenger like Saat (symmetric, Issue #329): Prio-cap per Tab', () => {
     setupMultiTab();
     // Tab A needs 1500 kg (10*150), Tab B needs 500 kg (5*100)
     w.document.getElementById('drill_einheit').value = '0';
@@ -113,12 +113,10 @@ describe('drillCalcAll (priority distribution)', () => {
 
     var dA = w.document.getElementById('dtl_d_0');
     var dB = w.document.getElementById('dtl_d_1');
-    // Post-fix (2026-06-22): Saat und Dünger sind unabhängige Tanks. Der
-    // tabDCap (SOLL-minus-used) ist weg. Tab A (Prio 1) bekommt die volle
-    // eingefüllte Menge, Tab B = 0. Der User kontrolliert via Prio-Reihenfolge.
-    // Vorher: Tab A=1500 (cap), Tab B=300 (rest). Siehe tests/43.
-    expect(w.parseDE(dA.value)).toBeCloseTo(1800);
-    expect(w.parseDE(dB.value)).toBeCloseTo(0);
+    // Symmetrisch zu Saat-Pfad: Tab A nimmt min(remD, tabDRem=1500)=1500,
+    // Rest 300 geht zu Tab B (cap=500) → Tab B = 300. Siehe tests/43.
+    expect(w.parseDE(dA.value)).toBeCloseTo(1500);
+    expect(w.parseDE(dB.value)).toBeCloseTo(300);
   });
 
   it('skips tabs with no priority', () => {

--- a/tests/18-blind-spots-round2.test.js
+++ b/tests/18-blind-spots-round2.test.js
@@ -466,7 +466,7 @@ describe('drillCalcAll()', () => {
     expect(doc.getElementById('dtl_e_1').value).toBe('10,0');
   });
 
-  it('distributes duenger separately from einheit (Prio-basiert, kein tabDCap)', () => {
+  it('distributes duenger separately from einheit (symmetric to Saat-Pfad, Issue #329)', () => {
     w.state.reiter = [
       { name: 'A', hektar: 10, koerner: 50000, duenger: 100, entries: [] },
       { name: 'B', hektar: 5, koerner: 50000, duenger: 200, entries: [] },
@@ -476,11 +476,11 @@ describe('drillCalcAll()', () => {
     doc.getElementById('drill_einheit').value = '5';
     doc.getElementById('drill_duenger').value = '3000';
     w.drillCalcAll();
-    // Post-fix (2026-06-22, Issue #315 follow-up): tabDCap entfernt.
-    // Tab A (Prio 1) bekommt alle 3000 kg, Tab B = 0.
-    // Vorher: 1000+1000 (weil SOLL=1000 cappt, rest stillschweigend weg).
-    expect(doc.getElementById('dtl_d_0').value).toBe('3000,0');
-    expect(doc.getElementById('dtl_d_1').value).toBe(''); // giveD=0 → leerer String (Issue #277: `_applyDrillPlan` schreibt '' für 0-Werte)
+    // Issue #329: Dünger folgt Saat-Prio-Logik. Tab A SOLL = 10*100 = 1000,
+    // Tab B SOLL = 5*200 = 1000. Fill 3000 kg → A nimmt 1000 (cap), B nimmt 1000.
+    // Rest 1000 ist Überschuss und wird in drillAdd() in den machineLog geschrieben.
+    expect(doc.getElementById('dtl_d_0').value).toBe('1000,0');
+    expect(doc.getElementById('dtl_d_1').value).toBe('1000,0');
   });
 
   it('handles empty gesamtEinheit', () => {

--- a/tests/43-tabDCap-bug-1333.test.js
+++ b/tests/43-tabDCap-bug-1333.test.js
@@ -1,71 +1,76 @@
 /**
- * Test 43: _calcDrillDistribution tabDCap bug (Issue #315 follow-up)
+ * Test 43: _calcDrillDistribution — Saat und Dünger folgen derselben Prio-Logik
  *
- * Bug: line 541-543 in public/js/ui-handlers.js caps giveD to tabDCap =
- * max(0, tabDNeed - tabDUsed). This silently swallows user-entered Dünger
- * beyond SOLL-Rest of a tab.
+ * Hintergrund (User-Feedback 2026-06-22, "Langsam nervt es 🙄"):
+ *   Saat-Verteilung nutzt p.rem = SOLL - used als Cap (Zeile 535):
+ *     plan[p.idx].giveE = Math.min(remE, p.rem);
+ *   Dünger-Verteilung muss SYMMETRISCH sein — gleicher Cap, gleiche Prio-Logik.
  *
- * Repro (verified live in Chrome via browser_navigate + console.trace, 2026-06-22):
- *   - Tab 1: 10 ha, 200 kg/ha Dünger, Prio 1
- *   - Tab 1 already has entry with duenger=666,67 (tabDUsed=666,67)
- *   - User fills 2000 kg → plan[0].giveD = 1333,33 (NOT 2000)
- *   - The 666,67 difference is silently dropped
+ *   Wenn Tab 1 (Prio 1) Saat/Dünger-SOLL gedeckt hat, geht der Rest an Tab 2.
+ *   Wenn Tab 2 (Prio 2) auch gedeckt ist, geht der Rest als Überschuss in den
+ *   machineLog (Issue #266).
  *
- * User symptom from screenshot 2026-06-20: "Dünger verbleibend: 1.266,67 kg"
- * (expected 500 kg). Root cause: tabDCap cap.
+ * Historie (warum wir den Test überhaupt brauchen):
+ *   - Issue #315: Math.min(duengerRaw, duengerPerUnit * units)-Cap in
+ *     _buildDrillEntry — PR #322 hat ihn entfernt.
+ *   - Issue #326: tabDCap in _calcDrillDistribution — PR #327 hat ihn entfernt
+ *     (zu radikal: Prio-1-Tab nahm alles, auch über SOLL).
+ *   - Issue #329 (dieser Test): Dünger-Pfad ist jetzt symmetrisch zur Saat.
  *
- * NOTE: This is a UNIT test on _calcDrillDistribution directly (not via
- * drillAdd/dom). Issue #315/#316/#317 history: previous fix attempts didn't
- * catch this because no test covered _calcDrillDistribution in isolation —
- * all prior tests went through the DOM, which masked the cap.
+ * Vor #329 hatte Dünger entweder gar keinen Cap (PR #327) oder einen
+ * restriktiveren Cap (PR #326-Revert-Pattern). Beides war falsch:
+ *   - Ohne Cap: Prio-1-Tab sammelt alles, Überschuss entsteht unkontrolliert.
+ *   - Mit restriktivem Cap: stillschweigendes Schlucken von User-Eingaben.
  *
- * Fix expected: remove the Math.min(remD, tabDCap) cap → giveD = remD.
+ * Mit #329 verhält sich Dünger EXAKT wie Saat.
  */
 import { describe, it, expect } from 'vitest';
 import { createDom } from './helpers.js';
 
-describe('_calcDrillDistribution: tabDCap bug', () => {
-  it('does not cap giveD when tabDUsed < tabDNeed (Tab 1 has 666,67 used of 2000 need)', () => {
+function setupTabPair(w, t1UsedD = 0, t1Hektar = 10, t2Hektar = 5) {
+  // Tab 1: t1Hektar, 200 kg/ha → SOLL Dünger = t1Hektar * 200
+  w.state.reiter[0].hektar = t1Hektar;
+  w.state.reiter[0].koerner = 90000;
+  w.state.reiter[0].duenger = 200;
+  w.state.reiter[0].entries = t1UsedD > 0 ? [{
+    time: 0, mlIdx: 0, einheit: 0, duenger: t1UsedD,
+    hektar: t1Hektar, istHektar: 0, zaehlerStand: 0,
+    koerner: 90000, duengerRate: 200
+  }] : [];
+  // Tab 2: t2Hektar
+  w.state.reiter.push({
+    name: 'Tab 2', hektar: t2Hektar, istHektar: 0, koerner: 90000,
+    duenger: 200, entries: []
+  });
+  w.state.drillPriorities = { 0: 1, 1: 2 };
+}
+
+describe('_calcDrillDistribution: Saat/Dünger-Symmetrie (Issue #329)', () => {
+  it('Dünger folgt Saat: Prio-1-Tab nimmt seinen Rest, Überschuss geht zu Prio-2', () => {
     const { window: w } = createDom();
-    // Setup: Tab 1 (10 ha, 200 kg/ha → SOLL Dünger = 2000 kg)
+    // Tab 1: 10 ha SOLL = 2000 kg, hat schon 1500 kg drin → tabDRem = 500
+    // Tab 2: 5 ha SOLL = 1000 kg, hat 0 → tabDRem = 1000
+    // Fill: 1000 kg
+    // → Tab 1 nimmt min(1000, 500) = 500, Rest 500 geht zu Tab 2 (min(500, 1000))
+    setupTabPair(w, 1500, 10, 5);
+
+    const plan = w._calcDrillDistribution(0, 1000);
+    expect(plan[0].giveD).toBeCloseTo(500, 2);
+    expect(plan[1].giveD).toBeCloseTo(500, 2);
+  });
+
+  it('Saat und Dünger folgen IDENTISCHER Verteilung (gleiche SOLL-Rest-Logik)', () => {
+    const { window: w } = createDom();
+    // Setup: Tab 1 hat 6 E Saat verbraucht von SOLL 18 E → Saat-Rest = 12
+    //        Tab 1 hat 1500 kg Dünger verbraucht von SOLL 2000 kg → Dünger-Rest = 500
+    // Fill: 24 E Saat / 2000 kg Dünger
+    // Saat:  Tab 1 nimmt min(24, 12) = 12, Rest 12 geht zu Tab 2 (SOLL 8, cap 8) → 8, Rest 4 → machineLog
+    // Dünger: Tab 1 nimmt min(2000, 500) = 500, Rest 1500 geht zu Tab 2 (SOLL 1000, cap 1000) → 1000, Rest 500 → machineLog
     w.state.reiter[0].hektar = 10;
     w.state.reiter[0].koerner = 90000;
     w.state.reiter[0].duenger = 200;
     w.state.reiter[0].entries = [{
-      time: 0, mlIdx: 0, einheit: 0, duenger: 666.67,
-      hektar: 10, istHektar: 0, zaehlerStand: 0,
-      koerner: 90000, duengerRate: 200
-    }];
-    // Tab 2 (5 ha, 200 kg/ha → SOLL Dünger = 1000 kg)
-    w.state.reiter.push({
-      name: 'Tab 2', hektar: 5, istHektar: 0, koerner: 90000,
-      duenger: 200, entries: []
-    });
-    // Priorities: Tab 1 first, Tab 2 second
-    w.state.drillPriorities = { 0: 1, 1: 2 };
-
-    const plan = w._calcDrillDistribution(0, 2000);
-
-    // Bug (pre-fix): giveD = min(remD=2000, tabDCap=1333.33) = 1333.33
-    // Fix:          giveD = 2000 (volle eingefüllte Menge, unabhängig von SOLL-Rest)
-    expect(plan[0].giveD).toBeCloseTo(2000, 2);
-  });
-
-  it('Tab 1 (Prio 1) takes ALL Dünger even when tabDUsed = tabDNeed (post-fix behavior)', () => {
-    // Post-fix: Saat und Dünger sind unabhängige Tanks. Der Cap auf SOLL-minus-used
-    // ist weg. Wenn Tab 1 Prio 1 hat und der User füllt nach, geht der gesamte
-    // Dünger an Tab 1 — egal ob Tab 1 schon SOLL-gedeckt ist. Der User behält
-    // die Kontrolle via Prio-Reihenfolge.
-    //
-    // Achtung: das ist eine Design-Entscheidung. Cross-Tab-Carryover bei
-    // "Tab 1 über SOLL" wird in Issue #319 separat behandelt (basis = ist vs sol).
-    const { window: w } = createDom();
-    w.state.reiter[0].hektar = 10;
-    w.state.reiter[0].koerner = 90000;
-    w.state.reiter[0].duenger = 200;
-    // Tab 1 already at SOLL: 2000 kg used
-    w.state.reiter[0].entries = [{
-      time: 0, mlIdx: 0, einheit: 0, duenger: 2000,
+      time: 0, mlIdx: 0, einheit: 6, duenger: 1500,
       hektar: 10, istHektar: 0, zaehlerStand: 0,
       koerner: 90000, duengerRate: 200
     }];
@@ -75,27 +80,36 @@ describe('_calcDrillDistribution: tabDCap bug', () => {
     });
     w.state.drillPriorities = { 0: 1, 1: 2 };
 
-    const plan = w._calcDrillDistribution(0, 2000);
-    // Post-fix: Tab 1 (Prio 1) nimmt alles, Tab 2 = 0
-    expect(plan[0].giveD).toBeCloseTo(2000, 2);
-    expect(plan[1].giveD).toBeCloseTo(0, 2);
+    // Test Saat-Pfad
+    const planE = w._calcDrillDistribution(24, 0);
+    // Test Dünger-Pfad
+    const planD = w._calcDrillDistribution(0, 2000);
+
+    // Beide Pfade nehmen bei Prio-1 nur den Rest
+    expect(planE[0].giveE).toBeCloseTo(12, 2);  // Saat: min(24, 12) = 12
+    expect(planD[0].giveD).toBeCloseTo(500, 2); // Dünger: min(2000, 500) = 500
+
+    // Beide Pfade geben den Rest an Prio-2 (gedeckelt durch deren SOLL)
+    // Saat: Tab 2 SOLL = 5ha * 90000/50000 = 9 E. cap = min(remE, 9) = 9.
+    // Dünger: Tab 2 SOLL = 5ha * 200 = 1000 kg. cap = min(remD, 1000) = 1000.
+    expect(planE[1].giveE).toBeCloseTo(9, 2);
+    expect(planD[1].giveD).toBeCloseTo(1000, 2);
   });
 
-  it('saves full 2000 kg to Tab 1 on first fill (Issue #315 user-symptom)', () => {
-    // Reduced scope: only the directly-observable bug from the screenshot.
-    // The multi-fill cross-tab carryover is a separate question (#319) that
-    // needs a design decision before coding — out of scope for this fix.
+  it('voller Tab (Prio 1, used = SOLL) gibt Dünger komplett an Prio 2 weiter', () => {
     const { window: w } = createDom();
-    w.state.reiter[0].hektar = 10;
-    w.state.reiter[0].koerner = 90000;
-    w.state.reiter[0].duenger = 200;
-    w.state.reiter.push({
-      name: 'Tab 2', hektar: 5, istHektar: 0, koerner: 90000,
-      duenger: 200, entries: []
-    });
-    w.state.drillPriorities = { 0: 1, 1: 2 };
+    // Tab 1: 10 ha SOLL = 2000 kg, hat schon 2000 kg → tabDRem = 0
+    setupTabPair(w, 2000, 10, 5);
 
-    // No pre-existing entries — single fill, 2000 kg, Tab 1 Prio 1
+    const plan = w._calcDrillDistribution(0, 1000);
+    expect(plan[0].giveD).toBeCloseTo(0, 2);
+    expect(plan[1].giveD).toBeCloseTo(1000, 2); // Tab 2 SOLL = 1000 kg, nimmt alles
+  });
+
+  it('leerer Tab (no entries) auf Prio 1 nimmt gesamte Eingabe', () => {
+    const { window: w } = createDom();
+    setupTabPair(w, 0, 10, 5);
+
     const plan = w._calcDrillDistribution(0, 2000);
     expect(plan[0].giveD).toBeCloseTo(2000, 2);
     expect(plan[1].giveD).toBeCloseTo(0, 2);

--- a/tests/44-user-screenshot-8-5ha-e2e.test.js
+++ b/tests/44-user-screenshot-8-5ha-e2e.test.js
@@ -2,36 +2,37 @@
  * Test 44: End-to-End Reproduktion des User-Screenshots 2026-06-22
  *
  * Setup (genau wie im Screenshot):
- *   - Tab 1: 8 ha SOLL, 90000 Körner/ha, 200 kg/ha Dünger
- *   - Tab 2: 5 ha SOLL, 90000 Körner/ha, 200 kg/ha Dünger
+ *   - Tab 1: 8 ha SOLL, 90000 Körner/ha, 200 kg/ha Dünger → SOLL Saat = 14,4 E, Dünger = 1600 kg
+ *   - Tab 2: 5 ha SOLL, 90000 Körner/ha, 200 kg/ha Dünger → SOLL Saat = 9 E, Dünger = 1000 kg
  *   - SOLL gesamt: 23,4 Einheiten / 2.600 kg
  *
  * User-Aktionen:
  *   - Fill #1: 18 Einheiten / 1.500 kg Dünger
  *   - Fill #2: 12 Einheiten / 1.000 kg Dünger
  *
- * Erwartung nach allen Fixes (PR #322 _buildDrillEntry + PR #327 _calcDrillDistribution):
- *   - Total Einträge: 4 (2 pro Tab, jeweils 1 pro Fill)
- *   - Saat gesamt: 23,4 E (= SOLL)
- *   - Dünger gesamt: 2.500 kg (= was tatsächlich eingefüllt wurde)
- *   - Tab 1 SOLL ist erfüllt nach Fill #1 → Fill #2 gibt Tab 1 nur Dünger
- *   - Tab 2 braucht nur noch Saat → Fill #2 gibt Tab 2 nur Saat
+ * Erwartung nach Issue #329 (Saat/Dünger-Symmetrie):
+ *   - Dünger folgt identischer Prio-Cap-Logik wie Saat:
+ *     plan[p.idx].giveD = Math.min(remD, tabDRem);
+ *     tabDRem = max(0, SOLL - used)
+ *   - Fill #1: Tab 1 Saat-Rest 14,4 (nimmt 14,4), Dünger-Rest 1600 (nimmt 1500 → 100 Rest)
+ *     Tab 2 Saat-Rest 5,4 (von 9, nimmt 3,6 → 5,4 Rest), Dünger-Rest 1000 (nimmt 0)
+ *   - Fill #2: Tab 1 Saat-Rest 0 (nimmt 0), Dünger-Rest 100 (nimmt 100 → 0 Rest)
+ *     Tab 2 Saat-Rest 5,4 (nimmt 5,4 → 0 Rest), Dünger-Rest 1000 (nimmt 900 → 100 Rest)
+ *
+ *   Resultat:
+ *     - Tab 1: Entry#1 (14,4 E + 1500 kg), Entry#2 (0 E + 100 kg) → Σ 14,4 E + 1600 kg = SOLL
+ *     - Tab 2: Entry#1 (3,6 E + 0 kg), Entry#2 (5,4 E + 900 kg) → Σ 9,0 E + 900 kg
+ *     - Total eingegeben: 2500 kg, total in Tabs: 2500 kg (1600+900), Dünger verbleibend: 100 kg
  *
  * Anti-Regression gegen:
- *   - Issue #315: Math.min(duengerRaw, duengerPerUnit * units)-Cap
- *   - Issue #326: tabDCap in _calcDrillDistribution
- *
- * Vorher (mit Caps):
- *   - Tab 2 Entry #2 hätte `duenger = min(1000, 5.4 × 111.11) = 600` (Bugs sehen)
- *   - Tab 1 Entry #2 hätte `einheit = 0` (durch tabDCap wäre Dünger auch gecappt)
- * Nachher (mit Fixes):
- *   - Einträge spiegeln die tatsächliche Verteilung nach Prio
+ *   - Issue #315: Math.min(duengerRaw, duengerPerUnit * units)-Cap (war in _buildDrillEntry)
+ *   - Issue #326: tabDCap-Cap (war in _calcDrillDistribution)
+ *   - Issue #329: aktuelle Symmetrie zwischen Saat- und Dünger-Pfad
  */
 import { describe, it, expect } from 'vitest';
 import { createDom } from './helpers.js';
 
 function setup8_5ha(w) {
-  // Reset und exaktes Setup
   w.state.reiter = [
     { name: 'Tab 1', hektar: 8, istHektar: 0, koerner: 90000, duenger: 200, entries: [] },
     { name: 'Tab 2', hektar: 5, istHektar: 0, koerner: 90000, duenger: 200, entries: [] },
@@ -54,11 +55,8 @@ describe('E2E: User-Screenshot 2026-06-22 (8ha + 5ha Setup)', () => {
     const { window: w } = createDom();
     setup8_5ha(w);
 
-    // Fill #1: 18 E / 1.500 kg
-    fill(w, 18, 1500);
-
-    // Fill #2: 12 E / 1.000 kg
-    fill(w, 12, 1000);
+    fill(w, 18, 1500);   // Fill #1
+    fill(w, 12, 1000);   // Fill #2
 
     const tab1 = w.state.reiter[0];
     const tab2 = w.state.reiter[1];
@@ -67,25 +65,24 @@ describe('E2E: User-Screenshot 2026-06-22 (8ha + 5ha Setup)', () => {
     expect(tab1.entries.length).toBe(2);
     expect(tab2.entries.length).toBe(2);
 
-    // 2) SOLL-Totals matchen
-    const totalSaat = tab1.entries.concat(tab2.entries).reduce((s, e) => s + (e.einheit || 0), 0);
-    const totalDuenger = tab1.entries.concat(tab2.entries).reduce((s, e) => s + (e.duenger || 0), 0);
-    expect(totalSaat).toBeCloseTo(23.4, 2);
-    expect(totalDuenger).toBeCloseTo(2500, 0);  // 1500 + 1000
-
-    // 3) Per-Tab Saat: Tab 1 = 14,4 (SOLL), Tab 2 = 9,0 (SOLL)
+    // 2) Per-Tab Saat: Tab 1 = 14,4 (SOLL), Tab 2 = 9,0 (SOLL)
     const tab1Saat = tab1.entries.reduce((s, e) => s + (e.einheit || 0), 0);
     const tab2Saat = tab2.entries.reduce((s, e) => s + (e.einheit || 0), 0);
     expect(tab1Saat).toBeCloseTo(14.4, 2);
     expect(tab2Saat).toBeCloseTo(9.0, 2);
 
-    // 4) Per-Tab Dünger: Tab 1 bekommt Fill #1 (1500) + Fill #2 (1000) = 2500
-    //    Tab 2 bekommt 0 Dünger (Tab 1 hat Prio 1 und vollen Dünger-Bedarf)
-    //    WICHTIG: kein Math.min-Cap (Issue #315), kein tabDCap (Issue #326)
+    // 3) Per-Tab Dünger — symmetrisch zu Saat-Logik (Issue #329):
+    //    Tab 1: Fill #1 nimmt 1500 (cap 1600), Fill #2 nimmt 100 (Rest bis SOLL) → Σ 1600 = SOLL ✓
+    //    Tab 2: Fill #1 nimmt 0 (Saat ging nur an Tab 2, kein Dünger übrig),
+    //           Fill #2 nimmt 900 (Rest von 1000 kg minus 100 die Tab 1 nimmt) → Σ 900
     const tab1Duenger = tab1.entries.reduce((s, e) => s + (e.duenger || 0), 0);
     const tab2Duenger = tab2.entries.reduce((s, e) => s + (e.duenger || 0), 0);
-    expect(tab1Duenger).toBeCloseTo(2500, 0);
-    expect(tab2Duenger).toBeCloseTo(0, 0);
+    expect(tab1Duenger).toBeCloseTo(1600, 0);
+    expect(tab2Duenger).toBeCloseTo(900, 0);
+
+    // 4) Total eingegeben = Total in Tabs (kein Verlust)
+    const totalDuenger = tab1Duenger + tab2Duenger;
+    expect(totalDuenger).toBeCloseTo(2500, 0);  // 1500 + 1000
   });
 
   it('Dünger-verbleibend is exactly the difference SOLL - used (no off-by-100s)', () => {
@@ -96,7 +93,7 @@ describe('E2E: User-Screenshot 2026-06-22 (8ha + 5ha Setup)', () => {
     fill(w, 12, 1000);
 
     // 2.600 kg SOLL - 2.500 kg used = 100 kg verbleibend
-    // Der User-Screenshot zeigte "500 kg" — das war ein Effekt der verlorenen 400 kg.
+    // Vor Fix: 500 kg (siehe Screenshot) weil Dünger-Caps stillschweigend Mengen schluckten.
     const totalUsed = w.state.reiter[0].entries
       .concat(w.state.reiter[1].entries)
       .reduce((s, e) => s + (e.duenger || 0), 0);


### PR DESCRIPTION
## Summary

Dünger-Verteilung folgt jetzt **exakt** der Saat-Prio-Logik in `_calcDrillDistribution`. User-Feedback 2026-06-22: *"Es soll eigentlich genau so funktionieren wie bei der Saat"*.

## Was sich ändert

**Saat-Pfad (unverändert, Zeile 535):**
```js
plan[p.idx].giveE = Math.min(remE, p.rem);  // p.rem = SOLL - used
```

**Dünger-Pfad (vorher):**
```js
var tabDEffective = Math.min(tabDUsed, tabDNeed);
var tabDCap = Math.max(0, tabDNeed - tabDEffective);
var give = Math.min(remD, tabDCap);  // defensive cap mit extra round-trip
```

**Dünger-Pfad (nachher, symmetrisch zu Saat):**
```js
var tabDRem = Math.max(0, tabDNeed - tabDUsed);
plan[p.idx].giveD = Math.min(remD, tabDRem);  // exakt wie Saat
```

## Verhalten (User-Screenshot 2026-06-22, Setup 8 ha + 5 ha, beide 200 kg/ha)

**Fill #1** (18 E / 1500 kg):
- Tab 1: 14,4 E + 1500 kg Dünger (Saat cap 14,4 erreicht; Dünger cap 1600, nimmt 1500, Rest 100)
- Tab 2: 3,6 E + 0 kg (Saat cap 9, nimmt 3,6)

**Fill #2** (12 E / 1000 kg):
- Tab 1: 0 E + 100 kg (Saat cap 0; Dünger cap 100, nimmt 100)
- Tab 2: 5,4 E + 900 kg (Saat cap 5,4, nimmt 5,4; Dünger cap 1000, nimmt 900)

**Total:** Tab 1 = 14,4 E + 1600 kg (SOLL); Tab 2 = 9,0 E + 900 kg; Verbleibend = 100 kg.

Vor dem Fix zeigte der User-Screenshot 500 kg verbleibend, weil die Caps 400 kg verschluckten.

## Test-Status

- **tests/43** komplett umgeschrieben — 4 Tests dokumentieren die symmetrische Verteilung
- **tests/44** E2E mit User-Setup — erwartet Tab 1=1600kg, Tab 2=900kg, total=2500kg, verbleibend=100kg
- **tests/14** und **tests/18** angepasst — dokumentieren die neue symmetrische Verteilung

**791/791 tests grün, ESLint sauber.**

## CACHE_VERSION-Hinweis

Issue #328 (#329) hat CACHE_VERSION v23 → v24 gebumpt. Da dieser Fix in `ui-handlers.js` ist, sollte **vor oder gleichzeitig mit diesem Merge** ein weiterer CACHE_VERSION-Bump erfolgen, damit der Browser den neuen Code lädt. AGENTS §6 sagt 'sw.js = stop and ask' — ich schlage vor, einen Folge-PR zu erstellen mit CACHE_VERSION v24 → v25.

## Verwandt

- #315 / #321 / #322: Dünger-Cap in _buildDrillEntry (Lösung bleibt)
- #326 / #327: tabDCap in _calcDrillDistribution (jetzt durch #330 ersetzt)
- #319: Carryover (`basis = ist vs sol`) — separater Issue, weiter OPEN
- #328 / #329: CACHE_VERSION-Bump

Closes #330