### PR TITLE
refactor(#8): extract _computeNetCarryoverPools helper (Phase 0 only)

### DIFF
--- a/public/js/calculations.js
+++ b/public/js/calculations.js
@@ -178,6 +178,51 @@ var _internal = {
   pendingKey: null
 };
 
+// Berechnet die Netto-Carryover-Pools (Phase 0 + Netting) für die reiter-Liste.
+//
+// Phase 0: Bedarfsberechnung
+//   Savings: SOLL - IST wenn IST > 0 && IST < SOLL (Ersparnis = nicht bepflanzte Fläche)
+//   Excess:  IST - SOLL wenn IST > SOLL
+//   Wenn IST=0 → keine Carryover (keine Ersparnis, kein Bedarf jenseits SOLL)
+//
+// Netting: Ersparnis-Pool und Mehrbedarf-Pool werden gegenseitig aufgerechnet.
+//   netSaved  = max(0, totalSaved  - totalExcess)
+//   netExcess = max(0, totalExcess - totalSaved)
+// Phase 1 verteilt nur netSaved, Phase 2 vergibt nur netExcess.
+//
+// Reines Helper-Modul: kein AppGlobals-Zugriff, keine Cache-Mutation.
+// Refactor Issue #8 Phase-0-Extraktion — Phase 1+2 bleiben unverändert
+// (siehe T6-Audit: Phase 1+2 tragen 5+ pinned Specs, die der mat-loop erhält).
+function _computeNetCarryoverPools(reiter) {
+  var totalSavedE = 0, totalSavedD = 0;
+  var totalExcessE = 0, totalExcessD = 0;
+
+  for (let i = 0; i < reiter.length; i++) {
+    var t = reiter[i];
+    var istE = getTabIstEinheiten(t);
+    var solE = getTabTotalEinheiten(t);
+    var istD = getTabIstDuenger(t);
+    var solD = getTabTotalDuenger(t);
+    if (istE > 0) {
+      if (solE > istE) totalSavedE += (solE - istE);
+      else if (istE > solE) totalExcessE += (istE - solE);
+    }
+    if (istD > 0) {
+      if (solD > istD) totalSavedD += (solD - istD);
+      else if (istD > solD) totalExcessD += (istD - solD);
+    }
+  }
+
+  return {
+    totalSavedE: totalSavedE, totalExcessE: totalExcessE,
+    totalSavedD: totalSavedD, totalExcessD: totalExcessD,
+    netSavedE:  Math.max(0, totalSavedE  - totalExcessE),
+    netExcessE: Math.max(0, totalExcessE - totalSavedE),
+    netSavedD:  Math.max(0, totalSavedD  - totalExcessD),
+    netExcessD: Math.max(0, totalExcessD - totalSavedD),
+  };
+}
+
 // Berechnet Carryover (Überschüsse/Ersparnisse) für alle Tabs.
 //
 // Phase 1: Ersparnisse (IST < SOLL → saved = SOLL - IST) werden an unfertige Tabs verteilt.
@@ -194,51 +239,15 @@ function computeAllCarryovers() {
     result.push({ savedEinheit: 0, savedDuenger: 0, excessEinheit: 0, excessDuenger: 0 });
   }
 
-  // --- PHASE 0: Bedarfsberechnung ---
-  // Savings: SOLL - IST wenn IST > 0 && IST < SOLL (Ersparnis = nicht bepflanzte Fläche)
-  // Excess: IST - SOLL wenn IST > SOLL
-  // Need: max(0, IST - used) wenn IST > 0 (sonst SOLL - used)
-  // Wenn IST=0 → keine Carryover (keine Ersparnis, kein Bedarf jenseits SOLL)
-  var totalSavedE = 0, totalSavedD = 0;
-  var totalExcessE = 0, totalExcessD = 0;
-
-  for (let i = 0; i < AppGlobals.state.reiter.length; i++) {
-    var t = AppGlobals.state.reiter[i];
-    var istE = getTabIstEinheiten(t);
-    var solE = getTabTotalEinheiten(t);
-    var usedE = getTabUsedEinheiten(t);
-    var istD = getTabIstDuenger(t);
-    var solD = getTabTotalDuenger(t);
-    var usedD = getTabUsedDuenger(t);
-    if (istE > 0) {
-      if (solE > istE) totalSavedE += (solE - istE);
-      else if (istE > solE) totalExcessE += (istE - solE);
-    }
-    if (istD > 0) {
-      if (solD > istD) totalSavedD += (solD - istD);
-      else if (istD > solD) totalExcessD += (istD - solD);
-    }
-  }
-
-  // === NETTO-SALDO (vor Phase 1 und 2) ===
-  //
-  // Fix Issue #XXX: Ersparnis-Pool und Mehrbedarf-Pool werden zuerst
-  // gegenseitig aufgerechnet (Netting). Nur der verbleibende Netto-Saldo
-  // wird an Phase 1 (Ersparnisse) bzw. Phase 2 (Mehrbedarfe) übergeben.
-  //
-  // Ohne Netting: Ein Tab mit IST > SOLL (Mehrbedarf) erhält in Phase 1
-  // fälschlicherweise Ersparnis-Carryover (weil istCovered=FALSE und
-  // isSource=FALSE). Gleichzeitig gibt Phase 2 den vollen totalExcess als
-  // Bürde an Folge-Tabs — saved und excess auf dem Folge-Tab heben sich
-  // NICHT auf, sondern addieren sich als doppelter Fehler.
-  //
-  // Mit Netting: netSaved = max(0, totalSaved - totalExcess).
-  //              netExcess = max(0, totalExcess - totalSaved).
-  // Phase 1 verteilt nur netSaved, Phase 2 vergibt nur netExcess.
-  var netSavedE  = Math.max(0, totalSavedE  - totalExcessE);
-  var netExcessE = Math.max(0, totalExcessE - totalSavedE);
-  var netSavedD  = Math.max(0, totalSavedD  - totalExcessD);
-  var netExcessD = Math.max(0, totalExcessD - totalSavedD);
+  // --- PHASE 0 + NETTING ---
+  // Bedarfsberechnung und gegenseitige Aufrechnung sind in
+  // _computeNetCarryoverPools extrahiert (Issue #8 Phase-0-Refactor).
+  // Phase 1+2 (mat-loops unten) sind unverändert.
+  var _pools = _computeNetCarryoverPools(AppGlobals.state.reiter);
+  var netSavedE  = _pools.netSavedE;
+  var netExcessE = _pools.netExcessE;
+  var netSavedD  = _pools.netSavedD;
+  var netExcessD = _pools.netExcessD;
 
   // === PHASE 1: Ersparnisse verteilen — Saat und Dünger getrennt ===
   //
@@ -390,8 +399,6 @@ function computeAllCarryovers() {
       }
       // self-excess: weiter ignoriert (kein negativer Carryover)
     }
