### PR TITLE
chore: CACHE_VERSION v32 → v33 (refactor batch #353-#361)

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // ⚠️ CACHE_VERSION muss bei jedem Release manuell gebumpet werden!
 // Bei Vergessen bekommen Nutzer die alte Version aus dem Cache.
 // alternativa: Build-Script das Hash/Zeitstempel injiziert.
-const CACHE_VERSION = 'agrar-rechner-v32';
+const CACHE_VERSION = 'agrar-rechner-v33';
 const STATIC_ASSETS = [
     '/',
     '/index.html',


### PR DESCRIPTION
## What

Bumps `CACHE_VERSION` from `v32` → `v33` in `public/sw.js`. Single-line change.

## Why

The refactor batch (Issues 1-10 from code-review, minus rejected Issue 6) landed via PRs #353-#361 on dev, but none bumped the Service Worker cache version. Existing users with a cached SW will keep getting the old `v32` code served from cache — they will not see the refactored code.

This bump invalidates the SW cache so existing users pick up:
- #353 `fmt()`/`fmtCompact()` → calculations.js (Issue 9)
- #354 `getTabFahrgassenFaktor` helper (Issue 4)
- #355 `parseEntryTime`/`formatEntryTime` module-level (Issue 5)
- #357 drill NaN fix + `getTabRemaining` (Issue 2, also fixes Issue 1 dashboard null-guard)
- #359 `getTotalDuenger`/`Einheiten` consolidation (Issue 7)
- #360 `_computeNetCarryoverPools` Phase 0 extraction (Issue 8 partial)
- #361 comment inflation thinning (Issue 10)

## Behavior change

None. All refactors are behavior-preserving. The only user-visible effect is the Issue 1+2 bugfix (NaN guard when `duenger` is undefined, dashboard now consistent with drill/results).

## Verification

- [x] `sw.js` changed only in the version string
- [x] No other files touched
- [x] `tests/37-deploy-sanity.test.js` asserts version string is present + non-empty (should stay green)