### PR TITLE
refactor(#7): consolidate getTotalDuenger/getTotalEinheiten into getTabTotal* canonicals

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,10 +167,10 @@ function berechne() {
 |---|---|
 | `getKornerGesamt()` | Körner gesamt für aktiven Tab (berücksichtigt Fahrgassen) |
 | `getTabKornerGesamt(r)` | Körner gesamt für Tab `r` (berücksichtigt Fahrgassen) |
-| `getTotalEinheiten()` | Einheiten gesamt für aktiven Tab |
-| `getTabTotalEinheiten(r)` | Einheiten für Tab `r` |
-| `getTotalDuenger()` | Dünger gesamt für aktiven Tab |
-| `getTabTotalDuenger(r)` | Dünger für Tab `r` |
+| `getTotalEinheiten()` | Einheiten gesamt für aktiven Tab (Convenience-Wrapper, delegiert an `getTabTotalEinheiten(activeReiter())`) |
+| `getTabTotalEinheiten(r)` | Einheiten für Tab `r` (kanonische SOLL-Berechnung) |
+| `getTotalDuenger()` | Dünger gesamt für aktiven Tab (Convenience-Wrapper, delegiert an `getTabTotalDuenger(activeReiter())`) |
+| `getTabTotalDuenger(r)` | Dünger für Tab `r` (kanonische SOLL-Berechnung) |
 | `getTabIstHektar(r)` | IST-Fläche von Tab `r` (direkter Wert, nicht aus Entries abgeleitet) |
 | `getTabIstEinheiten(r)` | Einheiten basierend auf IST-Fläche (wenn vorhanden) |
 | `getTabIstDuenger(r)` | Dünger basierend auf IST-Fläche |

--- a/public/js/calculations.js
+++ b/public/js/calculations.js
@@ -73,7 +73,7 @@ function getTabFahrgassenFaktor(r) {
 
 // --- Einheiten-Berechnung (SOLL) ---
 
-// Berechnet die Anzahl Einheiten für ein gegebenes Feld.
+// Berechnet die Anzahl Einheiten für ein gegebenes Feld (SOLL).
 // Berücksichtigt: Körner/ha, Körner/Einheit, Hektar, Fahrgassen-Korrektur.
 //
 // Formel:
@@ -81,20 +81,22 @@ function getTabFahrgassenFaktor(r) {
 //   einheiten × computeFahrgassenFaktor(breite)  falls fahrgassenEnabled
 //
 // Argumente:
-//   r           — Tab-Objekt mit hektar, koerner, fahrgassenEnabled, fahrgassenBreite, etc.
-//   koernerProEinheit — Körner pro Einheit (Standard: 50000)
+//   r                  — Tab-Objekt mit hektar, koerner, fahrgassenEnabled, fahrgassenBreite, etc.
+//   koernerProEinheit  — Körner pro Einheit (Standard: state.koernerProEinheit)
 //
 // Rückgabe: number (Einheiten, immer ≥ 0)
-function getTotalEinheiten(r, koernerProEinheit) {
-  if (!r || !r.hektar || !r.koerner || koernerProEinheit <= 0) return 0;
+//
+// Issue #7: Konsolidierung — dies ist jetzt die *einzige* kanonische Berechnung
+// für SOLL-Einheiten. Vorher gab es zwei redundante Funktionen
+// (getTotalEinheiten + getTabTotalEinheiten), die jeweils die gleiche Logik
+// ausführten. ui-handlers.js exportiert weiterhin getTotalEinheiten() als
+// No-arg-Kompatibilitäts-Wrapper, der an die aktive Reiter delegiert.
+function getTabTotalEinheiten(r, koernerProEinheit) {
+  var kpe = (koernerProEinheit !== undefined) ? koernerProEinheit : AppGlobals.state.koernerProEinheit;
+  if (!r || !r.hektar || !r.koerner || kpe <= 0) return 0;
   var faktor = getTabFahrgassenFaktor(r);
-  var einheiten = (r.hektar * r.koerner) / koernerProEinheit;
+  var einheiten = (r.hektar * r.koerner) / kpe;
   return Math.max(0, einheiten * faktor);
-}
-
-// Berechnet die Gesamteinheiten für ein Tab-Objekt (SOLL), mit globalen Einstellungen.
-function getTabTotalEinheiten(r) {
-  return getTotalEinheiten(r, AppGlobals.state.koernerProEinheit);
 }
 
 // Berechnet die IST-Einheiten basierend auf der IST-Fläche.
@@ -108,19 +110,21 @@ function getTabIstEinheiten(r) {
 
 // --- Dünger-Berechnung (SOLL) ---
 
-// Berechnet Düngermenge in kg (kg/ha × ha = kg).
+// Berechnet Düngermenge in kg (kg/ha × ha = kg) für ein Tab-Objekt (SOLL).
 // Formel: r.hektar * r.duenger
+//
 // Issue #191: Vorherige Version dividierte fälschlich durch 50
 // (aus der "1 Einheit = 50 kg" Annahme), was zu 50× zu kleinen kg-Werten
 // im SOLL-Pfad führte. Aufrufer hängen ' kg' an den Wert — die Funktion
 // muss kg liefern. Konsistent mit getTabIstDuenger (PR #190).
-function getTotalDuenger(r) {
+//
+// Issue #7: Konsolidierung — dies ist jetzt die *einzige* kanonische Berechnung
+// für SOLL-Dünger. Vorher gab es getTotalDuenger + getTabTotalDuenger als
+// triviale Wrapper-Duplikate (letztere rief nur erstere auf). ui-handlers.js
+// exportiert weiterhin getTotalDuenger() als No-arg-Kompatibilitäts-Wrapper.
+function getTabTotalDuenger(r) {
   if (!r || !r.hektar || !r.duenger) return 0;
   return Math.max(0, r.hektar * r.duenger);
-}
-
-function getTabTotalDuenger(r) {
-  return getTotalDuenger(r);
 }
 
 // Dünger (kg) pro Einheit Saatgut für einen Tab.
@@ -540,10 +544,8 @@ Object.assign(window.AppGlobals, {
   EPSILON_QUANTITY: EPSILON_QUANTITY,
   _internal: _internal,
   computeFahrgassenFaktor: computeFahrgassenFaktor,
-  getTotalEinheiten: getTotalEinheiten,
   getTabTotalEinheiten: getTabTotalEinheiten,
   getTabIstEinheiten: getTabIstEinheiten,
-  getTotalDuenger: getTotalDuenger,
   getTabTotalDuenger: getTabTotalDuenger,
   getDuengerProEinheit: getDuengerProEinheit,
   getTabIstDuenger: getTabIstDuenger,

--- a/public/js/ui-handlers.js
+++ b/public/js/ui-handlers.js
@@ -706,10 +706,10 @@
       var usedEinheit = entries.reduce(function(s, e) { return s + (e.einheit || 0); }, 0);
       var usedDuenger = entries.reduce(function(s, e) { return s + (e.duenger || 0); }, 0);
       if (entries.length > 0) {
-        // Use the calculations.js versions (with state.koernerProEinheit as default)
-        // so the arg-overridden wrapper in this file doesn't return NaN when called
-        // with only `r`. See getTotalEinheiten at L697 (arg version) and L52 in
-        // calculations.js (the canonical impl).
+        // Use the calculations.js canonical functions so the result matches the
+        // values displayed in the result card. Issue #7: calculations.js now
+        // exposes only getTabTotalEinheiten / getTabTotalDuenger (the previous
+        // getTotalEinheiten/getTotalDuenger names were absorbed into them).
         var newEinheiten = AppGlobals.getTabTotalEinheiten(r);
         var newDuenger = AppGlobals.getTabTotalDuenger(r);
         var einheitExceeds = newEinheiten > 0 && usedEinheit > newEinheiten + AppGlobals.EPSILON_QUANTITY;
@@ -771,11 +771,10 @@
       return AppGlobals.getTabKornerGesamt(AppGlobals.getActiveReiter());
     }
 
-    // Issue #186: Diese Wrapper schließen die Lücke zwischen calculations.js
-    // (das nur getTabTotalEinheiten(r) etc. exportiert) und render-results.js
-    // (das getTotalEinheiten() ohne Argument aufruft).
-    // WICHTIG: Andere Namen als in calculations.js, um die Funktion
-    // getTotalEinheiten(r, koernerProEinheit) dort nicht zu überschreiben.
+    // Issue #186: Convenience-Wrapper für aktiven Reiter.
+    // delegieren an AppGlobals.getTabTotalEinheiten(r) / getTabTotalDuenger(r)
+    // (Issue #7 — getTabTotalEinheiten/getTabTotalDuenger sind seit dem
+    // Issue-7-Refactor die kanonischen Funktionen in calculations.js).
     function getActiveTotalEinheiten() {
       return AppGlobals.getTabTotalEinheiten(AppGlobals.getActiveReiter());
     }
@@ -787,38 +786,26 @@
     // No-arg API-Kompatibilitäts-Wrapper (Issue #266).
     //
     // Tests rufen getTotalEinheiten() bzw. getTotalDuenger() ohne Argumente
-    // auf. calculations.js exportiert diese Namen mit Argument-Signaturen.
+    // auf. calculations.js exportiert diese Namen nicht mehr direkt
+    // (Issue #7 — Konsolidierung auf getTabTotalEinheiten/getTabTotalDuenger).
     // Da ui-handlers.js NACH calculations.js geladen wird, gewinnen die
     // Wrapper im globalen Scope. Mittels arguments.length wird zwischen
     // Argument- und No-Arg-Aufruf dispatcht.
     //
-    // Die arg-Versionen bleiben über getTabTotalEinheiten(r) / getTabTotalDuenger(r)
-    // für interne Berechnungen verfügbar (anderer Name → kein Konflikt).
-    //
-    // no-arg: rechnet gegen state.koernerProEinheit (der Default 50000,
-    // oder Custom via einheitGroesseUpdate).
+    // No-arg: rechnet gegen state.koernerProEinheit für aktiven Reiter.
+    // Arg-Version: delegiert an calculations.js-Kanone (mit optionalem
+    // kpe-Override für Tests, die explizit einen Wert mitgeben).
     function getTotalEinheiten(r, koernerProEinheit) {
       if (arguments.length === 0) {
-        // No-arg: für aktiven Reiter berechnen
         return AppGlobals.getActiveTotalEinheiten();
       }
-      // Arg-Version: calculations.js-Original (Issue #230)
-      if (!r || !r.hektar || !r.koerner || koernerProEinheit <= 0) return 0;
-      var fgEnabled = (r.fahrgassenEnabled !== undefined) ? r.fahrgassenEnabled : AppGlobals.state.fahrgassenEnabled;
-      var fgBreite = (r.fahrgassenBreite !== undefined) ? r.fahrgassenBreite : AppGlobals.state.fahrgassenBreite;
-      var faktor = 1;
-      if (fgEnabled && fgBreite > 0) {
-        faktor = AppGlobals.computeFahrgassenFaktor(fgBreite);
-      }
-      var e = (r.hektar * r.koerner) / koernerProEinheit;
-      return Math.max(0, e * faktor);
+      return AppGlobals.getTabTotalEinheiten(r, koernerProEinheit);
     }
     function getTotalDuenger(r) {
       if (arguments.length === 0) {
         return AppGlobals.getActiveTotalDuenger();
       }
-      if (!r || !r.hektar || !r.duenger) return 0;
-      return Math.max(0, r.hektar * r.duenger);
+      return AppGlobals.getTabTotalDuenger(r);
     }
 
     // --- Input Formatierung (portiert aus Inline-Code Z. 2438-2546) ---


### PR DESCRIPTION
## Summary

Issue 7 from the code review flagged `getTotalDuenger` / `getTabTotalDuenger` as redundant (the latter was a trivial wrapper calling the former). The same pattern existed symmetrically for Einheiten.

Fold both pairs into a single canonical function per material in `calculations.js`:

- `getTabTotalEinheiten(r, koernerProEinheit?)` — reads `state.koernerProEinheit` by default
- `getTabTotalDuenger(r)`

`getTotalEinheiten` / `getTotalDuenger` are kept as global polyfills owned by `ui-handlers.js`. They now **delegate** to the canonical functions instead of duplicating the calculation inline. The arg-version with explicit kpe (used by tests/41, tests/42) is preserved via the optional second parameter.

## T6 Audit Clearance

T6 (`t_5b13c234`) gave a clean **GO** verdict:
> Issue 7 (wrapper consolidation): GO — zero test changes needed if consolidating to one canonical definition.

## Verify

- `grep 'function getTotalDuenger' public/js/calculations.js` → 0 hits
- `grep 'function getTotalEinheiten' public/js/calculations.js` → 0 hits
- 839/839 tests green
- eslint clean

## Files

| File | Change |
|---|---|
| `public/js/calculations.js` | Rename `getTotal*` → `getTabTotal*`; inline the wrappers; drop redundant exports |
| `public/js/ui-handlers.js` | Polyfills delegate to canonical; outdated comments updated |
| `README.md` | Doc table clarified (`getTotal*` are convenience wrappers, `getTabTotal*` are canonical) |

## Diff stat

```
README.md                 |  8 +++---
public/js/calculations.js | 40 +++++++++++--------
public/js/ui-handlers.js  | 43 +++++----------------
3 files changed, 40 insertions(+), 51 deletions(-)
```