### PR TITLE
fix(#347): Drill-Summary aggregiert needE/needD ohne Mehrbedarf-Tabs (v2, rebased on #348)

### DIFF
--- a/public/js/render-drill.js
+++ b/public/js/render-drill.js
@@ -160,8 +160,29 @@
         // global carryover pool; summing across tabs gives the totals the
         // formula needs.
         var cco = AppGlobals.getCarryover(ti);
-        var needE = Math.max(0, tEinheiten - tUsedE);
-        var needD = Math.max(0, tDuenger - tUsedD);
+        // Issue #347 (Folge-Bug zu PR #348): Mehrbedarf-Tabs (istE > solE
+        // bzw. istD > solD) dürfen NICHT als Bedarfsempfänger in needE/needD
+        // zählen. Ihr "Restbedarf" (ist-basis − used) ist konzeptuell
+        // Quellen-Mehraufwand, der bereits durch den Netto-Saldo-Pool in
+        // computeAllCarryovers() (#347) absorbiert wurde. Wenn wir ihn hier
+        // erneut als positiven Bedarf zählen, verdoppelt sich die Cross-Tab-
+        // Aggregations-Formel: totalNeedE enthält dann den Mehrbedarf, und
+        // totalExcessE enthält ihn ebenfalls → remE wird künstlich groß.
+        //
+        // Spec-Anker: Issue #302 definiert "verteilbare_excess_saldi" als
+        // Quellen-Salden, die im Phase-B-Cross-Tab-Pool landen. Bedarfe sind
+        // per Definition "zu wenig" (ist < soll bzw. used < basis). Daher
+        // wird hier analog zu computeAllCarryovers() Phase 1 (hasMehrbedarf-
+        // Skip) jeder Mehrbedarf-Tab als nicht-bedarfs-empfangend markiert.
+        //
+        // NICHT angefasst (Spec #302): Z. 176-177 (Phase-B-Formel
+        // rem = max(0, TotalNeed - TotalSaved + TotalExcess)).
+        var solEForTab = AppGlobals.getTabTotalEinheiten(rt);
+        var solDForTab = AppGlobals.getTabTotalDuenger(rt);
+        var isMehrbedarfE = (tEinheiten > 0 && solEForTab > 0 && tEinheiten > solEForTab);
+        var isMehrbedarfD = (tDuenger > 0 && solDForTab > 0 && tDuenger > solDForTab);
+        var needE = (isMehrbedarfE || tUsedE >= tEinheiten) ? 0 : Math.max(0, tEinheiten - tUsedE);
+        var needD = (isMehrbedarfD || tUsedE >= tDuenger) ? 0 : Math.max(0, tDuenger - tUsedD);
         totalNeedE += needE;
         totalNeedD += needD;
         totalSavedE += cco.savedEinheit;

--- a/tests/05-drill-protocol.test.js
+++ b/tests/05-drill-protocol.test.js
@@ -418,11 +418,32 @@ describe('Drill-Protokoll', () => {
       w.renderResults();
 
       // Phase A + Phase B per Issue #302 spec, MIT Netto-Saldo-Korrektur #347.
-      // TotalNeed_E = (21.6-12) + (9-0) = 9.6 + 9 = 18.6 (kein Tab absorbiert
-      // self-excess, weil beides Mehrbedarf-Quellen sind).
-      expect(doc.getElementById('ds_saat_remaining').textContent).toBe('18,6 Einheiten');
-      // TotalNeed_D = (2400-2000) + (1000-0) = 400 + 1000 = 1400
-      expect(doc.getElementById('ds_duenger_remaining').textContent).toBe('1.400 kg');
+      //
+      // Fix-Reihenfolge:
+      //   PR #348 → Netto-Saldo in computeAllCarryovers(). Self-Absorb-Skip
+      //             verhindert Doppel-Zählung in der Cross-Tab-Formel.
+      //   PR #<dieser> → Folge-Bug: in renderDrillSummary() Phase A zählte
+      //                  Tab 0 (Mehrbedarf-Quelle, istE=21.6 > solE=9) als
+      //                  Bedarfsempfänger mit needE=9.6 (sein Restbedarf auf
+      //                  IST-Fläche). Das ist konzeptuell Quellen-Mehraufwand,
+      //                  nicht "zu wenig". Mit dem Mehrbedarf-Skip für Phase A
+      //                  landet nur der echte Bedarf von Tab 1 (needE=9) im
+      //                  totalNeedE.
+      //
+      // TotalNeed_E = 0 (Tab 0 ist Mehrbedarf → Skip) + (9-0) (Tab 1)
+      //             = 9
+      // TotalSaved_E = 0, TotalExcess_E = 0 (Tab 0 self-excess,
+      //                Phase 2 verteilt 0 dank Self-Absorb-Skip #348).
+      // → remEinheit = max(0, 9 - 0 + 0) = 9
+      //
+      // HINWEIS: Der vorherige Wert "18,6 Einheiten" (PR #348's Update)
+      // entsprach dem ALTEN Phase-A-Verhalten, in dem Tab 0 als
+      // Bedarfsempfänger mit 9.6 E gezählt wurde. Mit der Issue-#347-Folge-
+      // Korrektur (Mehrbedarf-Tabs zählen NICHT als Bedarfsempfänger) ist
+      // 9,0 der korrekte Wert.
+      expect(doc.getElementById('ds_saat_remaining').textContent).toBe('9,0 Einheiten');
+      // TotalNeed_D = 0 (Tab 0 Mehrbedarf) + (1000-0) (Tab 1) = 1000
+      expect(doc.getElementById('ds_duenger_remaining').textContent).toBe('1.000 kg');
 
       // Sanity: total/used are independent of carryover.
       expect(doc.getElementById('ds_saat_total').textContent).toBe('30,6 Einheiten');

--- a/tests/99-verify-bug-user-3tab-drill-summary.test.js
+++ b/tests/99-verify-bug-user-3tab-drill-summary.test.js
@@ -1,0 +1,118 @@
+// Pin-Test für Issue #347 (Folge-Bug zu PR #348)
+//
+// Vorher (PR #348 gefixt, Inline-Drill richtig):
+//   Inline-Drill Tab 3: r_drill_e_rem = "1,0 Einheit" ✓
+//   Carryover-Pool: getCarryover(2) korrekt (savedE=1, alles andere 0) ✓
+//   Drill-Summary (Cross-Tab-Aggregation):
+//     ds_saat_remaining  = "2,0 Einheiten" ✗ (sollte "1,0 Einheit")
+//     ds_duenger_remaining = "500 kg"     ✗ (sollte "400 kg")
+//
+// Nachher (dieser PR):
+//   Drill-Summary aggregiert per-tab needE/needD OHNE Mehrbedarf-Tabs.
+//   Tab 2 ist Mehrbedarf-Quelle (istE=16 > solE=15) → sein Restbedarf
+//   (16 − 11 = 5 E) ist Quellen-Mehraufwand, nicht Bedarf. Mit Skip
+//   ergibt sich totalNeedE = 0 (Tab 1 fertig) + 0 (Tab 2 Mehrbedarf)
+//   + 2 (Tab 3 echter Bedarf) = 2. Phase B: remE = max(0, 2 − 1 + 0) = 1.
+//
+// User-Szenario (Issue #347):
+//   Tab 1: 10→9 ha, used 18E/1800kg → Ersparnis-Quelle (2E, 200kg)
+//   Tab 2: 7.5→8 ha, used 11E/1500kg → Mehrbedarf-Quelle (1E, 100kg)
+//   Tab 3: 5→5 ha, used 8E/500kg   → neutral, eigener Restbedarf 2E/500kg
+// Erwartet (User-Spec):
+//   ds_saat_remaining    = "1,0 Einheit"
+//   ds_duenger_remaining = "400 kg"
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createDom } from './helpers.js';
+
+describe('Issue #347 Folge-Bug: Drill-Summary aggregiert ohne Mehrbedarf-Tabs', () => {
+  let w, AG, doc;
+
+  beforeEach(() => {
+    const result = createDom();
+    w = result.window;
+    AG = w.AppGlobals;
+    doc = w.document;
+  });
+
+  function setup3TabsUserScenario() {
+    AG.state.koernerProEinheit = 50000;
+    AG.state.activeReiter = 2;
+    AG.state.reiter = [
+      { name: 'Tab 1', hektar: 10,  istHektar: 9,   koerner: 100000, duenger: 200,
+        fahrgassenEnabled: false, fahrgassenBreite: 0,
+        entries: [{ einheit: 18, duenger: 1800, time: '08:00' }] },
+      { name: 'Tab 2', hektar: 7.5, istHektar: 8,   koerner: 100000, duenger: 200,
+        fahrgassenEnabled: false, fahrgassenBreite: 0,
+        entries: [{ einheit: 11, duenger: 1500, time: '09:00' }] },
+      { name: 'Tab 3', hektar: 5,   istHektar: 5,   koerner: 100000, duenger: 200,
+        fahrgassenEnabled: false, fahrgassenBreite: 0,
+        entries: [{ einheit: 8,  duenger: 500,  time: '10:00' }] },
+    ];
+    if (AG.invalidateCarryoverCache) AG.invalidateCarryoverCache();
+  }
+
+  it('Drill-Summary: ds_saat_remaining = "1,0 Einheit" (NICHT "2,0 Einheiten")', () => {
+    setup3TabsUserScenario();
+    AG.renderResults();
+    const actual = doc.getElementById('ds_saat_remaining').textContent;
+    expect(actual).toBe('1,0 Einheit');
+  });
+
+  it('Drill-Summary: ds_duenger_remaining = "400 kg" (NICHT "500 kg")', () => {
+    setup3TabsUserScenario();
+    AG.renderResults();
+    const actual = doc.getElementById('ds_duenger_remaining').textContent;
+    expect(actual).toBe('400 kg');
+  });
+
+  it('Per-tab Carryover: Tab 2 (Mehrbedarf-Quelle) bleibt bei savedE=0/savedD=0', () => {
+    // PR #348 pinnt das schon. Hier nur als Sanity-Check, dass die
+    // Voraussetzung für diesen Folge-Bug-Fix gegeben ist.
+    setup3TabsUserScenario();
+    const co2 = AG.getCarryover(1);
+    expect(co2.savedEinheit).toBe(0);
+    expect(co2.savedDuenger).toBe(0);
+  });
+
+  it('Per-tab Carryover: Tab 3 (neutraler Empfänger) bekommt savedE=1, savedD=100', () => {
+    setup3TabsUserScenario();
+    const co3 = AG.getCarryover(2);
+    // Netto-Saldo (PR #348): netSavedE = max(0, 2−1) = 1, netSavedD = max(0, 200−100) = 100.
+    // Phase 1 mit hasMehrbedarf-Skip für Tab 2 → Tab 3 empfängt die vollen 1E / 100kg.
+    expect(co3.savedEinheit).toBeCloseTo(1, 1);
+    expect(co3.savedDuenger).toBeCloseTo(100, 0);
+  });
+
+  it('Inline-Drill Tab 3 bleibt korrekt (r_drill_e_rem = "1,0 Einheit")', () => {
+    // Pattern #3-Check: Inline-Drill (render-results.js) verwendet die
+    // Per-Tab-Formel max(0, basis - used - saved + excess) — diese ist
+    // konsistent mit dem gefixten Cross-Tab-Summary.
+    setup3TabsUserScenario();
+    AG.renderResults();
+    const inlineE = doc.getElementById('r_drill_e_rem');
+    const inlineD = doc.getElementById('r_drill_d_rem');
+    expect(inlineE).toBeTruthy();
+    expect(inlineD).toBeTruthy();
+    expect(inlineE.textContent).toBe('1,0 Einheit');
+    expect(inlineD.textContent).toBe('400 kg');
+  });
+
+  it('Aggregations-Formel: Tab 2 (Mehrbedarf) trägt needE=0/needD=0 bei', () => {
+    // Direkter Pin auf die Code-Stelle render-drill.js Z. 163-164:
+    // Wenn isMehrbedarf=true, wird needE/needD auf 0 gesetzt, NICHT aus
+    // (tEinheiten - tUsedE) berechnet.
+    setup3TabsUserScenario();
+    AG.renderResults();
+    // Wir lesen ds_saat_remaining (Phase B aggregiert). Die richtige
+    // Aggregation setzt voraus, dass Tab 2 mit 0 beigetragen hat.
+    // Wenn das Formel-Delta = 5 (Tab 2's tEinheiten−tUsedE) eingeflossen
+    // wäre, würde ds_saat_remaining = 1 + 5 = 6 stehen (oder ähnliches).
+    const remE = doc.getElementById('ds_saat_remaining').textContent;
+    const remD = doc.getElementById('ds_duenger_remaining').textContent;
+    // Hätten wir Tab 2 als Bedarfsempfänger gezählt, wäre remE irgendwo
+    // zwischen 5 und 7 (abhängig von totalExcessE). 1,0 ist der Fix-Wert.
+    expect(parseFloat(remE.replace(',', '.'))).toBeLessThanOrEqual(2);
+    expect(parseFloat(remD.replace(/\./g, '').replace(' kg', ''))).toBeLessThanOrEqual(500);
+  });
+});


### PR DESCRIPTION
Rebase von #350 nach Merge von #348. Identischer Commit (87b89ac), eine Zeile weniger im Diff weil PR #348 bereits drin.

PR #350 wird geschlossen — der hier ist der Nachfolger mit korrektem Base auf ff305fd.