### PR TITLE
fix(#347): Drill-Summary aggregiert needE/needD ohne Mehrbedarf-Tabs

### DIFF
--- a/public/js/calculations.js
+++ b/public/js/calculations.js
@@ -194,6 +194,26 @@ function computeAllCarryovers() {
     }
   }
 
+  // === NETTO-SALDO (vor Phase 1 und 2) ===
+  //
+  // Fix Issue #XXX: Ersparnis-Pool und Mehrbedarf-Pool werden zuerst
+  // gegenseitig aufgerechnet (Netting). Nur der verbleibende Netto-Saldo
+  // wird an Phase 1 (Ersparnisse) bzw. Phase 2 (Mehrbedarfe) übergeben.
+  //
+  // Ohne Netting: Ein Tab mit IST > SOLL (Mehrbedarf) erhält in Phase 1
+  // fälschlicherweise Ersparnis-Carryover (weil istCovered=FALSE und
+  // isSource=FALSE). Gleichzeitig gibt Phase 2 den vollen totalExcess als
+  // Bürde an Folge-Tabs — saved und excess auf dem Folge-Tab heben sich
+  // NICHT auf, sondern addieren sich als doppelter Fehler.
+  //
+  // Mit Netting: netSaved = max(0, totalSaved - totalExcess).
+  //              netExcess = max(0, totalExcess - totalSaved).
+  // Phase 1 verteilt nur netSaved, Phase 2 vergibt nur netExcess.
+  var netSavedE  = Math.max(0, totalSavedE  - totalExcessE);
+  var netExcessE = Math.max(0, totalExcessE - totalSavedE);
+  var netSavedD  = Math.max(0, totalSavedD  - totalExcessD);
+  var netExcessD = Math.max(0, totalExcessD - totalSavedD);
+
   // === PHASE 1: Ersparnisse verteilen — Saat und Dünger getrennt ===
   //
   // Issue #315: Saat und Dünger sollen UNABHÄNGIG durch die Carryover-Prios
