### PR TITLE
chore(#336): CACHE_VERSION v25 → v26 — invalidate SW cache for PR #337 fix

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // ⚠️ CACHE_VERSION muss bei jedem Release manuell gebumpet werden!
 // Bei Vergessen bekommen Nutzer die alte Version aus dem Cache.
 // alternativa: Build-Script das Hash/Zeitstempel injiziert.
-const CACHE_VERSION = 'agrar-rechner-v25';
+const CACHE_VERSION = 'agrar-rechner-v26';
 const STATIC_ASSETS = [
     '/',
     '/index.html',


### PR DESCRIPTION
Fixes #336 (cache-invalidation follow-up).

## Problem

PR #337 (fix #336 — Ersparnis/Übertrag/Mehrbedarf im Ergebnis-Tab) wurde am 2026-06-22 auf `dev` gemerget. `render-results.js` und `css/styles.css` wurden geändert, aber `public/sw.js` Zeile 4 steht weiterhin auf `CACHE_VERSION='agrar-rechner-v25'`. Browser aller User servieren damit aus dem alten Cache und sehen die neuen Carryover-Zeilen nicht — Verdacht 1 aus User-Feedback „ich kann keine richtige Veränderung feststellen".

## Fix

`CACHE_VERSION` v25 → v26. Der `activate`-Handler in `sw.js:32` (`keys.filter(k => k !== CACHE_VERSION).map(k => caches.delete(k))`) löscht beim nächsten Reload alle alten Cache-Einträge und fetcht `render-results.js`, `styles.css` und Co. frisch.

## Diff

```diff
-const CACHE_VERSION = 'agrar-rechner-v25';
+const CACHE_VERSION = 'agrar-rechner-v26';
```

1 file, 1 line, kein unrelated refactor.

## Test-Status

`pnpm test` → 791 passed / 0 failed (matches dev baseline; nur ein String-Literal ändert sich).

## Pattern

Folgt demselben Muster wie:

- #332 (v24→v25 für #331)
- #329 (v23→v24 für #328)
- #312 (v22→v23 für #311)

Closes #336