### PR TITLE
refactor(#9): fmt()/fmtCompact() von main.js nach calculations.js

### DIFF
--- a/public/js/calculations.js
+++ b/public/js/calculations.js
@@ -6,6 +6,29 @@
 // Keine Seiteneffekte, keine DOM-Manipulation.
 // ============================================================================
 
+// --- Format/Parser Utilities (pure) ---
+
+// fmt — Runde auf 1 Dezimalstelle, deutsche Formatierung mit Komma.
+// DE-Rundung: "round half up" — ab .5 wird aufgerundet.
+// Beispiel: 0.05 → '0,1' (nicht '0,0' wie toFixed default).
+// Issue #9: aus main.js hierher verschoben — pure Funktion, gehört zu den
+// Berechnungs-Helfern und macht die AppGlobals-Abhängigkeit explizit.
+function fmt(n) {
+  if (n === null || n === undefined || isNaN(n)) return '0,0';
+  var x = n * 10;
+  var rounded = (x >= 0 ? Math.floor(x + 0.5) : -Math.floor(-x + 0.5)) / 10;
+  return String(rounded.toFixed(1)).replace('.', ',');
+}
+
+// fmtCompact — wie fmt(), aber lässt das nachstehende ",0" für ganze Zahlen weg.
+// Wird im Dashboard verwendet (Tests 26, 40 erwarten "12" statt "12,0").
+// Issue #9: aus main.js hierher verschoben (pure Funktion).
+function fmtCompact(n) {
+  var s = fmt(n);
+  if (s.endsWith(',0')) s = s.slice(0, -2);
+  return s;
+}
+
 // --- Konstanten ---
 
 // Schwelle für "noch etwas vorhanden" (Einheiten / kg).
@@ -492,6 +515,8 @@ function getTabRates(tabIdx) {
 
 // Register exposed globals on AppGlobals (ADR-001 Schritt 3, Issue #278).
 Object.assign(window.AppGlobals, {
+  fmt: fmt,
+  fmtCompact: fmtCompact,
   EPSILON_QUANTITY: EPSILON_QUANTITY,
   _internal: _internal,
   computeFahrgassenFaktor: computeFahrgassenFaktor,

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -11,24 +11,11 @@ var APP_VERSION = 'v1.0.0';
 var APP_BUILD_DATE = 'Mai 2025';
 
 // --- Format/Parser Utilities (used across modules) ---
-
-function fmt(n) {
-  if (n === null || n === undefined || isNaN(n)) return '0,0';
-  // Runde auf 1 Dezimalstelle, deutsche Formatierung mit Komma
-  // DE-Rundung: "round half up" — ab .5 wird aufgerundet.
-  // Beispiel: 0.05 → '0,1' (nicht '0,0' wie toFixed default)
-  var x = n * 10;
-  var rounded = (x >= 0 ? Math.floor(x + 0.5) : -Math.floor(-x + 0.5)) / 10;
-  return String(rounded.toFixed(1)).replace('.', ',');
-}
-
-// fmtCompact — wie fmt(), aber lässt das nachstehende ",0" für ganze Zahlen weg.
-// Wird im Dashboard verwendet (Tests 26, 40 erwarten "12" statt "12,0").
-function fmtCompact(n) {
-  var s = fmt(n);
-  if (s.endsWith(',0')) s = s.slice(0, -2);
-  return s;
-}
+//
+// Issue #9: fmt()/fmtCompact() sind nach calculations.js umgezogen, weil sie
+// pure Funktionen sind und nicht von App-Bootstrap abhängen. parseDE() und
+// formatEinheit() bleiben hier (werden vom Input-Format-Pfad gebraucht, der
+// im App-Init-Block läuft).
 
 // Issue #262: Rückgabe war 'null' für ungültige/leere Eingaben — hat 207 Tests rot
 // gemacht und Null-Werte in den State geschleust. Jetzt wieder 0 mit NaN-Guard.
@@ -169,8 +156,6 @@ Object.assign(window.AppGlobals, {
   APP_BUILD_DATE: APP_BUILD_DATE,
   _stateListeners: _stateListeners,
   _pendingKey: _pendingKey,
-  fmt: fmt,
-  fmtCompact: fmtCompact,
   parseDE: parseDE,
   formatEinheit: formatEinheit,
   appOnStateChange: appOnStateChange,


### PR DESCRIPTION
fmt() und fmtCompact() sind pure Format-Helfer ohne State/DOM-Zugriff. Sie gehören logisch zu den Berechnungs-Helpers in calculations.js, nicht zum App-Bootstrap in main.js. Durch den Umzug wird die AppGlobals-Last-Order-Abhängigkeit explizit: alle anderen Module konnten fmt() bisher nur aufrufen, weil main.js als letztes geladen wurde — jetzt lädt calculations.js (das ohnehin schon vor main.js läuft) die Funktionen direkt.

Changes:
- public/js/calculations.js: fmt() + fmtCompact() hinzugefügt (oben, vor Konstanten), in AppGlobals registriert
- public/js/main.js: Definitionen + AppGlobals-Eintrag entfernt, Kommentar zur Erklärung hinterlassen
- parseDE() und formatEinheit() bleiben in main.js (Input-/Bootstrap-Pfad)

Verification:
- grep 'function fmt' public/js/main.js → 0 hits ✓
- grep 'function fmt' public/js/calculations.js → 2 hits (fmt, fmtCompact) ✓
- 839/839 vitest tests pass ✓
- pnpm lint clean ✓