### PR TITLE
chore(#331): CACHE_VERSION v24 → v25 — invalidate SW cache for PR #331 fix

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // ⚠️ CACHE_VERSION muss bei jedem Release manuell gebumpet werden!
 // Bei Vergessen bekommen Nutzer die alte Version aus dem Cache.
 // alternativa: Build-Script das Hash/Zeitstempel injiziert.
-const CACHE_VERSION = 'agrar-rechner-v24';
+const CACHE_VERSION = 'agrar-rechner-v25';
 const STATIC_ASSETS = [
     '/',
     '/index.html',


### PR DESCRIPTION
## Summary

Bumped CACHE_VERSION v24 → v25 damit Service Worker die neue `ui-handlers.js` (mit Dünger-Symmetrie-Fix aus PR #331) an Clients ausliefert.

## Why

PR #331 (Issue #330) hat `_calcDrillDistribution` so umgebaut, dass Dünger-Verteilung exakt der Saat-Prio-Logik folgt. Service Worker cached aber die alte Version und liefert sie aus. Pattern identisch zu PR #329 (v23 → v24, Issue #328).

## Was sich ändert

`public/sw.js:4`: `CACHE_VERSION = 'agrar-rechner-v24'` → `'agrar-rechner-v25'`. Sonst nichts.

## Tests

`tests/37-deploy-sanity.test.js`: 12/12 grün. SW-Asset-Manifest korrekt.

## AGENTS §6 Hinweis

`public/sw.js` ist Red-Flag-File ("caching rules need human review"). Hier wird **nur die CACHE_VERSION-Konstante** geändert, nicht das Caching-Verhalten. User hat explizit Freigabe gegeben.

## Nach Merge

Browser Hard-Reload → SW installiert v25-Cache → User sieht PR #331 Fixes (Dünger = Saat-Logik, keine Mengenverluste).

Closes #331