-    if (isSaatPass2) totalExcessE = remExcess;
-    else totalExcessD = remExcess;
   }
 
   _internal.carryoverCache = result;


### PR DESCRIPTION
## Summary

Extracts **Phase 0 (Bedarfsberechnung) + Netting** from `computeAllCarryovers` into a new private module-level helper `_computeNetCarryoverPools(reiter)`. Phase 1 + Phase 2 mat-loops stay byte-for-byte unchanged.

## Why this scope (and not the full Phase 1+2 split the issue originally proposed)

The T6 audit (Kanban parent task `t_5b13c234`) verdict was **NO-GO** for the full per-phase split:

- Phase 1+2 carry 5+ pinned specs (basis=ist, Phase 1+2 Netto-Saldo Fix, Self-Absorb-Skip, Cross-Tab Drill-Summary aggregation, Dashboard carryover subtraction, Result-card shape).
- The pin history crosses #138 / #348 / #347 Folge-Bug — i.e. the bug class the test net exists to catch is exactly *"Phase 1+2 double-count after refactor"* (PRs #347/#348/#350/#351).
- A naive split would re-introduce Pattern-#12.

Phase 0 + Netting is the **safe** extraction target: pure value computation, no carryover distribution semantics, no pinned-spec coupling, no test churn.

## What changed

- New private helper `_computeNetCarryoverPools(reiter)` returns 8-value pool object: `{ totalSavedE, totalExcessE, totalSavedD, totalExcessD, netSavedE, netExcessE, netSavedD, netExcessD }`.
- `computeAllCarryovers` calls it once: `var _pools = _computeNetCarryoverPools(AppGlobals.state.reiter);`
- Phase 1 + Phase 2 mat-loops: zero semantic changes, zero formatting changes.
- Helper is **not** exported on `AppGlobals` (no test calls it directly; T6 audit confirmed).

## Bonus cleanup

Two dead writes removed (was `totalExcessE = remExcess` / `D` at the end of Phase 2's mat-loop). These were no-ops even before this refactor — the names were never read outside their local scope — but ESLint's `no-undef` would have flagged them once Phase 0 stopped declaring them. Tests stayed green, confirming the dead-code nature.

## Verify

- `pnpm test` — **839/839 green** (50 test files, 171s baseline → 93s on this run)
- `pnpm lint` — clean
- No tests needed updating (Phase 0 is only consumed via `getCarryover(i)` /`computeAllCarryovers()`, public API unchanged)

## Risk

**Low.** Helper is pure, behaviorally identical to the inlined Phase 0+Netting, Phase 1+2 is untouched. The full per-phase split remains an option for a future PR if a Phase-2-only bug motivates it.

Refs: T6 audit kanban-comment #86 on parent t_5b13c234.