@@ -210,9 +230,13 @@ function computeAllCarryovers() {
   // gedeckt ist (usedE >= istE bei istE > 0), bekommen KEINEN Carryover. Die
   // Ersparnis war für ANDERE Tabs gedacht — diese Quelle soll nicht "doppelt
   // profitieren".
+  //
+  // Zusätzlicher Skip (Netto-Fix): Tabs mit IST > SOLL (Mehrbedarf) dürfen
+  // keine Ersparnis aus Phase 1 empfangen. Ihr Mehrbedarf ist bereits durch
+  // den Netto-Saldo aus dem Excess-Pool herausgerechnet.
   _internal.carryoverCache = result;
-  var remSavedE = totalSavedE;
-  var remSavedD = totalSavedD;
+  var remSavedE = netSavedE;
+  var remSavedD = netSavedD;
   for (var mat = 0; mat < 2; mat++) {
     var isSaatPass = (mat === 0);
     var remSaved = isSaatPass ? remSavedE : remSavedD;
@@ -240,8 +264,20 @@ function computeAllCarryovers() {
         var isSource = isSaatPass
           ? (solE > istE && istE > 0)
           : (solD > istD && istD > 0);
+        // Netto-Fix: Tabs mit IST > SOLL (Mehrbedarf) überspringen.
+        // Ihr Mehrverbrauch ist bereits durch den Netto-Saldo herausgerechnet.
+        var hasMehrbedarf = isSaatPass
+          ? (istE > 0 && istE > solE)
+          : (istD > 0 && istD > solD);
+        // Issue #347 Mini-Korrektur: kein hasNoEntries-Skip in Phase 1.
+        // Leere Empfänger-Tabs sollen Carryover (saved) empfangen können.
+        // Phase 2 hat ihren eigenen t2.entries.length === 0 Skip (für capacity
+        // als Absorber). Phase 1 muss aber leere Tabs als Empfänger zulassen,
+        // damit das SAV-Budget an die nächsten nicht-fertigen Tabs kaskadiert.
+        // Der bestehende `need_ <= 0.05` Skip reicht als Filter.
         if (need_ <= 0.05) continue;
         if (istCovered && isSource) continue;
+        if (hasMehrbedarf) continue;
         if (need_ > 0.05 && remSaved > 0.05) {
           var take = Math.min(remSaved, need_);
           if (take > 0) {
@@ -279,12 +315,15 @@ function computeAllCarryovers() {
   }
   for (var mat2 = 0; mat2 < 2; mat2++) {
     var isSaatPass2 = (mat2 === 0);
-    var remExcess = isSaatPass2 ? totalExcessE : totalExcessD;
+    var remExcess = isSaatPass2 ? netExcessE : netExcessD;
 
     // Tabs mit Capacity für dieses Material sammeln + sortieren.
     // Capacity = max(0, basis − used − saved_received) — IST-basiert
     // (Original-Semantik aus Phase 0). Self-Excess (used > basis):
     // ignoriert (kein negativer Carryover).
+    // Netto-Fix: Tabs mit IST > SOLL (Mehrbedarf-Quellen) werden als Absorber
+    // ausgeschlossen. Ihr Excess ist bereits durch den Netto-Saldo verrechnet —
+    // sie sollen ihn nicht zurückbekommen.
     var tabOrder2 = [];
     for (let i = 0; i < AppGlobals.state.reiter.length; i++) {
       var t2 = AppGlobals.state.reiter[i];
@@ -295,6 +334,11 @@ function computeAllCarryovers() {
       var istD2 = getTabIstDuenger(t2);
       var solD2 = getTabTotalDuenger(t2);
       var usedD2 = getTabUsedDuenger(t2);
+      // Mehrbedarf-Quellen überspringen (Netto-Fix)
+      var isMehrbedarf2 = isSaatPass2
+        ? (istE2 > 0 && istE2 > solE2)
+        : (istD2 > 0 && istD2 > solD2);
+      if (isMehrbedarf2) continue;
       var basis2 = isSaatPass2
         ? (istE2 > 0 ? istE2 : solE2)
         : (istD2 > 0 ? istD2 : solD2);
@@ -325,8 +369,8 @@ function computeAllCarryovers() {
       if (entry2.cap > 0.05) {
         var takeCap = Math.min(remExcess, entry2.cap);
         if (takeCap > 0.05) {
-          if (isSaatPass2) result[idx2].excessEinheit = takeCap;
-          else result[idx2].excessDuenger = takeCap;
+          if (isSaatPass2) result[idx2].excessEinheit += takeCap;
+          else result[idx2].excessDuenger += takeCap;
           remExcess -= takeCap;
         }
       }

--- a/public/js/render-drill.js
+++ b/public/js/render-drill.js
@@ -52,8 +52,8 @@
           var totalD = istSum > 0 ? AppGlobals.getTabIstDuenger(r) : AppGlobals.getTabTotalDuenger(r);
           var usedD = r.entries.reduce(function(s, e) { return s + e.duenger; }, 0);
           var co = AppGlobals.getCarryover(i);
-          var remaining = totalE - usedE;
-          var remainingD = totalD - usedD;
+          var remaining = Math.max(0, totalE - usedE - co.savedEinheit + co.excessEinheit);
+          var remainingD = Math.max(0, totalD - usedD - co.savedDuenger + co.excessDuenger);
           var statusEl = document.createElement('div');
           statusEl.id = 'dtl_need_' + i;
           statusEl.className = 'drill-tab-need';
@@ -187,35 +187,39 @@
       if (dsUsedD) dsUsedD.textContent = usedDuenger > 0 ? usedDuenger.toLocaleString('de-DE') + ' kg' : '—';
       var dsRemD = document.getElementById('ds_duenger_remaining');
       if (dsRemD) dsRemD.textContent = remDuenger > 0 ? remDuenger.toLocaleString('de-DE') + ' kg' : '0 kg';
-      // Issue #266-B2: IST<SOLL savings in #ds_savings (aggregated across all
-      // tabs that are savings sources). Issue #273: apply fahrgassenFaktor via
-      // getTabTotalEinheiten/getTabIstEinheiten so display matches carryover.
+      // Netto-Saldo IST vs SOLL in #ds_savings (aggregated across all tabs
+      // that have IST-Fläche set). Positive = Ersparnis (IST < SOLL),
+      // negative = Mehrbedarf (IST > SOLL). Issue #273: apply fahrgassenFaktor
+      // via getTabTotalEinheiten/getTabIstEinheiten so display matches carryover.
       var dsSav = document.getElementById('ds_savings');
       if (dsSav) {
-        var savETotal = 0;
-        var savDTotal = 0;
-        var anySavings = false;
+        var saldoETotal = 0;
+        var saldoDTotal = 0;
+        var anySaldo = false;
         for (var si = 0; si < allTabs.length; si++) {
           var sr = allTabs[si];
           if (!sr) continue;
           var srIstHa = AppGlobals.getTabIstHektar(sr);
-          if (srIstHa > 0 && sr.hektar > srIstHa) {
-            anySavings = true;
-            savETotal += AppGlobals.getTabTotalEinheiten(sr) - AppGlobals.getTabIstEinheiten(sr);
-            savDTotal += (sr.hektar - srIstHa) * (sr.duenger || 0);
+          if (srIstHa > 0 && sr.hektar > 0) {
+            anySaldo = true;
+            saldoETotal += AppGlobals.getTabTotalEinheiten(sr) - AppGlobals.getTabIstEinheiten(sr);
+            saldoDTotal += (sr.hektar - srIstHa) * (sr.duenger || 0);
           }
         }
-        if (anySavings) {
-          var savParts = [];
-          if (savETotal > 0.05) savParts.push(AppGlobals.fmt(savETotal) + ' Einheiten Saatgut');
-          if (savDTotal > 0.05) savParts.push(savDTotal.toLocaleString('de-DE') + ' kg Dünger');
-          if (savParts.length > 0) {
-            dsSav.textContent = 'Ersparnis: ' + savParts.join(', ');
-            dsSav.style.display = 'block';
-          } else {
-            dsSav.textContent = '';
-            dsSav.style.display = 'none';
+        if (anySaldo && (Math.abs(saldoETotal) > 0.05 || Math.abs(saldoDTotal) > 0.05)) {
+          var parts = [];
+          if (Math.abs(saldoETotal) > 0.05) {
+            parts.push((saldoETotal > 0 ? '+' : '') + AppGlobals.fmt(saldoETotal) + ' Einheiten Saatgut');
           }
+          if (Math.abs(saldoDTotal) > 0.05) {
+            parts.push((saldoDTotal > 0 ? '+' : '') + saldoDTotal.toLocaleString('de-DE') + ' kg Dünger');
+          }
+          if (saldoETotal > 0.05 || saldoDTotal > 0.05) {
+            dsSav.textContent = 'Ersparnis: ' + parts.join(', ');
+          } else {
+            dsSav.textContent = 'Mehrbedarf: ' + parts.join(', ');
+          }
+          dsSav.style.display = 'block';
         } else {
           dsSav.textContent = '';
           dsSav.style.display = 'none';
@@ -224,6 +228,84 @@
     }
 
     // --- Render: Drill Log ---
+
+    // Issue #336 follow-up #4: gemeinsamer Saldo-Helper für Per-Tab- und
+    // Net-Totals-Anzeige. Berechnet die Roh-Differenzen für einen Tab:
+    //   savingsE = SOLL - IST  (positiv wenn weniger verbraucht als geplant)
+    //   excessE  = IST - SOLL   (positiv wenn mehr verbraucht als geplant)
+    //   savingsD / excessD: kg/ha × Hektar-Differenz
+    // KEINE Gates hier (nicht „nur wenn istHektar > 0") — die Aufrufer
+    // entscheiden was sie anzeigen. _appendTabCarryoverBlocks blendet
+    // negative Werte aus (Per-Tab zeigt nur die positive Seite), und
+    // _appendNetTotalsBlock summiert über alle reiter und bildet das
+    // Net. So bleibt der Net-Totals IMMER konsistent mit dem Per-Tab-
+    // Saldo: was im Maschinen-Protokoll oder Ergebnis-Tab pro Tab als
+    // Mehrbedarf/Ersparnis steht, fließt 1:1 in die Net-Zeile ein.
+    function _computeTabSelfSaldo(rt) {
+      if (!rt) return { savingsE: 0, savingsD: 0, excessE: 0, excessD: 0 };
+      var sE = 0, sD = 0, eE = 0, eD = 0;
+      if (rt.istHektar > 0 && rt.hektar > 0) {
+        sE = AppGlobals.getTabTotalEinheiten(rt) - AppGlobals.getTabIstEinheiten(rt);
+        sD = (rt.hektar - rt.istHektar) * (rt.duenger || 0);
+        eE = AppGlobals.getTabIstEinheiten(rt) - AppGlobals.getTabTotalEinheiten(rt);
+        eD = (rt.istHektar - rt.hektar) * (rt.duenger || 0);
+      }
+      return { savingsE: sE, savingsD: sD, excessE: eE, excessD: eD };
+    }
+
+    // Issue #336 follow-up #5b: Cross-Tab-Saldo für Drill-Log + Maschinen-
+    // Protokoll (User-Feedback 2026-06-23, 5. Runde: „Es soll in den
+    // Ergebnissen Bereich unter dünger verbleibend im Protokoll/drill log").
+    // Aggregiert über ALLE reiter mittels _computeTabSelfSaldo (gleiche
+    // Logik wie _appendTabCarryoverBlocks — Pattern 3 Single Source of
+    // Truth). Net > 0 → grüne „Ersparnis"-Zeile. Net < 0 → rote „Mehrbedarf"-
+    // Zeile. Wird in renderDrillLog() und renderMachineLog() jeweils
+    // VOR den Per-Tab-Headern aufgerufen, unter „Dünger verbleibend".
+    //
+    // ACHTUNG (Issue #336 follow-up #4): _computeTabSelfSaldo gibt sowohl
+    // savingsE (positiv) ALS AUCH excessE (positiv bei IST>SOLL) zurück,
+    // wobei der jeweils andere Wert negativ ist. Wir summieren die
+    // *positiven* Seiten separat, dann net = totalSav - totalExc.
+    function _appendNetTotalsBlock(container) {
+      if (!container) return;
+      var totalSavE = 0, totalSavD = 0, totalExcE = 0, totalExcD = 0;
+      var allReiter = AppGlobals.state.reiter || [];
+      for (var ti = 0; ti < allReiter.length; ti++) {
+        var rt = allReiter[ti];
+        var s = _computeTabSelfSaldo(rt);
+        if (s.savingsE > 0) totalSavE += s.savingsE;
+        if (s.savingsD > 0) totalSavD += s.savingsD;
+        if (s.excessE > 0) totalExcE += s.excessE;
+        if (s.excessD > 0) totalExcD += s.excessD;
+      }
+      var netE = totalSavE - totalExcE;
+      var netD = totalSavD - totalExcD;
+      var showSavings = netE > 0.05 || netD > 0.05;
+      var showExcess = netE < -0.05 || netD < -0.05;
+      if (!showSavings && !showExcess) return;
+      var label = document.createElement('div');
+      label.className = 'drill-entry-tab-header drill-net-totals-header';
+      label.textContent = 'Gesamt-Saldo (alle Tabs)';
+      container.appendChild(label);
+      if (showSavings) {
+        var sParts = [];
+        if (netE > 0.05) sParts.push(AppGlobals.fmt(netE) + ' Einheiten Saatgut');
+        if (netD > 0.05) sParts.push(netD.toLocaleString('de-DE') + ' kg Dünger');
+        var sDiv = document.createElement('div');
+        sDiv.className = 'net-totals-line net-totals-savings';
+        sDiv.textContent = 'Ersparnis: ' + sParts.join(', ');
+        container.appendChild(sDiv);
+      }
+      if (showExcess) {
+        var eParts = [];
+        if (netE < -0.05) eParts.push(AppGlobals.fmt(-netE) + ' Einheiten Saatgut');
+        if (netD < -0.05) eParts.push((-netD).toLocaleString('de-DE') + ' kg Dünger');
+        var eDiv = document.createElement('div');
+        eDiv.className = 'net-totals-line net-totals-excess';
+        eDiv.textContent = 'Mehrbedarf aus überschrittenen Flächen: -' + eParts.join(', ');
+        container.appendChild(eDiv);
+      }
+    }
 
     // Issue #309: Per-tab carryover/savings/excess block helper.
     // Appends the three optional divs (.drill-savings / .drill-carryover /
@@ -237,24 +319,17 @@
     function _appendTabCarryoverBlocks(tabIdx, ct, container) {
       if (!ct) return;
       var cco = AppGlobals.getCarryover(tabIdx);
-      var isSavingsSource = (ct.istHektar > 0 && ct.hektar > 0 && ct.istHektar < ct.hektar);
-      var isExcessSource = (ct.istHektar > 0 && ct.hektar > 0 && ct.istHektar > ct.hektar);
-      if (isSavingsSource) {
-        // Issue #273: source savings must apply fahrgassenFaktor, same as
-        // the carryover calculation. Use getTabTotalEinheiten - getTabIstEinheiten
-        // (both already apply the per-tab FG factor) so display and
-        // carryover share one formula.
-        var sE = AppGlobals.getTabTotalEinheiten(ct) - AppGlobals.getTabIstEinheiten(ct);
-        var sD = (ct.hektar - ct.istHektar) * (ct.duenger || 0);
+      var s = _computeTabSelfSaldo(ct);
+      // Per-Tab zeigt nur die positive Seite: savings wenn > 0, excess wenn > 0.
+      // (Der Net-Totals summiert beide Seiten und bildet das Net — s. Helper.)
+      if (s.savingsE > 0.05 || s.savingsD > 0.05) {
         var sParts = [];
-        if (sE > 0.05) sParts.push(AppGlobals.fmt(sE) + ' Einheiten Saatgut');
-        if (sD > 0.05) sParts.push(sD.toLocaleString('de-DE') + ' kg Dünger');
-        if (sParts.length > 0) {
-          var sDiv = document.createElement('div');
-          sDiv.className = 'drill-savings';
-          sDiv.textContent = 'Ersparnis: ' + sParts.join(', ');
-          container.appendChild(sDiv);
-        }
+        if (s.savingsE > 0.05) sParts.push(AppGlobals.fmt(s.savingsE) + ' Einheiten Saatgut');
+        if (s.savingsD > 0.05) sParts.push(s.savingsD.toLocaleString('de-DE') + ' kg Dünger');
+        var sDiv = document.createElement('div');
+        sDiv.className = 'drill-savings';
+        sDiv.textContent = 'Ersparnis: ' + sParts.join(', ');
+        container.appendChild(sDiv);
       }
       if (cco.savedEinheit > 0.05 || cco.savedDuenger > 0.05) {
         var cParts = [];
@@ -265,22 +340,14 @@
         cDiv.textContent = 'Übertrag aus ersparten Flächen: +' + cParts.join(', ');
         container.appendChild(cDiv);
       }
-      if (isExcessSource) {
-        // Issue #273: source excess must apply fahrgassenFaktor, same as
-        // the carryover calculation. Use getTabIstEinheiten - getTabTotalEinheiten
-        // (both already apply the per-tab FG factor) so display and
-        // carryover share one formula.
-        var eE = AppGlobals.getTabIstEinheiten(ct) - AppGlobals.getTabTotalEinheiten(ct);
-        var eD = (ct.istHektar - ct.hektar) * (ct.duenger || 0);
+      if (s.excessE > 0.05 || s.excessD > 0.05) {
         var eParts = [];
-        if (eE > 0.05) eParts.push(AppGlobals.fmt(eE) + ' Einheiten Saatgut');
-        if (eD > 0.05) eParts.push(eD.toLocaleString('de-DE') + ' kg Dünger');
-        if (eParts.length > 0) {
-          var eDiv = document.createElement('div');
-          eDiv.className = 'drill-excess';
-          eDiv.textContent = 'Mehrbedarf aus überschrittenen Flächen: -' + eParts.join(', ');
-          container.appendChild(eDiv);
-        }
+        if (s.excessE > 0.05) eParts.push(AppGlobals.fmt(s.excessE) + ' Einheiten Saatgut');
+        if (s.excessD > 0.05) eParts.push(s.excessD.toLocaleString('de-DE') + ' kg Dünger');
+        var eDiv = document.createElement('div');
+        eDiv.className = 'drill-excess';
+        eDiv.textContent = 'Mehrbedarf aus überschrittenen Flächen: -' + eParts.join(', ');
+        container.appendChild(eDiv);
       }
     }
 
@@ -290,10 +357,9 @@
       if (!ct) return false;
       var cco = AppGlobals.getCarryover(tabIdx);
       if (cco.savedEinheit > 0.05 || cco.savedDuenger > 0.05) return true;
-      if (ct.istHektar > 0 && ct.hektar > 0) {
-        if (ct.istHektar < ct.hektar) return true;  // savings source
-        if (ct.istHektar > ct.hektar) return true;  // excess source
-      }
+      var s = _computeTabSelfSaldo(ct);
+      if (s.savingsE > 0.05 || s.savingsD > 0.05) return true;
+      if (s.excessE > 0.05 || s.excessD > 0.05) return true;
       return false;
     }
 
@@ -342,6 +408,10 @@
         if (usedD > 0) parts.push(usedD.toLocaleString('de-DE') + ' kg Dünger');
         totalSummary.textContent = parts.join(' · ');
       }
+      // Issue #336 follow-up #5b: Cross-Tab-Saldo als erster Block im
+      // Drill-Log, vor den Per-Tab-Headern. Steht im „Ergebnisse Bereich"
+      // (unter „Dünger verbleibend" / ds_savings / drill-summary-rows).
+      _appendNetTotalsBlock(container);
       // Iterate per tab in index order. Per-tab #N numbering (Option A):
       // entries[0] = '#1', entries[1] = '#2', etc. Consistent with single-tab
       // behaviour — test 09-blind-spots ('drill entry shows time prefix when
@@ -431,6 +501,10 @@
       header.className = 'drill-entry-tab-header';
       header.textContent = 'Maschinen-Protokoll';
       container.appendChild(header);
+      // Issue #336 follow-up #5b: Cross-Tab-Saldo als erster Block im
+      // Maschinen-Protokoll, VOR den Per-Tab-Sub-Headern. Im „Ergebnisse
+      // Bereich" (zwischen Maschinen-Protokoll-Header und Tab-Sub-Headers).
+      _appendNetTotalsBlock(container);
       // Issue #309: per-tab carryover sections (Ersparnis / Übertrag / Mehrbedarf)
       // — the machine-log entries themselves are a flat global list (no tabIdx
       // on machineLog entries, by design), but the carryover blocks are

--- a/public/js/render-drill.js
+++ b/public/js/render-drill.js
@@ -160,8 +160,29 @@
         // global carryover pool; summing across tabs gives the totals the
         // formula needs.
         var cco = AppGlobals.getCarryover(ti);
-        var needE = Math.max(0, tEinheiten - tUsedE);
-        var needD = Math.max(0, tDuenger - tUsedD);
+        // Issue #347 (Folge-Bug zu PR #348): Mehrbedarf-Tabs (istE > solE
+        // bzw. istD > solD) dürfen NICHT als Bedarfsempfänger in needE/needD
+        // zählen. Ihr "Restbedarf" (ist-basis − used) ist konzeptuell
+        // Quellen-Mehraufwand, der bereits durch den Netto-Saldo-Pool in
+        // computeAllCarryovers() (#347) absorbiert wurde. Wenn wir ihn hier
+        // erneut als positiven Bedarf zählen, verdoppelt sich die Cross-Tab-
+        // Aggregations-Formel: totalNeedE enthält dann den Mehrbedarf, und
+        // totalExcessE enthält ihn ebenfalls → remE wird künstlich groß.
+        //
+        // Spec-Anker: Issue #302 definiert "verteilbare_excess_saldi" als
+        // Quellen-Salden, die im Phase-B-Cross-Tab-Pool landen. Bedarfe sind
+        // per Definition "zu wenig" (ist < soll bzw. used < basis). Daher
+        // wird hier analog zu computeAllCarryovers() Phase 1 (hasMehrbedarf-
+        // Skip) jeder Mehrbedarf-Tab als nicht-bedarfs-empfangend markiert.
+        //
+        // NICHT angefasst (Spec #302): Z. 176-177 (Phase-B-Formel
+        // rem = max(0, TotalNeed - TotalSaved + TotalExcess)).
+        var solEForTab = AppGlobals.getTabTotalEinheiten(rt);
+        var solDForTab = AppGlobals.getTabTotalDuenger(rt);
+        var isMehrbedarfE = (tEinheiten > 0 && solEForTab > 0 && tEinheiten > solEForTab);
+        var isMehrbedarfD = (tDuenger > 0 && solDForTab > 0 && tDuenger > solDForTab);
+        var needE = (isMehrbedarfE || tUsedE >= tEinheiten) ? 0 : Math.max(0, tEinheiten - tUsedE);
+        var needD = (isMehrbedarfD || tUsedE >= tDuenger) ? 0 : Math.max(0, tDuenger - tUsedD);
         totalNeedE += needE;
         totalNeedD += needD;
         totalSavedE += cco.savedEinheit;

--- a/tests/05-drill-protocol.test.js
+++ b/tests/05-drill-protocol.test.js
@@ -418,11 +418,32 @@ describe('Drill-Protokoll', () => {
       w.renderResults();
 
       // Phase A + Phase B per Issue #302 spec, MIT Netto-Saldo-Korrektur #347.
-      // TotalNeed_E = (21.6-12) + (9-0) = 9.6 + 9 = 18.6 (kein Tab absorbiert
-      // self-excess, weil beides Mehrbedarf-Quellen sind).
-      expect(doc.getElementById('ds_saat_remaining').textContent).toBe('18,6 Einheiten');
-      // TotalNeed_D = (2400-2000) + (1000-0) = 400 + 1000 = 1400
-      expect(doc.getElementById('ds_duenger_remaining').textContent).toBe('1.400 kg');
+      //
+      // Fix-Reihenfolge:
+      //   PR #348 → Netto-Saldo in computeAllCarryovers(). Self-Absorb-Skip
+      //             verhindert Doppel-Zählung in der Cross-Tab-Formel.
+      //   PR #<dieser> → Folge-Bug: in renderDrillSummary() Phase A zählte
+      //                  Tab 0 (Mehrbedarf-Quelle, istE=21.6 > solE=9) als
+      //                  Bedarfsempfänger mit needE=9.6 (sein Restbedarf auf
+      //                  IST-Fläche). Das ist konzeptuell Quellen-Mehraufwand,
+      //                  nicht "zu wenig". Mit dem Mehrbedarf-Skip für Phase A
+      //                  landet nur der echte Bedarf von Tab 1 (needE=9) im
+      //                  totalNeedE.
+      //
+      // TotalNeed_E = 0 (Tab 0 ist Mehrbedarf → Skip) + (9-0) (Tab 1)
+      //             = 9
+      // TotalSaved_E = 0, TotalExcess_E = 0 (Tab 0 self-excess,
+      //                Phase 2 verteilt 0 dank Self-Absorb-Skip #348).
+      // → remEinheit = max(0, 9 - 0 + 0) = 9
+      //
+      // HINWEIS: Der vorherige Wert "18,6 Einheiten" (PR #348's Update)
+      // entsprach dem ALTEN Phase-A-Verhalten, in dem Tab 0 als
+      // Bedarfsempfänger mit 9.6 E gezählt wurde. Mit der Issue-#347-Folge-
+      // Korrektur (Mehrbedarf-Tabs zählen NICHT als Bedarfsempfänger) ist
+      // 9,0 der korrekte Wert.
+      expect(doc.getElementById('ds_saat_remaining').textContent).toBe('9,0 Einheiten');
+      // TotalNeed_D = 0 (Tab 0 Mehrbedarf) + (1000-0) (Tab 1) = 1000
+      expect(doc.getElementById('ds_duenger_remaining').textContent).toBe('1.000 kg');
 
       // Sanity: total/used are independent of carryover.
       expect(doc.getElementById('ds_saat_total').textContent).toBe('30,6 Einheiten');

--- a/tests/05-drill-protocol.test.js
+++ b/tests/05-drill-protocol.test.js
@@ -379,7 +379,21 @@ describe('Drill-Protokoll', () => {
     // Phase B: TotalExcess_E = 9.6, TotalExcess_D = 400.
     //          remEinheit  = max(0, 18.6 - 0 + 9.6) = 28.2
     //          remDuenger  = max(0, 1400 - 0 + 400) = 1800
-    it('renderDrillSummary() nets carryover across tabs (Issue #302)', () => {
+    it('renderDrillSummary() nets carryover across tabs (Issue #302, updated for Issue #347)', () => {
+      // Issue #347 (Netto-Saldo-Fix): Eine Mehrbedarf-Quelle (IST > SOLL) darf
+      // sich in Phase 2 NICHT selbst als Empfänger ihres eigenen Excess
+      // eintragen — sie muss den Rest selbst absorbieren (Eigen-Restbedarf).
+      // Vor #347 hat Phase 2 (`isMehrbedarf2` Skip fehlte) den Mehrbedarf-Pool
+      // auch an die Quelle selbst verteilt, was zu doppelter Zählung führt.
+      //
+      // Szenario: Beide Tabs haben istHektar=2.4 > SOLL=1 → BEIDE sind
+      // Mehrbedarf-Quellen. Mit Fix: BEIDE werden in Phase 2 als Absorber
+      // ausgeschlossen → kein Tab bekommt `excessEinheit/duenger` von sich
+      // selbst. Der `ds_saat_remaining` / `ds_duenger_remaining` zeigt
+      // daher nur den unverteilten Bedarf, NICHT plus Eigen-Excess.
+      //
+      // ALTES Verhalten (vor #347): 28,2 E / 1.800 kg (Tab 0 self-absorbed).
+      // NEUES Verhalten (nach #347): 18,6 E / 500 kg (kein Self-Absorb).
       setupTwoTabs(w);
       // Reset tabs to the user's repro (1 ha / 450.000 K/ha / 1000 kg).
       // setupTwoTabs defaults to 10 ha / 90000 K/ha / 200 kg/ha — too large.
@@ -403,9 +417,12 @@ describe('Drill-Protokoll', () => {
 
       w.renderResults();
 
-      // Phase A + Phase B per Issue #302 spec.
-      expect(doc.getElementById('ds_saat_remaining').textContent).toBe('28,2 Einheiten');
-      expect(doc.getElementById('ds_duenger_remaining').textContent).toBe('1.800 kg');
+      // Phase A + Phase B per Issue #302 spec, MIT Netto-Saldo-Korrektur #347.
+      // TotalNeed_E = (21.6-12) + (9-0) = 9.6 + 9 = 18.6 (kein Tab absorbiert
+      // self-excess, weil beides Mehrbedarf-Quellen sind).
+      expect(doc.getElementById('ds_saat_remaining').textContent).toBe('18,6 Einheiten');
+      // TotalNeed_D = (2400-2000) + (1000-0) = 400 + 1000 = 1400
+      expect(doc.getElementById('ds_duenger_remaining').textContent).toBe('1.400 kg');
 
       // Sanity: total/used are independent of carryover.
       expect(doc.getElementById('ds_saat_total').textContent).toBe('30,6 Einheiten');

--- a/tests/19-savings-carryover.test.js
+++ b/tests/19-savings-carryover.test.js
@@ -258,25 +258,35 @@ describe('IST/SOLL Savings & Carryover', () => {
     expect(co2.savedDuenger).toBeCloseTo(100, 0);
   });
 
-  it('excess cascades to second-to-last filled tab', () => {
+  it('excess cascades to neutral absorbers only (Issue #347 Netto-Fix)', () => {
+    // Issue #347 (Netto-Saldo-Fix): Eine Mehrbedarf-Quelle (IST > SOLL) wird
+    // in Phase 2 ALS ABSORBER ausgeschlossen (Skip `isMehrbedarf2`). Sie soll
+    // ihren Eigen-Restbedarf NICHT durch Selbst-Absorption in die
+    // `excessEinheit` der Quelle selbst buchen — das verwechselt
+    // Eigen-Restbedarf mit Empfänger-Bereitschaft (Maintainer's diagnose in
+    // Issue #347).
+    //
+    // Vor #347: Tab 0 (Quelle) self-absorbed 1 E Rest → Buggy Doppelt-Zählung.
+    // Nach #347: Tab 0 bekommt 0 (Skip); Tab 1 absorbiert volle 2 E (cap).
     const { w } = setup();
     w.addReiter();
-    // Tab 0: SOLL=5, IST=8 → excess = 3 Einheiten
+    // Tab 0: SOLL=5, IST=8 → Mehrbedarf-Quelle (excess = 3 E)
     w.state.reiter[0] = { ...w.state.reiter[0], hektar: 5, istHektar: 8, koerner: 50000, duenger: 100 };
-    // Tab 1: last filled, remaining = 2 Einheiten → absorbs min(3, 2) = 2 excess
+    // Tab 1: neutral, used=2/4, cap = 4-2 = 2 → absorbiert min(3, 2) = 2
     w.state.reiter[1] = { ...w.state.reiter[1], hektar: 4, koerner: 50000, duenger: 100 };
     w.state.reiter[1].entries.push({ einheit: 2, zaehlerStand: 4, duenger: 200, time: '10:00' });
-    // Tab 0: second-to-last, remaining = 5 → absorbs rest 1 excess
+    // Tab 0 entries: usedE=3
     w.state.reiter[0].entries.push({ einheit: 3, zaehlerStand: 3, duenger: 300, time: '09:00' });
 
-    // Excess: SOLL 5 - IST 8 = -3 → 3 Einheiten excess
-    // Tab 1 (last filled): remaining = 4-2 = 2, absorbs min(3, 2) = 2
-    // Tab 0 (prev filled): remaining = 8-3 = 5, absorbs min(1, 5) = 1
+    // Excess-Pool = 3 E. Tab 0 ist Quelle (istE=8 > solE=5) → Skip in Phase 2.
+    // Tab 1 (neutral) absorbiert 2 E (volle Cap). Rest 1 E verfällt.
     var co1 = w.getCarryover(1);
     expect(co1.excessEinheit).toBeCloseTo(2, 1);
 
+    // Tab 0 (Mehrbedarf-Quelle): bekommt KEINEN excessEinheit (Self-Absorb
+    // ist mit Netto-Fix ausgeschlossen).
     var co0 = w.getCarryover(0);
-    expect(co0.excessEinheit).toBeCloseTo(1, 1);
+    expect(co0.excessEinheit).toBeCloseTo(0, 1);
   });
 
   it('savings display applies fahrgassenFaktor (Issue #273)', () => {

--- a/tests/99-verify-bug-user-3tab-drill-summary.test.js
+++ b/tests/99-verify-bug-user-3tab-drill-summary.test.js
@@ -1,0 +1,118 @@
+// Pin-Test für Issue #347 (Folge-Bug zu PR #348)
+//
+// Vorher (PR #348 gefixt, Inline-Drill richtig):
+//   Inline-Drill Tab 3: r_drill_e_rem = "1,0 Einheit" ✓
+//   Carryover-Pool: getCarryover(2) korrekt (savedE=1, alles andere 0) ✓
+//   Drill-Summary (Cross-Tab-Aggregation):
+//     ds_saat_remaining  = "2,0 Einheiten" ✗ (sollte "1,0 Einheit")
+//     ds_duenger_remaining = "500 kg"     ✗ (sollte "400 kg")
+//
+// Nachher (dieser PR):
+//   Drill-Summary aggregiert per-tab needE/needD OHNE Mehrbedarf-Tabs.
+//   Tab 2 ist Mehrbedarf-Quelle (istE=16 > solE=15) → sein Restbedarf
+//   (16 − 11 = 5 E) ist Quellen-Mehraufwand, nicht Bedarf. Mit Skip
+//   ergibt sich totalNeedE = 0 (Tab 1 fertig) + 0 (Tab 2 Mehrbedarf)
+//   + 2 (Tab 3 echter Bedarf) = 2. Phase B: remE = max(0, 2 − 1 + 0) = 1.
+//
+// User-Szenario (Issue #347):
+//   Tab 1: 10→9 ha, used 18E/1800kg → Ersparnis-Quelle (2E, 200kg)
+//   Tab 2: 7.5→8 ha, used 11E/1500kg → Mehrbedarf-Quelle (1E, 100kg)
+//   Tab 3: 5→5 ha, used 8E/500kg   → neutral, eigener Restbedarf 2E/500kg
+// Erwartet (User-Spec):
+//   ds_saat_remaining    = "1,0 Einheit"
+//   ds_duenger_remaining = "400 kg"
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createDom } from './helpers.js';
+
+describe('Issue #347 Folge-Bug: Drill-Summary aggregiert ohne Mehrbedarf-Tabs', () => {
+  let w, AG, doc;
+
+  beforeEach(() => {
+    const result = createDom();
+    w = result.window;
+    AG = w.AppGlobals;
+    doc = w.document;
+  });
+
+  function setup3TabsUserScenario() {
+    AG.state.koernerProEinheit = 50000;
+    AG.state.activeReiter = 2;
+    AG.state.reiter = [
+      { name: 'Tab 1', hektar: 10,  istHektar: 9,   koerner: 100000, duenger: 200,
+        fahrgassenEnabled: false, fahrgassenBreite: 0,
+        entries: [{ einheit: 18, duenger: 1800, time: '08:00' }] },
+      { name: 'Tab 2', hektar: 7.5, istHektar: 8,   koerner: 100000, duenger: 200,
+        fahrgassenEnabled: false, fahrgassenBreite: 0,
+        entries: [{ einheit: 11, duenger: 1500, time: '09:00' }] },
+      { name: 'Tab 3', hektar: 5,   istHektar: 5,   koerner: 100000, duenger: 200,
+        fahrgassenEnabled: false, fahrgassenBreite: 0,
+        entries: [{ einheit: 8,  duenger: 500,  time: '10:00' }] },
+    ];
+    if (AG.invalidateCarryoverCache) AG.invalidateCarryoverCache();
+  }
+
+  it('Drill-Summary: ds_saat_remaining = "1,0 Einheit" (NICHT "2,0 Einheiten")', () => {
+    setup3TabsUserScenario();
+    AG.renderResults();
+    const actual = doc.getElementById('ds_saat_remaining').textContent;
+    expect(actual).toBe('1,0 Einheit');
+  });
+
+  it('Drill-Summary: ds_duenger_remaining = "400 kg" (NICHT "500 kg")', () => {
+    setup3TabsUserScenario();
+    AG.renderResults();
+    const actual = doc.getElementById('ds_duenger_remaining').textContent;
+    expect(actual).toBe('400 kg');
+  });
+
+  it('Per-tab Carryover: Tab 2 (Mehrbedarf-Quelle) bleibt bei savedE=0/savedD=0', () => {
+    // PR #348 pinnt das schon. Hier nur als Sanity-Check, dass die
+    // Voraussetzung für diesen Folge-Bug-Fix gegeben ist.
+    setup3TabsUserScenario();
+    const co2 = AG.getCarryover(1);
+    expect(co2.savedEinheit).toBe(0);
+    expect(co2.savedDuenger).toBe(0);
+  });
+
+  it('Per-tab Carryover: Tab 3 (neutraler Empfänger) bekommt savedE=1, savedD=100', () => {
+    setup3TabsUserScenario();
+    const co3 = AG.getCarryover(2);
+    // Netto-Saldo (PR #348): netSavedE = max(0, 2−1) = 1, netSavedD = max(0, 200−100) = 100.
+    // Phase 1 mit hasMehrbedarf-Skip für Tab 2 → Tab 3 empfängt die vollen 1E / 100kg.
+    expect(co3.savedEinheit).toBeCloseTo(1, 1);
+    expect(co3.savedDuenger).toBeCloseTo(100, 0);
+  });
+
+  it('Inline-Drill Tab 3 bleibt korrekt (r_drill_e_rem = "1,0 Einheit")', () => {
+    // Pattern #3-Check: Inline-Drill (render-results.js) verwendet die
+    // Per-Tab-Formel max(0, basis - used - saved + excess) — diese ist
+    // konsistent mit dem gefixten Cross-Tab-Summary.
+    setup3TabsUserScenario();
+    AG.renderResults();
+    const inlineE = doc.getElementById('r_drill_e_rem');
+    const inlineD = doc.getElementById('r_drill_d_rem');
+    expect(inlineE).toBeTruthy();
+    expect(inlineD).toBeTruthy();
+    expect(inlineE.textContent).toBe('1,0 Einheit');
+    expect(inlineD.textContent).toBe('400 kg');
+  });
+
+  it('Aggregations-Formel: Tab 2 (Mehrbedarf) trägt needE=0/needD=0 bei', () => {
+    // Direkter Pin auf die Code-Stelle render-drill.js Z. 163-164:
+    // Wenn isMehrbedarf=true, wird needE/needD auf 0 gesetzt, NICHT aus
+    // (tEinheiten - tUsedE) berechnet.
+    setup3TabsUserScenario();
+    AG.renderResults();
+    // Wir lesen ds_saat_remaining (Phase B aggregiert). Die richtige
+    // Aggregation setzt voraus, dass Tab 2 mit 0 beigetragen hat.
+    // Wenn das Formel-Delta = 5 (Tab 2's tEinheiten−tUsedE) eingeflossen
+    // wäre, würde ds_saat_remaining = 1 + 5 = 6 stehen (oder ähnliches).
+    const remE = doc.getElementById('ds_saat_remaining').textContent;
+    const remD = doc.getElementById('ds_duenger_remaining').textContent;
+    // Hätten wir Tab 2 als Bedarfsempfänger gezählt, wäre remE irgendwo
+    // zwischen 5 und 7 (abhängig von totalExcessE). 1,0 ist der Fix-Wert.
+    expect(parseFloat(remE.replace(',', '.'))).toBeLessThanOrEqual(2);
+    expect(parseFloat(remD.replace(/\./g, '').replace(' kg', ''))).toBeLessThanOrEqual(500);
+  });
+});

--- a/tests/99-verify-bug-user-3tab.test.js
+++ b/tests/99-verify-bug-user-3tab.test.js
@@ -1,0 +1,83 @@
+// Regression-Test für Issue #347 (User-Bug-Report)
+// Pin-Assertion: In computeAllCarryovers() Phase 1 darf ein Tab mit IST>SOLL
+// (Mehrbedarf-Quelle) KEIN savedEinheit/savedDuenger zugewiesen bekommen.
+// Das gleiche für Phase 2: ein Tab mit IST=SOLL (neutraler Empfänger) bekommt
+// KEIN excessEinheit/excessDuenger, weil er keinen eigenen Mehrbedarf hat.
+//
+// User-Szenario:
+//   Tab 1: 10→9 ha, used 18E/1800kg → Ersparnis-Quelle (2E, 200kg)
+//   Tab 2: 7.5→8 ha, used 11E/1500kg → Mehrbedarf-Quelle (1E, 100kg)
+//   Tab 3: 5→5 ha, used 8E/500kg   → neutral, eigener Restbedarf 2E/500kg
+// Erwartet: Tab 3 verbleibend = 1 E, 400 kg.
+// Tatsächlich (Bug): 2-3 E, 500 kg.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createDom } from './helpers.js';
+
+describe('Issue #347: Carryover-Phase 1+2 vergibt Salden an falsche Tabs', () => {
+  let w, AG;
+
+  beforeEach(() => {
+    const result = createDom();
+    w = result.window;
+    AG = w.AppGlobals;
+  });
+
+  function setup3Tabs() {
+    AG.state.koernerProEinheit = 50000;
+    AG.state.activeReiter = 2;
+    AG.state.reiter = [
+      { name: 'T1', hektar: 10,  istHektar: 9,   koerner: 100000, duenger: 200,
+        entries: [{ einheit: 18, duenger: 1800, time: '08:00' }] },
+      { name: 'T2', hektar: 7.5, istHektar: 8,   koerner: 100000, duenger: 200,
+        entries: [{ einheit: 11, duenger: 1500, time: '09:00' }] },
+      { name: 'T3', hektar: 5,   istHektar: 5,   koerner: 100000, duenger: 200,
+        entries: [{ einheit: 8,  duenger: 500,  time: '10:00' }] },
+    ];
+    if (AG.invalidateCarryoverCache) AG.invalidateCarryoverCache();
+  }
+
+  it('Phase 1: Tab 2 (Mehrbedarf-Quelle, istE > solE) bekommt KEIN savedEinheit', () => {
+    setup3Tabs();
+    const co2 = AG.getCarryover(1);
+    // Tab 2 hat IST=16 > SOLL=15 → Mehrbedarf. Phase 1 darf hier nichts
+    // aus dem Ersparnis-Pool zuteilen, weil Tab 2 selbst Quelle ist.
+    expect(co2.savedEinheit).toBe(0);
+    expect(co2.savedDuenger).toBe(0);
+  });
+
+  it('Phase 2: Tab 3 (neutraler Empfänger, istE == solE) bekommt KEIN excessEinheit', () => {
+    setup3Tabs();
+    const co3 = AG.getCarryover(2);
+    // Tab 3 ist neutral (IST=SOLL). Phase 2 darf keinen Mehrbedarf-Empfang
+    // buchen, weil Tab 3 keinen eigenen Mehrbedarf hat.
+    expect(co3.excessEinheit).toBe(0);
+    expect(co3.excessDuenger).toBe(0);
+  });
+
+  it('Tab 3 verbleibend = 1 E, 400 kg nach dem Fix', () => {
+    setup3Tabs();
+    const r3 = AG.state.reiter[2];
+    const co3 = AG.getCarryover(2);
+    const basisE = AG.getTabIstEinheiten(r3);
+    const basisD = AG.getTabIstDuenger(r3);
+    const usedE = r3.entries.reduce((s,e)=>s+(e.einheit||0), 0);
+    const usedD = r3.entries.reduce((s,e)=>s+(e.duenger||0), 0);
+    const remE = Math.max(0, basisE - usedE - co3.savedEinheit + co3.excessEinheit);
+    const remD = Math.max(0, basisD - usedD - co3.savedDuenger + co3.excessDuenger);
+    // Erwartet nach Fix: 2 E (10-8-0+0... wait, Tab 3 EMPFÄNGT die ganze Ersparnis
+    // aus Tab 1 wenn Tab 2 korrekt übersprungen wird → remE = 10-8-2+0 = 0?
+    // Hmm, mit korrigierter Phase 1 (Tab 2 ausgeschlossen) bekommt Tab 3 alle
+    // 2E Ersparnis → remE = max(0, 10-8-2+0) = 0. Das ist nicht 1.
+    //
+    // Korrekte Erwartung mit Phase-1-Fix + Netting:
+    //   totalSaved=2, totalExcess=1, Net = totalSaved - totalExcess = 1.
+    //   Tab 3 Restbedarf vor Carryover: 10 - 8 = 2. Nach Carryover: 2 - 1 = 1.
+    // → remE = 1. Die Phase 2 muss Netting anwenden, sonst Doppel-Zählung.
+    //
+    // Dieser Test pinnt das END-RESULT (Tab 3 = 1 E / 400 kg), das nur mit
+    // Phase-1-Fix + Phase-2-Netting erreicht wird. Phase-2-only Fix reicht NICHT.
+    expect(remE).toBeCloseTo(1, 1);
+    expect(remD).toBeCloseTo(400, 0);
+  });
+});


### PR DESCRIPTION
# fix(#347): Drill-Summary aggregiert needE/needD ohne Mehrbedarf-Tabs

## Zusammenfassung

Folge-Bug zu PR #348 (`fix/347-carryover-netting` — Netto-Saldo in `computeAllCarryovers`):
Inline-Drill (`r_drill_e_rem`, `r_drill_d_rem`) und Carryover-Pool sind nach PR #348
korrekt, **aber** die aggregierte Drill-Summary (`ds_saat_remaining`, `ds_duenger_remaining`)
zeigt weiterhin falsche Werte im Mehrbedarf-Szenario.

## Was ändert sich?

In `public/js/render-drill.js` Phase A der `renderDrillSummary()`-Aggregation wird
für Mehrbedarf-Tabs (`istE > solE` bzw. `istD > solD`) der per-tab `needE`/`needD`
auf `0` gesetzt — analog zum `hasMehrbedarf`-Skip in `computeAllCarryovers()` Phase 1.

**Vorher (PR #348-Buggy-Stand):**
- Tab 2 (Mehrbedarf-Quelle, `istE=16 > solE=15`): `needE = max(0, 16 − 11) = 5`
- `totalNeedE` aggregiert den Mehrbedarf-Restbedarf **zusätzlich** zu seinem `excessEinheit`
  → Phase-B-Formel verdoppelt sich künstlich.

**Nachher (dieser Fix):**
- Tab 2: `isMehrbedarfE=true` → `needE = 0` (kein Bedarfsempfänger)
- `totalNeedE` enthält nur echte Bedarfe. `totalExcessE` bleibt im Cross-Tab-Pool.

## User-Szenario (Issue #347)

Tab 1: 10→9 ha, used 18E/1800kg → **Ersparnis-Quelle** (2E, 200kg)
Tab 2: 7.5→8 ha, used 11E/1500kg → **Mehrbedarf-Quelle** (1E, 100kg)
Tab 3: 5→5 ha, used 8E/500kg → neutral, eigener Restbedarf 2E/500kg

| Anzeige | Vorher | Nachher | Erwartet |
|---|---|---|---|
| `ds_saat_remaining` | `2,0 Einheiten` ✗ | `1,0 Einheit` ✓ | `1,0 Einheit` |
| `ds_duenger_remaining` | `500 kg` ✗ | `400 kg` ✓ | `400 kg` |
| Inline `r_drill_e_rem` | `1,0 Einheit` ✓ | `1,0 Einheit` ✓ | `1,0 Einheit` |
| Inline `r_drill_d_rem` | `400 kg` ✓ | `400 kg` ✓ | `400 kg` |

## Spec-Anker

- **Phase A (gefixt):** Mehrbedarf-Skip analog `computeAllCarryovers()` Phase 1.
  Bedarfe sind per Definition "zu wenig"; Mehrbedarf-Restbedarf auf IST-Fläche
  ist Quellen-Mehraufwand, bereits durch Netto-Saldo-Pool absorbiert.
- **Phase B (NICHT angefasst):** Z. 176-177 — `rem = max(0, TotalNeed - TotalSaved + TotalExcess)`.
  Diese Formel ist Spec #302 und bleibt unverändert.
- **Dashboard (NICHT angefasst):** `render-dashboard.js` zeigt den realen Stand
  ohne Carryover (Pattern #3 aus `calculation-bug-patterns.md` — bewusst andere
  Perspektive als Drill-Summary, dokumentiert in render-drill.js Z. 116-122).

## Geänderte Dateien

- `public/js/render-drill.js` — Phase A: Mehrbedarf-Skip für `needE`/`needD` (Z. 163-164)
- `tests/05-drill-protocol.test.js` — `renderDrillSummary() nets carryover across tabs (Issue #302, updated for Issue #347)`:
  Erwartungswert korrigiert von `18,6 → 9,0` und `1.400 → 1.000 kg`.
  Begründung: Tab 0 ist Mehrbedarf-Quelle (`istE=21.6 > solE=9`); mit Phase-A-Mehrbedarf-Skip
  trägt er `needE=0` bei statt `9.6`. Test-Kommentar "beides Mehrbedarf-Quellen" war faktisch
  falsch (Tab 1 hat `istE=0 < solE=9`).
- `tests/99-verify-bug-user-3tab-drill-summary.test.js` — **NEU**: 6 Pin-Asserts für das
  exakte User-Szenario aus Issue #347 (Tab 1/2/3).

## Voraussetzung: PR #348 muss gemerged sein

Dieser PR ist explizit als Folge-Bug zu PR #348 markiert. Ohne den Netto-Saldo-Fix
in `computeAllCarryovers()` würde der Phase-A-Mehrbedarf-Skip nicht die korrekten
User-Werte liefern (Phase 2 würde dann den self-excess noch doppelt zählen).

Branch ist auf `origin/fix/347-carryover-netting` rebased (PR #348's HEAD), nicht
auf `origin/dev` — sonst wäre der `tests/05-drill-protocol.test.js:382`-Test im
falschen Spec-Anker (`28,2` vs. `18,6`).

Reviewer-Folge von PR #348 (Bobby9228's REQUEST_CHANGES-Kommentar
[#4817414132](https://github.com/Bobby9228/agrar-rechner/pull/348#issuecomment-4817414132)).

## Test-Status

- **Branch:** 821 Tests grün (3 neue Test-Files, 9 neue Test-Cases)
- **Baseline (PR #348 / `fix/347-carryover-netting`):** 815 Tests grün
- **Delta:** +6 Tests in `tests/99-verify-bug-user-3tab-drill-summary.test.js`,
  +3 Pin-Anpassungen in `tests/05-drill-protocol.test.js`. Keine Regressionen.
- **Lint:** `./node_modules/.bin/eslint public/js/ tests/` → clean (0 errors)

## Closes #347?

Nein — nicht im vollen Sinn. PR #348 hat den **Carryover-Pool-Teil** von #347
geschlossen (Phase 1+2 + Tab-Liste + Inline-Drill). Issue #347 body erwähnt die
**aggregierte Drill-Summary** (`ds_saat_remaining` falsch) als Folge-Symptom,
das **nach** PR #348 noch sichtbar ist. Dieser PR fixt genau diesen Folge-Bug.

Wenn Maintainer beide PRs als "Closes #347" zusammenfassen wollen: gern per
`gh issue close 347 --comment "Fixed via PR #348 + PR #<dieser>"` manuell schließen.

## Was ich NICHT geändert habe

- `computeAllCarryovers()` (PR #348 deckt das ab)
- `renderDrillSummary()` Z. 176-177 (Phase-B-Formel, Spec #302)
- `render-dashboard.js` (bewusst andere Perspektive, dokumentiert)
- KEIN auto-merge — Maintainer entscheidet