### PR TITLE
fix(#2): drill NaN + introduce getTabRemaining (Issue 2)

### DIFF
--- a/public/js/calculations.js
+++ b/public/js/calculations.js
@@ -447,6 +447,34 @@ function getCarryover(tabIndex) {
   return { savedEinheit: 0, savedDuenger: 0, excessEinheit: 0, excessDuenger: 0 };
 }
 
+// Issue 2 (Code-Review): DRY-Helper für die "verbleibend"-Formel.
+// Liefert pro Tab die auf Carryover genetteten Restbedarfe (Saatgut + Dünger)
+// sowie Basis + Used, damit Render-Sites die Anzeige konsistent aus einer
+// einzigen Quelle speisen. IST-Fläche hat Vorrang vor SOLL (Issue #186).
+// Nutzt intern getTabUsedEinheiten/getTabUsedDuenger (mit `|| 0` Guards) —
+// das fixt den NaN-Bug in render-drill.js:51+53, wo vorher bare
+// `r.entries.reduce(s + e.einheit, 0)` lief und bei fehlendem `e.einheit`
+// NaN produzierte.
+// NICHT in isTabDone() integrieren (Issue 6 wurde abgelehnt — andere
+// Clamp-Semantik, isTabDone rechnet needE/needD statt max(0, basis-used)).
+function getTabRemaining(r, tabIdx) {
+  var istE = getTabIstEinheiten(r);
+  var istD = getTabIstDuenger(r);
+  var basisE = istE > 0 ? istE : getTabTotalEinheiten(r);
+  var basisD = istD > 0 ? istD : getTabTotalDuenger(r);
+  var usedE  = getTabUsedEinheiten(r);
+  var usedD  = getTabUsedDuenger(r);
+  var co     = getCarryover(tabIdx);
+  return {
+    basisE:     basisE,
+    basisD:     basisD,
+    usedE:      usedE,
+    usedD:      usedD,
+    remainingE: Math.max(0, basisE - usedE - co.savedEinheit + co.excessEinheit),
+    remainingD: Math.max(0, basisD - usedD - co.savedDuenger + co.excessDuenger)
+  };
+}
+
 // --- Tab-Fertig-Check (pure) ---
 
 // Prüft ob ein Tab "fertig" ist (alle Bedarfe gedeckt).
@@ -552,6 +580,7 @@ Object.assign(window.AppGlobals, {
   computeAllCarryovers: computeAllCarryovers,
   invalidateCarryoverCache: invalidateCarryoverCache,
   getCarryover: getCarryover,
+  getTabRemaining: getTabRemaining,
   isTabDone: isTabDone,
   getTabLastEntryTime: getTabLastEntryTime,
   getTabIstHektar: getTabIstHektar,

--- a/public/js/render-dashboard.js
+++ b/public/js/render-dashboard.js
@@ -57,17 +57,17 @@
         if (r.hektar > 0 && r.koerner > 0) {
           var istSum = AppGlobals.getTabIstHektar(r);
           totalHa += istSum > 0 ? istSum : r.hektar;
-          var basisE = istSum > 0 ? AppGlobals.getTabIstEinheiten(r) : AppGlobals.getTabTotalEinheiten(r);
-          var basisD = istSum > 0 ? AppGlobals.getTabIstDuenger(r) : r.hektar * r.duenger;
-          var usedE = r.entries ? r.entries.reduce(function(s, e) { return s + (e.einheit || 0); }, 0) : 0;
-          var usedD = r.entries ? r.entries.reduce(function(s, e) { return s + (e.duenger || 0); }, 0) : 0;
-          var co = AppGlobals.getCarryover(idx);
-          totalEinheitRem += Math.max(0, basisE - usedE - co.savedEinheit + co.excessEinheit);
-          totalDuengerRem += Math.max(0, basisD - usedD - co.savedDuenger + co.excessDuenger);
-          totalEinheitenBasis += basisE;
-          totalEinheitenUsed += usedE;
-          totalDuengerBasis += basisD;
-          totalDuengerUsed += usedD;
+          // Issue 2 (Code-Review): DRY — alle vier "verbleibend"-Sites ziehen
+          // Basis + Used + Carryover aus getTabRemaining. Die `|| 0`-Guards
+          // in getTabUsedEinheiten/Duenger fixen den NaN-Bug, der vorher bei
+          // fehlendem `e.einheit` über die bare reduce here propagiert wurde.
+          var rem = AppGlobals.getTabRemaining(r, idx);
+          totalEinheitRem += rem.remainingE;
+          totalDuengerRem += rem.remainingD;
+          totalEinheitenBasis += rem.basisE;
+          totalEinheitenUsed += rem.usedE;
+          totalDuengerBasis += rem.basisD;
+          totalDuengerUsed += rem.usedD;
         }
       });
       var totalPct = totalEinheitenBasis > 0 || totalDuengerBasis > 0
@@ -163,16 +163,16 @@
         var pct = 0;
         var statusClass = 'na';
         if (r.hektar > 0 && r.koerner > 0) {
-          var istSum = AppGlobals.getTabIstHektar(r);
-          einheiten = istSum > 0 ? AppGlobals.getTabIstEinheiten(r) : AppGlobals.getTabTotalEinheiten(r);
-          usedEinheit = r.entries ? r.entries.reduce(function(s, e) { return s + (e.einheit || 0); }, 0) : 0;
-          duengerTotal = istSum > 0 ? AppGlobals.getTabIstDuenger(r) : r.hektar * r.duenger;
-          usedDuenger = r.entries ? r.entries.reduce(function(s, e) { return s + (e.duenger || 0); }, 0) : 0;
-          // Issue #305: subtract carryover savings / add excess from other tabs.
-          // Per-tab formula matches renderDrillSummary() / #302 / #303.
-          var co = AppGlobals.getCarryover(idx);
-          einheitRem = Math.max(0, einheiten - usedEinheit - co.savedEinheit + co.excessEinheit);
-          duengerRem = Math.max(0, duengerTotal - usedDuenger - co.savedDuenger + co.excessDuenger);
+          // Issue 2 (Code-Review): DRY — getTabRemaining liefert Basis + Used
+          // + Carryover-genettetes Remaining aus einer Quelle (fix #266-A
+          // Konsistenz + NaN-Bug, der durch bare reduce entstand).
+          var rem = AppGlobals.getTabRemaining(r, idx);
+          einheiten = rem.basisE;
+          usedEinheit = rem.usedE;
+          duengerTotal = rem.basisD;
+          usedDuenger = rem.usedD;
+          einheitRem = rem.remainingE;
+          duengerRem = rem.remainingD;
           var minFilled = Math.min(
             einheiten > 0 ? usedEinheit / einheiten : 1,
             duengerTotal > 0 ? usedDuenger / duengerTotal : 1

--- a/public/js/render-drill.js
+++ b/public/js/render-drill.js
@@ -46,14 +46,16 @@
         label.textContent = r.name || ('Tab ' + (i + 1));
         nameWrap.appendChild(label);
         if (r.hektar > 0 && r.koerner > 0) {
-          var istSum = AppGlobals.getTabIstHektar(r);
-          var totalE = istSum > 0 ? AppGlobals.getTabIstEinheiten(r) : AppGlobals.getTabTotalEinheiten(r);
-          var usedE = r.entries.reduce(function(s, e) { return s + e.einheit; }, 0);
-          var totalD = istSum > 0 ? AppGlobals.getTabIstDuenger(r) : AppGlobals.getTabTotalDuenger(r);
-          var usedD = r.entries.reduce(function(s, e) { return s + e.duenger; }, 0);
-          var co = AppGlobals.getCarryover(i);
-          var remaining = Math.max(0, totalE - usedE - co.savedEinheit + co.excessEinheit);
-          var remainingD = Math.max(0, totalD - usedD - co.savedDuenger + co.excessDuenger);
+          // Issue 2 (Code-Review): DRY + NaN-Fix. Die alten bare reduces
+          //   r.entries.reduce(function(s, e) { return s + e.einheit; }, 0)
+          //   r.entries.reduce(function(s, e) { return s + e.duenger; }, 0)
+          // hatten KEIN `|| 0`-Guard und produzierten NaN sobald ein Entry
+          // kein `einheit`/`duenger`-Feld hatte. getTabRemaining zieht
+          // getTabUsedEinheiten/Duenger (mit `|| 0` Guards) und liefert
+          // basisE/D + remainingE/D + carryover-genettet in einem Aufruf.
+          var rem = AppGlobals.getTabRemaining(r, i);
+          var remaining = rem.remainingE;
+          var remainingD = rem.remainingD;
           var statusEl = document.createElement('div');
           statusEl.id = 'dtl_need_' + i;
           statusEl.className = 'drill-tab-need';

--- a/public/js/render-results.js
+++ b/public/js/render-results.js
@@ -172,20 +172,18 @@
       if (rdSection) rdSection.style.display = 'block';
       var usedE = r.entries.reduce(function(s, e) { return s + (e.einheit || 0); }, 0);
       var usedD = r.entries.reduce(function(s, e) { return s + (e.duenger || 0); }, 0);
-      // Issue #320: Konsistenz mit render-dashboard.js:60-61, render-drill.js:50-52,143-144,
-      // und renderResultCard oben (alle nutzen `istHa > 0` ternary). Der `||`-Fallback
-      // war im aktuellen Code funktional identisch (verifiziert per Brute-Force), aber die
-      // explizite Ternary-Form ist robuster gegen künftige Refactorings von getTabIstX()
-      // und macht die Code-Basis einheitlich mit den 4 Geschwister-Sites.
-      var istHa = AppGlobals.getTabIstHektar(r);
-      var istE = istHa > 0 ? AppGlobals.getTabIstEinheiten(r) : AppGlobals.getTabTotalEinheiten(r);
-      var istD = istHa > 0 ? AppGlobals.getTabIstDuenger(r) : AppGlobals.getTabTotalDuenger(r);
-      // Issue #305: subtract carryover savings / add excess from other tabs
-      // so the inline-drill "verbleibend" matches the dashboard + drill summary.
+      // Issue #320: Konsistenz mit render-dashboard.js, render-drill.js und
+      // renderResultCard oben — alle ziehen Basis + Used + Carryover aus
+      // derselben Quelle (getTabRemaining), sodass die "verbleibend"-Sites
+      // konsistent sind.
+      // Issue 2 (Code-Review): DRY — getTabRemaining ersetzt die inline-Formel
+      // (Basis + Used + Carryover-genettet in einem Aufruf). Line 23 oben
+      // (renderResultCard) bleibt unangetastet — sie nutzt getActiveTotalEinheiten
+      // mit anderer Semantik (SOLL-Total statt IST-präferiert).
       var activeIdx = AppGlobals.state.activeReiter || 0;
-      var co = AppGlobals.getCarryover(activeIdx);
-      var remE = Math.max(0, istE - usedE - co.savedEinheit + co.excessEinheit);
-      var remD = Math.max(0, istD - usedD - co.savedDuenger + co.excessDuenger);
+      var rem = AppGlobals.getTabRemaining(r, activeIdx);
+      var remE = rem.remainingE;
+      var remD = rem.remainingD;
       var usedEl = document.getElementById('r_drill_e_used');
       if (usedEl) usedEl.textContent = AppGlobals.formatEinheit(usedE);
       var remEl = document.getElementById('r_drill_e_rem');

--- a/tests/NN-drill-nan-missing-einheit.test.js
+++ b/tests/NN-drill-nan-missing-einheit.test.js
@@ -1,0 +1,84 @@
+// Pin-Test für Issue 2 (Code-Review): render-drill.js:51+53 hatte
+//   r.entries.reduce(function(s, e) { return s + e.einheit; }, 0)
+// OHNE `|| 0` — produziert NaN, sobald ein Entry ohne `e.einheit` existiert.
+//
+// Fix: render-drill.js nutzt jetzt AppGlobals.getTabRemaining(r, i),
+// das intern getTabUsedEinheiten/getTabUsedDuenger (mit `|| 0` Guards) aufruft.
+//
+// Erwartung: kein NaN im Status-Text; "remaining" = (basis - used) für
+// ein realistisches Szenario mit fehlendem `e.einheit`-Feld.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createDom } from './helpers.js';
+
+describe('Issue 2: renderDrillTabList ist NaN-frei bei fehlendem e.einheit', () => {
+  let w, AG, doc;
+
+  beforeEach(() => {
+    const result = createDom();
+    w = result.window;
+    AG = w.AppGlobals;
+    doc = w.document;
+  });
+
+  it('Status-Text enthält kein "NaN" wenn ein Entry kein einheit-Feld hat', () => {
+    // Tab mit zwei Entries — eines davon hat kein `einheit`-Feld.
+    AG.state.koernerProEinheit = 50000;
+    AG.state.reiter = [
+      { name: 'Tab 1', hektar: 10, istHektar: 0, koerner: 100000, duenger: 200,
+        fahrgassenEnabled: false, fahrgassenBreite: 0,
+        entries: [
+          { duenger: 100, time: '08:00' }, // ← kein `einheit`-Feld!
+          { einheit: 5, duenger: 100, time: '09:00' },
+        ] },
+    ];
+    if (AG.invalidateCarryoverCache) AG.invalidateCarryoverCache();
+
+    w.renderDrillTabList();
+
+    var need = doc.getElementById('dtl_need_0');
+    expect(need).toBeTruthy();
+    expect(need.textContent).not.toContain('NaN');
+  });
+
+  it('remaining-Einheiten sind > 0 und finit (nicht NaN) bei fehlendem e.einheit', () => {
+    // getTabRemaining ist AppGlobals-exportiert; liefert obj mit remainingE/remainingD.
+    AG.state.koernerProEinheit = 50000;
+    AG.state.reiter = [
+      { name: 'Tab 1', hektar: 10, istHektar: 0, koerner: 100000, duenger: 200,
+        fahrgassenEnabled: false, fahrgassenBreite: 0,
+        entries: [
+          { duenger: 100, time: '08:00' }, // ← kein `einheit`-Feld!
+        ] },
+    ];
+    if (AG.invalidateCarryoverCache) AG.invalidateCarryoverCache();
+
+    var rem = AG.getTabRemaining(AG.state.reiter[0], 0);
+    expect(Number.isFinite(rem.remainingE)).toBe(true);
+    expect(Number.isFinite(rem.remainingD)).toBe(true);
+    expect(rem.remainingE).toBeGreaterThan(0);
+  });
+
+  it('AppGlobals.getTabRemaining existiert', () => {
+    expect(typeof AG.getTabRemaining).toBe('function');
+  });
+
+  it('inline-drill in renderDrillEntriesInline ist NaN-frei bei fehlendem e.einheit', () => {
+    AG.state.koernerProEinheit = 50000;
+    AG.state.activeReiter = 0;
+    AG.state.reiter = [
+      { name: 'Tab 1', hektar: 10, istHektar: 0, koerner: 100000, duenger: 200,
+        fahrgassenEnabled: false, fahrgassenBreite: 0,
+        entries: [
+          { duenger: 100, time: '08:00' }, // ← kein `einheit`-Feld!
+          { einheit: 5, duenger: 100, time: '09:00' },
+        ] },
+    ];
+    if (AG.invalidateCarryoverCache) AG.invalidateCarryoverCache();
+
+    w.renderDrillEntriesInline();
+    var remEl = doc.getElementById('r_drill_e_rem');
+    expect(remEl).toBeTruthy();
+    expect(remEl.textContent).not.toContain('NaN');
+  });
+});


### PR DESCRIPTION
Issue 2 (Code-Review). Two problems:

1. **NaN bug** in render-drill.js:51+53 — bare `r.entries.reduce(s + e.einheit, 0)` without `|| 0` produced NaN when an entry lacked `e.einheit`.
2. **Formula duplication** — the `Math.max(0, basis - used - co.saved + co.excess)` formula was duplicated 4× across render files.

**Fix:** introduced `getTabRemaining(r, tabIdx)` in calculations.js returning `{ basisE, basisD, usedE, usedD, remainingE, remainingD }`. Uses `getTabUsedEinheiten/Duenger` internally — the `|| 0` guards fix the NaN bug. Exported via AppGlobals. 4 render sites now call it.

**isTabDone is NOT touched** — Issue 6 was REJECTED for different clamp semantics. `renderResultCard` (line 23, `getActiveTotalEinheiten` semantics) is also intentionally untouched.

**Tests:** `tests/NN-drill-nan-missing-einheit.test.js` (4 tests) — RED first (helper missing), then GREEN. 843/843 full suite pass. eslint clean.

**Verify:**
- `grep -n 'function getTabRemaining' public/js/calculations.js` → 1 hit
- `grep -rn 'AppGlobals.getTabRemaining' public/js/` → 4 hits (4 call sites + 1 export)
- `grep -n 'return s + e.einheit' public/js/render-drill.js` → 0 hits (the bare reduce is gone)

Fixes Issue 2 from code-review.