### PR TITLE
fix(#335): Netting-Coverage fließt in Mehrbedarf-Tab 'verbleibend' zurück

### DIFF
--- a/public/js/calculations.js
+++ b/public/js/calculations.js
@@ -154,7 +154,7 @@ function computeAllCarryovers() {
 
   var result = [];
   for (let i = 0; i < AppGlobals.state.reiter.length; i++) {
-    result.push({ savedEinheit: 0, savedDuenger: 0, excessEinheit: 0, excessDuenger: 0 });
+    result.push({ savedEinheit: 0, savedDuenger: 0, excessEinheit: 0, excessDuenger: 0, nettedEinheit: 0, nettedDuenger: 0 });
   }
 
   // --- PHASE 0 + NETTING ---
@@ -163,6 +163,42 @@ function computeAllCarryovers() {
   var netExcessE = _pools.netExcessE;
   var netSavedD  = _pools.netSavedD;
   var netExcessD = _pools.netExcessD;
+
+  // === PHASE 0.5: Netting-Coverage auf Mehrbedarf-Tabs zurückfließen lassen ===
+  //
+  // Ohne diesen Schritt bleibt getCarryover(MehrbedarfTab) = {0,0,0,0} und
+  // getTabRemaining zeigt rohen Mehrbedarf, obwohl das Netting den Bedarf
+  // global bereits abgedeckt hat. Pro-rata Verteilung: jeder Mehrbedarf-Tab
+  // erhält so viel Coverage wie möglich (bis zu seinem eigenen Mehrbedarf).
+  // Coverage-Pool = min(totalExcess, totalSaved) = der Anteil, der von
+  // Ersparnissen absorbiert wird. Pro-rata: coverageRatio = Pool / totalExcess.
+  // Edge: totalSaved == totalExcess → Pool = totalExcess → ratio = 1 → alle
+  // Mehrbedarf-Tabs voll abgedeckt (auch wenn netSaved=0).
+  {
+    var moreE = [], excE = 0;
+    var moreD = [], excD = 0;
+    for (let i = 0; i < AppGlobals.state.reiter.length; i++) {
+      var mt = AppGlobals.state.reiter[i];
+      var mistE = getTabIstEinheiten(mt);
+      var msolE = getTabTotalEinheiten(mt);
+      var mistD = getTabIstDuenger(mt);
+      var msolD = getTabTotalDuenger(mt);
+      if (mistE > 0 && mistE > msolE) { moreE.push(i); excE += (mistE - msolE); }
+      if (mistD > 0 && mistD > msolD) { moreD.push(i); excD += (mistD - msolD); }
+    }
+    var poolE = excE - netExcessE; // = min(totalSavedE, totalExcessE) — der Anteil, der bereits abgedeckt ist
+    var poolD = excD - netExcessD;
+    var ratioE = excE > 0 ? Math.min(1, Math.max(0, poolE) / excE) : 0;
+    var ratioD = excD > 0 ? Math.min(1, Math.max(0, poolD) / excD) : 0;
+    for (let k = 0; k < moreE.length; k++) {
+      var mt2 = AppGlobals.state.reiter[moreE[k]];
+      result[moreE[k]].nettedEinheit = (getTabIstEinheiten(mt2) - getTabTotalEinheiten(mt2)) * ratioE;
+    }
+    for (let k = 0; k < moreD.length; k++) {
+      var mt3 = AppGlobals.state.reiter[moreD[k]];
+      result[moreD[k]].nettedDuenger = (getTabIstDuenger(mt3) - getTabTotalDuenger(mt3)) * ratioD;
+    }
+  }
 
   // === PHASE 1: Ersparnisse verteilen — Saat und Dünger getrennt ===
   //
@@ -329,12 +365,14 @@ function invalidateCarryoverCache() {
 function getCarryover(tabIndex) {
   var all = computeAllCarryovers();
   if (tabIndex >= 0 && tabIndex < all.length) return all[tabIndex];
-  return { savedEinheit: 0, savedDuenger: 0, excessEinheit: 0, excessDuenger: 0 };
+  return { savedEinheit: 0, savedDuenger: 0, excessEinheit: 0, excessDuenger: 0, nettedEinheit: 0, nettedDuenger: 0 };
 }
 
 // Liefert pro Tab die auf Carryover genetteten Restbedarfe (Saatgut + Dünger)
 // sowie Basis + Used, damit Render-Sites die Anzeige konsistent speisen.
 // IST-Fläche hat Vorrang vor SOLL. Nutzt getTabUsed* (mit `|| 0`-Guards).
+// netted* (Phase 0.5): Anteil des Mehrbedarfs, der durch Cross-Tab-Netting
+// abgedeckt ist — wird vom rohen Mehrbedarf subtrahiert.
 function getTabRemaining(r, tabIdx) {
   var istE = getTabIstEinheiten(r);
   var istD = getTabIstDuenger(r);
@@ -348,8 +386,8 @@ function getTabRemaining(r, tabIdx) {
     basisD:     basisD,
     usedE:      usedE,
     usedD:      usedD,
-    remainingE: Math.max(0, basisE - usedE - co.savedEinheit + co.excessEinheit),
-    remainingD: Math.max(0, basisD - usedD - co.savedDuenger + co.excessDuenger)
+    remainingE: Math.max(0, basisE - usedE - co.savedEinheit + co.excessEinheit - co.nettedEinheit),
+    remainingD: Math.max(0, basisD - usedD - co.savedDuenger + co.excessDuenger - co.nettedDuenger)
   };
 }
 
@@ -363,22 +401,23 @@ function isTabDone(r, tabIndex) {
   // Carryover nur berücksichtigen wenn tabIndex mitgegeben
   var carryover = (tabIndex !== undefined)
     ? getCarryover(tabIndex)
-    : { savedEinheit: 0, savedDuenger: 0, excessEinheit: 0, excessDuenger: 0 };
+    : { savedEinheit: 0, savedDuenger: 0, excessEinheit: 0, excessDuenger: 0, nettedEinheit: 0, nettedDuenger: 0 };
   // IST > 0 ? IST : SOLL
   var istE = getTabIstEinheiten(r);
   var totalE = istE > 0 ? istE : getTabTotalEinheiten(r);
   var usedE = getTabUsedEinheiten(r);
-  // Remaining = Need - Carryover.Saved + Carryover.Excess
-  // Need = max(0, totalE - usedE)
+  // Remaining = Need - Carryover.Saved + Carryover.Excess - Carryover.Netted
+  // Need = max(0, totalE - usedE). Netted = durch Cross-Tab-Netting
+  // abgedeckter Mehrbedarf (Phase 0.5).
   var needE = Math.max(0, totalE - usedE);
-  var remainingE = needE - carryover.savedEinheit + carryover.excessEinheit;
+  var remainingE = needE - carryover.savedEinheit + carryover.excessEinheit - carryover.nettedEinheit;
   if (remainingE > 0.05) return false;
 
   var istD = getTabIstDuenger(r);
   var totalD = istD > 0 ? istD : getTabTotalDuenger(r);
   var usedD = getTabUsedDuenger(r);
   var needD = Math.max(0, totalD - usedD);
-  var remainingD = needD - carryover.savedDuenger + carryover.excessDuenger;
+  var remainingD = needD - carryover.savedDuenger + carryover.excessDuenger - carryover.nettedDuenger;
   return remainingD <= 0.05;
 }
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // ⚠️ CACHE_VERSION muss bei jedem Release manuell gebumpet werden!
 // Bei Vergessen bekommen Nutzer die alte Version aus dem Cache.
 // alternativa: Build-Script das Hash/Zeitstempel injiziert.
-const CACHE_VERSION = 'agrar-rechner-v33';
+const CACHE_VERSION = 'agrar-rechner-v34';
 const STATIC_ASSETS = [
     '/',
     '/index.html',

--- a/tests/53-mehrbedarf-tab-verbleibend.test.js
+++ b/tests/53-mehrbedarf-tab-verbleibend.test.js
@@ -1,0 +1,259 @@
+/**
+ * Tests for Issue (Mehrbedarf-Tab Verbleibend / netting flow-back):
+ *
+ * Im 3-Tab-Szenario (10/7,5/5 ha) zeigt ein Mehrbedarf-Tab (IST>SOLL,
+ * z.B. Tab 2 mit 8ha IST bei 7,5ha SOLL) den rohen Mehrbedarf (1 E + 100 kg)
+ * als "verbleibend / noch einzufüllen" an, obwohl dieser Mehrbedarf durch
+ * das Cross-Tab-Netting VOLLSTÄNDIG abgedeckt ist (Tab 1 Ersparnis ≥
+ * Tab 2 Mehrbedarf). Der Tab ist real fertig, die Anzeige suggeriert aber
+ * offenen Bedarf.
+ *
+ * Root cause: _computeNetCarryoverPools() netted korrekt
+ * (netSaved=max(0,totalSaved-totalExcess), netExcess=max(0,totalExcess-totalSaved)).
+ * computeAllCarryovers überspringt Mehrbedarf-Tabs in Phase 1 und Phase 2.
+ * ⇒ getCarryover(MehrbedarfTab) = {0,0,0,0}. Netting-Abdeckung fließt
+ *   NICHT zurück in den per-Tab-Wert.
+ * ⇒ Per-Tab remaining formula (max(0, basis - used - saved + excess))
+ *   zeigt rohen Mehrbedarf statt 0.
+ *
+ * Setup:
+ *   Tab 0 (10/9 ha):    SOLL 20 E / 2.000 kg, IST 18 E / 1.800 kg, used 18 E / 1.800 kg → Ersparnis-Quelle
+ *   Tab 1 (7.5/8 ha):   SOLL 15 E / 1.500 kg, IST 16 E / 1.600 kg, used 15 E / 1.500 kg → MEHRBEDARF
+ *   Tab 2 (5/5 ha):     SOLL 10 E / 1.000 kg, IST 10 E / 1.000 kg, used  8 E /   500 kg → neutral, unterfüllt
+ *
+ *   totalSaved  E = 2, D = 200
+ *   totalExcess E = 1, D = 100
+ *   netSaved    E = 1, D = 100      ← Tab 2 Mehrbedarf VOLLSTÄNDIG abgedeckt (netExcess = 0)
+ *   netExcess   E = 0, D = 0
+ *
+ * After fix:
+ *   - getCarryover(Tab 1) must reflect netted coverage (saved/excess that flowed back).
+ *     OR all 4 remaining-computation sites must clamp basis to SOLL for Mehrbedarf-Tabs.
+ *   - getCarryover(Tab 2) = { savedEinheit: 1, savedDuenger: 100, ... }
+ *     (Tab 3 receives the post-netting savings; Tab 1's residual savings 1E/100kg flow to Tab 3).
+ *   - isTabDone(Tab 1) === true
+ *   - All 4 render sites show 0/0 for Tab 1's remaining
+ *   - Tab 0 unchanged (Ersparnis-Quelle, done): 0/0
+ *   - Tab 2 unchanged (neutral, unterfüllt, gets savings): 1E + 400 kg (8/500 used, basis 10/1000, saved 1E/100kg → (10-8-1)=1, (1000-500-100)=400)
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createDom } from './helpers.js';
+
+describe('Mehrbedarf-Tab verbleibend = 0 wenn durch Netting abgedeckt', () => {
+  let w, doc;
+
+  beforeEach(() => {
+    const result = createDom();
+    w = result.window;
+    doc = w.document;
+  });
+
+  // Helper: set up the 3-tab repro from the task spec.
+  function setup3Tabs() {
+    w.state.koernerProEinheit = 50000;
+    w.state.reiter[0] = {
+      name: 'Acker 1', hektar: 10, istHektar: 9, koerner: 100000, duenger: 200,
+      entries: [{ einheit: 18, duenger: 1800, time: '08:00' }],
+      fahrgassenEnabled: false, fahrgassenBreite: 0
+    };
+    w.state.reiter[1] = {
+      name: 'Acker 2', hektar: 7.5, istHektar: 8, koerner: 100000, duenger: 200,
+      entries: [{ einheit: 15, duenger: 1500, time: '09:00' }],
+      fahrgassenEnabled: false, fahrgassenBreite: 0
+    };
+    w.state.reiter[2] = {
+      name: 'Acker 3', hektar: 5, istHektar: 5, koerner: 100000, duenger: 200,
+      entries: [{ einheit: 8, duenger: 500, time: '10:00' }],
+      fahrgassenEnabled: false, fahrgassenBreite: 0
+    };
+    if (w.invalidateCarryoverCache) w.invalidateCarryoverCache();
+  }
+
+  // Mirror the per-tab remaining formula used by all 4 render sites AFTER fix.
+  // MUST stay identical to the inline math in render-drill.js:55-56,
+  // render-dashboard.js:65-66 / 174-175, render-results.js:187-188,
+  // and isTabDone() in calculations.js. Netting-Coverage-Abzug (Phase 0.5)
+  // wird via co.nettedEinheit / co.nettedDuenger subtrahiert.
+  function computeRemaining(r, i) {
+    var istHa = w.getTabIstHektar(r);
+    var istE = istHa > 0 ? w.getTabIstEinheiten(r) : w.getTabTotalEinheiten(r);
+    var istD = istHa > 0 ? w.getTabIstDuenger(r) : w.getTabTotalDuenger(r);
+    var usedE = r.entries ? r.entries.reduce(function (s, e) { return s + (e.einheit || 0); }, 0) : 0;
+    var usedD = r.entries ? r.entries.reduce(function (s, e) { return s + (e.duenger || 0); }, 0) : 0;
+    var co = w.getCarryover(i);
+    return {
+      basisE: istE, basisD: istD, usedE: usedE, usedD: usedD,
+      remainingE: Math.max(0, istE - usedE - co.savedEinheit + co.excessEinheit - (co.nettedEinheit || 0)),
+      remainingD: Math.max(0, istD - usedD - co.savedDuenger + co.excessDuenger - (co.nettedDuenger || 0)),
+    };
+  }
+
+  // ── Core scenario ───────────────────────────────────────────────────────
+
+  it('Tab 1 (Mehrbedarf, durch Netting voll abgedeckt) zeigt remainingE === 0', () => {
+    setup3Tabs();
+    const rem = computeRemaining(w.state.reiter[1], 1);
+    expect(rem.remainingE).toBe(0);
+  });
+
+  it('Tab 1 (Mehrbedarf, durch Netting voll abgedeckt) zeigt remainingD === 0', () => {
+    setup3Tabs();
+    const rem = computeRemaining(w.state.reiter[1], 1);
+    expect(rem.remainingD).toBe(0);
+  });
+
+  it('isTabDone(Tab 1) === true (Mehrbedarf ist durch Netting abgedeckt)', () => {
+    setup3Tabs();
+    expect(w.isTabDone(w.state.reiter[1], 1)).toBe(true);
+  });
+
+  // ── Regression-Guard: Tab 0 (Ersparnis-Quelle) bleibt 0/0 ────────────────
+
+  it('Tab 0 (Ersparnis-Quelle, done) bleibt remainingE === 0', () => {
+    setup3Tabs();
+    expect(computeRemaining(w.state.reiter[0], 0).remainingE).toBe(0);
+  });
+
+  it('Tab 0 (Ersparnis-Quelle, done) bleibt remainingD === 0', () => {
+    setup3Tabs();
+    expect(computeRemaining(w.state.reiter[0], 0).remainingD).toBe(0);
+  });
+
+  // ── Regression-Guard: Tab 2 (neutral, unterfüllt, empfängt savings) ─────
+  //   Tab 2 hat used < basis (8 E / 500 kg von 10 E / 1.000 kg).
+  //   Pool nach Netting: netSaved = 1 E / 100 kg → fließt an Tab 2.
+  //   ⇒ remaining = (10 - 8 - 1) E + (1000 - 500 - 100) kg = 1 E + 400 kg
+
+  it('Tab 2 (neutral, unterfüllt) bleibt remainingE === 1 (erspartes 1E nach Tab 2 geflossen)', () => {
+    setup3Tabs();
+    expect(computeRemaining(w.state.reiter[2], 2).remainingE).toBe(1);
+  });
+
+  it('Tab 2 (neutral, unterfüllt) bleibt remainingD === 400 (ersparte 100 kg nach Tab 2 geflossen)', () => {
+    setup3Tabs();
+    expect(computeRemaining(w.state.reiter[2], 2).remainingD).toBe(400);
+  });
+
+  // ── 4-Site render verification ──────────────────────────────────────────
+  //
+  // (a) Drill-Tab-Status dtl_need_1 = "✓ fertig"
+  // (b) Dashboard Per-Tab-Karte Acker 2 (Tab 1): einheitRem=0 duengerRem=0
+  // (c) Inline drill r_drill_e_rem/r_drill_d_rem (activeReiter = 1)
+  // (d) Drill summary ds_saat_remaining/ds_duenger_remaining — must remain 0/0
+  //     (Phase A/B netting already correctly aggregates; totalNeedE excludes
+  //     Mehrbedarf-tabs since Issue #347 — totalNeed = (10-8) = 2E,
+  //     totalSaved = 1E, totalExcess = 0, rem = max(0, 2-1+0) = 1 E.)
+
+  it('(a) Drill-Tab-Status Tab 1 zeigt "✓ fertig"', () => {
+    setup3Tabs();
+    w.state.activeReiter = 1;
+    w.renderDrillTabList();
+    const el = doc.getElementById('dtl_need_1');
+    expect(el).toBeTruthy();
+    expect(el.textContent).toContain('fertig');
+  });
+
+  it('(b) Dashboard Per-Tab-Karte Acker 2 zeigt 0 / 0', () => {
+    setup3Tabs();
+    w.openDashboard();
+    const cards = doc.querySelectorAll('.dashboard-reiter-card');
+    // Tab 1 is the second card. Values: [Hektar, Körner/ha, Einh. verbl., Dünger verbl.]
+    const values = cards[1].querySelectorAll('.dashboard-stat-value');
+    expect(values[2].textContent.trim()).toBe('0');
+    expect(values[3].textContent.trim()).toContain('0');
+  });
+
+  it('(c) Inline-Drill (activeReiter = Tab 1) zeigt 0,0 Einheiten / 0 kg', () => {
+    setup3Tabs();
+    w.state.activeReiter = 1;
+    w.renderResults();
+    expect(doc.getElementById('r_drill_e_rem').textContent).toContain('0');
+    // formatEinheit returns "—" when remD === 0; that's OK per formatter contract.
+    const remDRow = doc.getElementById('r_drill_d_rem');
+    const remDRowDisplay = doc.getElementById('r_drill_d_rem_row').style.display;
+    // Either shown as "0 kg" or row hidden via "—" — both are "nicht mehr offen".
+    expect(remDRow.textContent === '—' || remDRow.textContent.includes('0')).toBe(true);
+    expect(remDRowDisplay === 'none' || remDRow.textContent.includes('0')).toBe(true);
+  });
+
+  // ── Edge case: Mehrbedarf NICHT vollständig abgedeckt ───────────────────
+  //   Tab A: 10/9 ha → Ersparnis 2E/200kg
+  //   Tab B: 7.5/8 ha → Mehrbedarf 1E/100kg
+  //   Tab C: 7.5/8 ha → Mehrbedarf 1E/100kg
+  //   totalExcess = 2E/200kg > totalSaved = 2E/200kg → netExcess = 0 (full coverage)
+  //   Push it over: Tab B + Tab C mit 1E/100kg each, beide durch Netting abgedeckt (1E bleibt über für Tab C → 1E/100kg un-covered).
+  //
+  //   Korrekt: Tab B (erste Mehrbedarf-Quelle) kriegt 1E/100kg aus Tab A, remaining = 0/0.
+  //            Tab C (zweite Mehrbedarf-Quelle) kriegt 1E/100kg aus Tab A (rest), remaining = 0/0.
+  //   Total netExcess = 0. Wenn mehr Tabs: z.B. 3 Mehrbedarf-Tabs à 1E, totalExcess = 3E
+  //   totalSaved = 2E → netExcess = 1E → Tab 3 (dritter Mehrbedarf) zeigt 1E remaining.
+
+  it('Edge case: 2 Mehrbedarf-Tabs, beide vollständig durch Netting abgedeckt → beide 0/0', () => {
+    w.state.koernerProEinheit = 50000;
+    w.state.reiter[0] = {
+      name: 'A', hektar: 10, istHektar: 9, koerner: 100000, duenger: 200,
+      entries: [{ einheit: 18, duenger: 1800, time: '08:00' }],
+      fahrgassenEnabled: false, fahrgassenBreite: 0
+    };
+    w.state.reiter[1] = {
+      name: 'B', hektar: 7.5, istHektar: 8, koerner: 100000, duenger: 200,
+      entries: [{ einheit: 15, duenger: 1500, time: '09:00' }],
+      fahrgassenEnabled: false, fahrgassenBreite: 0
+    };
+    w.state.reiter[2] = {
+      name: 'C', hektar: 7.5, istHektar: 8, koerner: 100000, duenger: 200,
+      entries: [{ einheit: 15, duenger: 1500, time: '09:30' }],
+      fahrgassenEnabled: false, fahrgassenBreite: 0
+    };
+    if (w.invalidateCarryoverCache) w.invalidateCarryoverCache();
+    // totalSaved = 2E/200kg, totalExcess = 2E/200kg → netSaved = 0, netExcess = 0
+    // Beide Mehrbedarf-Tabs (B + C) sollten 0/0 remaining zeigen.
+    expect(computeRemaining(w.state.reiter[1], 1).remainingE).toBe(0);
+    expect(computeRemaining(w.state.reiter[1], 1).remainingD).toBe(0);
+    expect(computeRemaining(w.state.reiter[2], 2).remainingE).toBe(0);
+    expect(computeRemaining(w.state.reiter[2], 2).remainingD).toBe(0);
+  });
+
+  it('Edge case: 3 Mehrbedarf-Tabs à 1E, totalExcess = 3E > totalSaved = 2E → coverageRatio = 2/3, jeder Tab hat 0.33E offen', () => {
+    w.state.koernerProEinheit = 50000;
+    w.state.reiter[0] = {
+      name: 'A', hektar: 10, istHektar: 9, koerner: 100000, duenger: 200,
+      entries: [{ einheit: 18, duenger: 1800, time: '08:00' }],
+      fahrgassenEnabled: false, fahrgassenBreite: 0
+    };
+    // 3 Mehrbedarf-Tabs. totalExcess = 3E, totalSaved = 2E →
+    // coverageRatio = 2/3 → jeder Mehrbedarf-Tab bekommt 0.67E coverage,
+    // 0.33E bleiben offen (über alle 3 Tabs verteilt = 1E = un-covered netExcess).
+    w.state.reiter[1] = {
+      name: 'B', hektar: 7.5, istHektar: 8, koerner: 100000, duenger: 200,
+      entries: [{ einheit: 15, duenger: 1500, time: '09:00' }],
+      fahrgassenEnabled: false, fahrgassenBreite: 0
+    };
+    w.state.reiter[2] = {
+      name: 'C', hektar: 7.5, istHektar: 8, koerner: 100000, duenger: 200,
+      entries: [{ einheit: 15, duenger: 1500, time: '09:30' }],
+      fahrgassenEnabled: false, fahrgassenBreite: 0
+    };
+    w.state.reiter[3] = {
+      name: 'D', hektar: 7.5, istHektar: 8, koerner: 100000, duenger: 200,
+      entries: [{ einheit: 15, duenger: 1500, time: '10:00' }],
+      fahrgassenEnabled: false, fahrgassenBreite: 0
+    };
+    if (w.invalidateCarryoverCache) w.invalidateCarryoverCache();
+
+    // Tab 0 (Ersparnis-Quelle) → 0E
+    expect(computeRemaining(w.state.reiter[0], 0).remainingE).toBe(0);
+    // Tab 1, 2, 3 (Mehrbedarf, partial coverage): each ~0.33E remaining.
+    // Sum über alle 3 = 1E = un-covered netExcess. Test prüft die Summe.
+    const rem1 = computeRemaining(w.state.reiter[1], 1).remainingE;
+    const rem2 = computeRemaining(w.state.reiter[2], 2).remainingE;
+    const rem3 = computeRemaining(w.state.reiter[3], 3).remainingE;
+    const sum = rem1 + rem2 + rem3;
+    // Floating-Point-tolerant: jede Tab bleibt ≈ 1/3, Summe ≈ 1E.
+    expect(Math.abs(sum - 1)).toBeLessThan(0.05);
+    // Kein Tab zeigt den vollen 1E Mehrbedarf (Netting muss wirken).
+    expect(rem1).toBeLessThan(0.5);
+    expect(rem2).toBeLessThan(0.5);
+    expect(rem3).toBeLessThan(0.5);
+  });
+});


### PR DESCRIPTION
## Summary

Mehrbedarf-Tab (IST>SOLL) zeigt den rohen Mehrbedarf als "verbleibend / noch
einzufüllen" an, obwohl das Cross-Tab-Netting diesen Bedarf vollständig
abgedeckt hat. Tab ist real fertig, die Anzeige suggeriert aber offenen
Bedarf. Fix: Netting-Coverage fließt per Phase 0.5 zurück in den per-Tab-Wert.

## Root cause

- `_computeNetCarryoverPools()` netted korrekt: bei Tab1-Sav=2E, Tab2-Exc=1E
  → `netSaved=1E/100kg`, `netExcess=0`.
- `computeAllCarryovers()` übersprang Mehrbedarf-Tabs in Phase 1 und Phase 2,
  d.h. `getCarryover(MehrbedarfTab) = {0,0,0,0}`.
- `getTabRemaining(Tab 2) = max(0, 16 - 15 - 0 + 0) = 1E` → roher Mehrbedarf.

## Fix (Ansatz A — Carryover-Engine-konsistent)

Neue Phase 0.5 in `computeAllCarryovers` (zwischen Phase 0+Netting und Phase 1):

```
poolE = excE - netExcessE   // = min(totalSavedE, totalExcessE)
ratioE = excE > 0 ? min(1, max(0, poolE) / excE) : 0
// für jeden Mehrbedarf-Tab i:
result[i].nettedEinheit  = (istE[i] - solE[i]) * ratioE
result[i].nettedDuenger  = (istD[i] - solD[i]) * ratioD
```

Plus: `getTabRemaining` und `isTabDone` subtrahieren `nettedEinheit /
nettedDuenger` konsistent von der `remaining`-Formel.

### Edge cases (verifiziert in tests)

| Szenario | totalSaved | totalExcess | ratio | Tab-Remaining |
|----------|-----------:|------------:|------:|---------------|
| Tab 1 voll abgedeckt (3 Tab, 1 Mehrbedarf) | 2E | 1E | 1.0 | 0/0 |
| 2 Mehrbedarf-Tabs, beide voll abgedeckt | 2E | 2E | 1.0 | 0/0 für beide |
| 3 Mehrbedarf-Tabs, partial coverage | 2E | 3E | 0.67 | je ~0.33E (Summe = 1E) |

Bei `totalSaved == totalExcess` ist `ratio = 1` und alle Mehrbedarf-Tabs
sind voll abgedeckt — auch wenn `netSaved = 0`.

### Alternative (Ansatz B — display-only clamp)

Hätte `basis` in `getTabRemaining` auf `min(basisE, solE)` für Mehrbedarf-Tabs
geclamped. Bewusst verworfen: (1) ändert nur Anzeige, nicht die zugrundeliegende
Carryover-Engine; (2) würde das Protokoll vs. Tabs-Drift-Symptom (Issue #335)
nicht fixen, weil `_appendTabCarryoverBlocks` direkt `getCarryover` liest.

## Test-Status

- Branch: 855 passed / 0 failed (855 total in 52 files)
- Neue Tests: `tests/53-mehrbedarf-tab-verbleibend.test.js` (12 Tests, alle grün)
  - Tab 1 (Mehrbedarf, durch Netting voll abgedeckt) zeigt remainingE === 0
  - Tab 1 zeigt remainingD === 0
  - isTabDone(Tab 1) === true
  - Tab 0 (Ersparnis-Quelle) bleibt 0/0 (regression guard)
  - Tab 2 (neutral, unterfüllt) bleibt 1E+400kg (regression guard)
  - 4-Site DOM-Readback: drill-tab-status, dashboard, inline-drill
  - Edge case 1: 2 Mehrbedarf-Tabs, beide voll durch Netting abgedeckt → 0/0
  - Edge case 2: 3 Mehrbedarf-Tabs, partial coverage → Summe = 1E
- 4-Site DOM-Repro (`.hermes/repro-tab2-verbleibend.mjs`): Tab 2 zeigt 0/0
  auf drill-tab-status, dashboard, inline-drill UND drill-summary ✓
- Lint clean (`./node_modules/.bin/eslint` direkt, pnpm lint hat worktree
  esbuild build-script issue per Skill-Pitfall)
- Keine Regressionen: alle 843 vorher existierenden Tests bleiben grün

## Files

- `public/js/calculations.js` — Phase 0.5 + getTabRemaining/isTabDone erweitert
- `tests/53-mehrbedarf-tab-verbleibend.test.js` — 12 neue Tests (12/12 grün)
- `public/sw.js` — CACHE_VERSION v33 → v34 (Service Worker cache invalidation)

## Verification

```bash
node .hermes/repro-tab2-verbleibend.mjs   # URTEIL: ✓
./node_modules/.bin/vitest run            # 855 passed / 0 failed
./node_modules/.bin/eslint public/js/calculations.js tests/53-mehrbedarf-tab-verbleibend.test.js  # clean
```

Closes #335