### PR TITLE
fix(ci): remove broken deploy step, rely on CF Dashboard Git integration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy to Cloudflare Pages
+name: CI
 
 on:
   push:
@@ -10,11 +10,11 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: deploy-${{ github.ref }}
+  group: ci-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  test-and-deploy:
+  lint-and-test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -23,8 +23,6 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          # Wrangler 4.x requires Node ≥ 22. The runner default has already
-          # moved off Node 20 (deprecated 2025-09); align with it.
           node-version: '22'
 
       - name: Install pnpm
@@ -41,17 +39,9 @@ jobs:
       - name: Run tests
         run: pnpm test
 
-      - name: Deploy to Cloudflare Workers (Static Assets)
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          # Pin Wrangler ≥ 4 — the action's default 3.90.0 rejects assets-only
-          # workers ("Missing entry-point"), while 4.x deploys them cleanly.
-          wranglerVersion: "4"
-          # Repo deploys via Cloudflare Workers Static Assets (see wrangler.jsonc:
-          # name="agrar-rechner-dev", assets.directory="./public"). `wrangler deploy`
-          # reads the binding from wrangler.jsonc — no --project-name needed.
-          # The previous `wrangler pages deploy public/ --project-name=agrar-rechner-dev`
-          # failed with code 8000007 because no Pages project by that name exists.
-          command: deploy
+# Deploy is handled by Cloudflare Dashboard Git integration
+# (Workers Builds for agrar-rechner-dev). The previous wrangler-action
+# deploy step failed with "Authentication error [code: 10000]" because
+# the CLOUDFLARE_API_TOKEN secret lacks Account:Read scope. Since the
+# Dashboard integration already deploys successfully on every push to dev,
+# the GitHub Actions deploy step is redundant and has been removed.


### PR DESCRIPTION
## Problem

The wrangler-action deploy step has failed with `Authentication error [code: 10000]` on **every PR since #345**. Five code-level fix attempts (#345, #349, #352, etc.) all failed because the root cause is the `CLOUDFLARE_API_TOKEN` secret missing `Account:Read` scope — a Cloudflare Dashboard config issue, not a code bug.

## Solution

Remove the deploy step entirely. The **Cloudflare Dashboard Git integration** ("Workers Builds" for `agrar-rechner-dev`) already deploys successfully on every push to dev — visible as the green check on every recent PR. The GitHub Actions deploy step was redundant and only produced a false-red status.

## Changes

- Workflow name: `Deploy to Cloudflare Pages` → `CI`
- Job name: `test-and-deploy` → `lint-and-test`
- Concurrency group: `deploy-*` → `ci-*`
- Removed: `Deploy to Cloudflare Workers (Static Assets)` step (wrangler-action@v3)
- Kept: checkout, lint, test (CI gate unchanged)

## Verification

- `pnpm test` + `pnpm lint` still run as the CI gate
- CF Dashboard Workers Builds continue to deploy on dev push (no change to that integration)
- Resolves the perpetual false-red CI status on every PR