### PR TITLE
fix(#368): Carryover-Netting pro-rata → sequenziell nach Bearbeitungs-Reihenfolge

### DIFF
--- a/public/js/calculations.js
+++ b/public/js/calculations.js
@@ -166,17 +166,27 @@ function computeAllCarryovers() {
 
   // === PHASE 0.5: Netting-Coverage auf Mehrbedarf-Tabs zurückfließen lassen ===
   //
-  // Ohne diesen Schritt bleibt getCarryover(MehrbedarfTab) = {0,0,0,0} und
-  // getTabRemaining zeigt rohen Mehrbedarf, obwohl das Netting den Bedarf
-  // global bereits abgedeckt hat. Pro-rata Verteilung: jeder Mehrbedarf-Tab
-  // erhält so viel Coverage wie möglich (bis zu seinem eigenen Mehrbedarf).
-  // Coverage-Pool = min(totalExcess, totalSaved) = der Anteil, der von
-  // Ersparnissen absorbiert wird. Pro-rata: coverageRatio = Pool / totalExcess.
-  // Edge: totalSaved == totalExcess → Pool = totalExcess → ratio = 1 → alle
-  // Mehrbedarf-Tabs voll abgedeckt (auch wenn netSaved=0).
+  // Issue #368 (Carryover-Regel 2): Wenn die verfügbaren Ersparnisse nicht für
+  // alle Mehrbedarf-Tabs reichen, erfolgt die Netting-Abdeckung SEQUENZIELL
+  // nach Bearbeitungs-Reihenfolge. Das zuerst bearbeitete Feld wird KOMPLETT
+  // abgedeckt, dann das nächste, bis die Ersparnis aufgebraucht ist.
+  //
+  // Vor #368 (PR #366) war die Verteilung PRO-RATA: jeder Mehrbedarf-Tab
+  // bekam anteilig (Pool / totalExcess) seines Bedarfs. Das verteilte eine
+  // unzureichende Ersparnis gleichmäßig über alle Mehrbedarf-Tabs — was den
+  // später bearbeiteten Tab teilverdeckt ließ, obwohl der erste Tab bereits
+  // genug gehabt hätte. Sequenzielle Verteilung ist die korrekte Semantik:
+  // "wer zuerst da war, wird zuerst bedient".
+  //
+  // Pool-Definition (unverändert): pool = exc - netExcess = min(saved, exc).
+  // Saat und Dünger werden getrennt behandelt (Regel 4 — Pools unabhängig).
+  // Sortierung: parseEntryTime(lastEntry.time) aufsteigend, Tiebreaker
+  // gleicher time: Tab-Index aufsteigend (deterministisch).
   {
-    var moreE = [], excE = 0;
-    var moreD = [], excD = 0;
+    var moreE = [];
+    var moreD = [];
+    var excE = 0;
+    var excD = 0;
     for (let i = 0; i < AppGlobals.state.reiter.length; i++) {
       var mt = AppGlobals.state.reiter[i];
       var mistE = getTabIstEinheiten(mt);
@@ -186,17 +196,42 @@ function computeAllCarryovers() {
       if (mistE > 0 && mistE > msolE) { moreE.push(i); excE += (mistE - msolE); }
       if (mistD > 0 && mistD > msolD) { moreD.push(i); excD += (mistD - msolD); }
     }
-    var poolE = excE - netExcessE; // = min(totalSavedE, totalExcessE) — der Anteil, der bereits abgedeckt ist
-    var poolD = excD - netExcessD;
-    var ratioE = excE > 0 ? Math.min(1, Math.max(0, poolE) / excE) : 0;
-    var ratioD = excD > 0 ? Math.min(1, Math.max(0, poolD) / excD) : 0;
-    for (let k = 0; k < moreE.length; k++) {
-      var mt2 = AppGlobals.state.reiter[moreE[k]];
-      result[moreE[k]].nettedEinheit = (getTabIstEinheiten(mt2) - getTabTotalEinheiten(mt2)) * ratioE;
+    var lastEntryTime = function(i) {
+      var tab = AppGlobals.state.reiter[i];
+      if (!tab.entries || tab.entries.length === 0) return 0;
+      var last = tab.entries[tab.entries.length - 1];
+      return parseEntryTime(last ? (last.time || 0) : 0);
+    };
+    var byTimeAsc = function(a, b) {
+      var ta = lastEntryTime(a), tb = lastEntryTime(b);
+      if (ta !== tb) return ta - tb;
+      return a - b; // Tab-Index aufsteigend als Tiebreaker
+    };
+    // Saat — sequenzielle Greedy-Zuweisung
+    moreE.sort(byTimeAsc);
+    var poolE = Math.max(0, excE - netExcessE);
+    var remPoolE = poolE;
+    for (let k = 0; k < moreE.length && remPoolE > 0.05; k++) {
+      var idx = moreE[k];
+      var mte = AppGlobals.state.reiter[idx];
+      var exc = getTabIstEinheiten(mte) - getTabTotalEinheiten(mte);
+      if (exc <= 0) continue;
+      var take = Math.min(remPoolE, exc);
+      result[idx].nettedEinheit = take;
+      remPoolE -= take;
     }
-    for (let k = 0; k < moreD.length; k++) {
-      var mt3 = AppGlobals.state.reiter[moreD[k]];
-      result[moreD[k]].nettedDuenger = (getTabIstDuenger(mt3) - getTabTotalDuenger(mt3)) * ratioD;
+    // Dünger — sequenzielle Greedy-Zuweisung
+    moreD.sort(byTimeAsc);
+    var poolD = Math.max(0, excD - netExcessD);
+    var remPoolD = poolD;
+    for (let k = 0; k < moreD.length && remPoolD > 0.05; k++) {
+      var idx = moreD[k];
+      var mtd = AppGlobals.state.reiter[idx];
+      var exc = getTabIstDuenger(mtd) - getTabTotalDuenger(mtd);
+      if (exc <= 0) continue;
+      var take = Math.min(remPoolD, exc);
+      result[idx].nettedDuenger = take;
+      remPoolD -= take;
     }
   }
 

--- a/public/js/render-drill.js
+++ b/public/js/render-drill.js
@@ -183,8 +183,21 @@
         var solDForTab = AppGlobals.getTabTotalDuenger(rt);
         var isMehrbedarfE = (tEinheiten > 0 && solEForTab > 0 && tEinheiten > solEForTab);
         var isMehrbedarfD = (tDuenger > 0 && solDForTab > 0 && tDuenger > solDForTab);
-        var needE = (isMehrbedarfE || tUsedE >= tEinheiten) ? 0 : Math.max(0, tEinheiten - tUsedE);
-        var needD = (isMehrbedarfD || tUsedE >= tDuenger) ? 0 : Math.max(0, tDuenger - tUsedD);
+        // Issue #368 (Carryover-Regel 2): Bei sequenzieller Netting-Verteilung
+        // kann ein Mehrbedarf-Tab UNTERDECKT bleiben, wenn der Pool kleiner
+        // ist als die Summe aller Mehrbedarfe. Der ungedeckte Anteil
+        // (istE − solE − cco.nettedEinheit) zählt als real offener Bedarf und
+        // muss in den globalen Drill-Summary-Remaining auftauchen.
+        // Vor #368 (PR #366, pro-rata) verdeckte die Gleichverteilung diese
+        // Lücke nie — der Pool reichte entweder für alle oder niemanden ganz.
+        var uncoveredE = isMehrbedarfE ? Math.max(0, tEinheiten - solEForTab - (cco.nettedEinheit || 0)) : 0;
+        var uncoveredD = isMehrbedarfD ? Math.max(0, tDuenger - solDForTab - (cco.nettedDuenger || 0)) : 0;
+        var needE = uncoveredE > 0
+          ? uncoveredE
+          : (isMehrbedarfE || tUsedE >= tEinheiten ? 0 : Math.max(0, tEinheiten - tUsedE));
+        var needD = uncoveredD > 0
+          ? uncoveredD
+          : (isMehrbedarfD || tUsedE >= tDuenger ? 0 : Math.max(0, tDuenger - tUsedD));
         totalNeedE += needE;
         totalNeedD += needD;
         totalSavedE += cco.savedEinheit;

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // ⚠️ CACHE_VERSION muss bei jedem Release manuell gebumpet werden!
 // Bei Vergessen bekommen Nutzer die alte Version aus dem Cache.
 // alternativa: Build-Script das Hash/Zeitstempel injiziert.
-const CACHE_VERSION = 'agrar-rechner-v34';
+const CACHE_VERSION = 'agrar-rechner-v35';
 const STATIC_ASSETS = [
     '/',
     '/index.html',

--- a/tests/05-drill-protocol.test.js
+++ b/tests/05-drill-protocol.test.js
@@ -379,7 +379,7 @@ describe('Drill-Protokoll', () => {
     // Phase B: TotalExcess_E = 9.6, TotalExcess_D = 400.
     //          remEinheit  = max(0, 18.6 - 0 + 9.6) = 28.2
     //          remDuenger  = max(0, 1400 - 0 + 400) = 1800
-    it('renderDrillSummary() nets carryover across tabs (Issue #302, updated for Issue #347)', () => {
+    it('renderDrillSummary() nets carryover across tabs (Issue #302, updated for Issue #347, Issue #368)', () => {
       // Issue #347 (Netto-Saldo-Fix): Eine Mehrbedarf-Quelle (IST > SOLL) darf
       // sich in Phase 2 NICHT selbst als Empfänger ihres eigenen Excess
       // eintragen — sie muss den Rest selbst absorbieren (Eigen-Restbedarf).
@@ -392,8 +392,19 @@ describe('Drill-Protokoll', () => {
       // selbst. Der `ds_saat_remaining` / `ds_duenger_remaining` zeigt
       // daher nur den unverteilten Bedarf, NICHT plus Eigen-Excess.
       //
+      // Issue #368 (Carryover-Regel 2 — sequenzielle Netting): Wenn kein
+      // Savings-Pool existiert (alle Tabs sind Mehrbedarf-Quellen), bleibt
+      // jeder Mehrbedarf-Tab vollständig ungedeckt. render-drill.js summiert
+      // jetzt den ungedeckten Mehrbedarf-Anteil (istE − solE − nettedE) in
+      // totalNeedE, damit die globale Drill-Summary die ehrliche Summe aller
+      // offenen Arbeiten zeigt — konsistent mit getTabRemaining().
+      //
       // ALTES Verhalten (vor #347): 28,2 E / 1.800 kg (Tab 0 self-absorbed).
       // NEUES Verhalten (nach #347): 18,6 E / 500 kg (kein Self-Absorb).
+      // NEUERES Verhalten (nach #368 + render-drill.js uncovered): 21,6 E /
+      // 3.000 kg (Tab 0 Mehrbedarf ungedeckt mitgezählt, Tab 1 als normaler
+      // Bedarfsempfänger). Vor #368 (PR #366 pro-rata) war der Effekt gleich,
+      // weil ohne Savings-Pool sowieso nichts gecovered wurde.
       setupTwoTabs(w);
       // Reset tabs to the user's repro (1 ha / 450.000 K/ha / 1000 kg).
       // setupTwoTabs defaults to 10 ha / 90000 K/ha / 200 kg/ha — too large.
@@ -430,20 +441,23 @@ describe('Drill-Protokoll', () => {
       //                  landet nur der echte Bedarf von Tab 1 (needE=9) im
       //                  totalNeedE.
       //
-      // TotalNeed_E = 0 (Tab 0 ist Mehrbedarf → Skip) + (9-0) (Tab 1)
-      //             = 9
+      // Issue #368: Ohne Savings-Pool ist Tab 0 voll ungedeckt (12.6 E
+      // Mehraufwand), sein ungedeckter Mehrbedarf zählt jetzt in totalNeedE.
+      // Tab 1 ist kein Mehrbedarf → sein Bedarf (9 E, da istHektar=0 → tEinheiten=solE)
+      // zählt normal.
+      //
+      // TotalNeed_E = 12.6 (Tab 0 ungedeckter Mehrbedarf, Issue #368) + 9 (Tab 1)
+      //             = 21.6
       // TotalSaved_E = 0, TotalExcess_E = 0 (Tab 0 self-excess,
       //                Phase 2 verteilt 0 dank Self-Absorb-Skip #348).
-      // → remEinheit = max(0, 9 - 0 + 0) = 9
+      // → remEinheit = max(0, 21.6 - 0 + 0) = 21.6
       //
-      // HINWEIS: Der vorherige Wert "18,6 Einheiten" (PR #348's Update)
-      // entsprach dem ALTEN Phase-A-Verhalten, in dem Tab 0 als
-      // Bedarfsempfänger mit 9.6 E gezählt wurde. Mit der Issue-#347-Folge-
-      // Korrektur (Mehrbedarf-Tabs zählen NICHT als Bedarfsempfänger) ist
-      // 9,0 der korrekte Wert.
-      expect(doc.getElementById('ds_saat_remaining').textContent).toBe('9,0 Einheiten');
-      // TotalNeed_D = 0 (Tab 0 Mehrbedarf) + (1000-0) (Tab 1) = 1000
-      expect(doc.getElementById('ds_duenger_remaining').textContent).toBe('1.000 kg');
+      // HINWEIS: Der vorherige Wert "9,0 Einheiten" entsprach dem Verhalten
+      // ohne #368-Korrektur. Mit #368 ist 21,6 der ehrliche Wert, weil Tab 0
+      // keinen Savings-Pool findet und seinen vollen Mehraufwand offen behält.
+      expect(doc.getElementById('ds_saat_remaining').textContent).toBe('21,6 Einheiten');
+      // TotalNeed_D = 1400 (Tab 0 ungedeckter Mehrbedarf: 2400-1000-0) + 1000 (Tab 1) = 2400
+      expect(doc.getElementById('ds_duenger_remaining').textContent).toBe('2.400 kg');
 
       // Sanity: total/used are independent of carryover.
       expect(doc.getElementById('ds_saat_total').textContent).toBe('30,6 Einheiten');

--- a/tests/53-mehrbedarf-tab-verbleibend.test.js
+++ b/tests/53-mehrbedarf-tab-verbleibend.test.js
@@ -214,16 +214,19 @@ describe('Mehrbedarf-Tab verbleibend = 0 wenn durch Netting abgedeckt', () => {
     expect(computeRemaining(w.state.reiter[2], 2).remainingD).toBe(0);
   });
 
-  it('Edge case: 3 Mehrbedarf-Tabs à 1E, totalExcess = 3E > totalSaved = 2E → coverageRatio = 2/3, jeder Tab hat 0.33E offen', () => {
+  it('Edge case: 3 Mehrbedarf-Tabs à 1E, totalExcess = 3E > totalSaved = 2E → sequenziell: erste 2 Tabs voll, 3. leer (Issue #368)', () => {
     w.state.koernerProEinheit = 50000;
     w.state.reiter[0] = {
       name: 'A', hektar: 10, istHektar: 9, koerner: 100000, duenger: 200,
       entries: [{ einheit: 18, duenger: 1800, time: '08:00' }],
       fahrgassenEnabled: false, fahrgassenBreite: 0
     };
-    // 3 Mehrbedarf-Tabs. totalExcess = 3E, totalSaved = 2E →
-    // coverageRatio = 2/3 → jeder Mehrbedarf-Tab bekommt 0.67E coverage,
-    // 0.33E bleiben offen (über alle 3 Tabs verteilt = 1E = un-covered netExcess).
+    // 3 Mehrbedarf-Tabs. totalExcess = 3E, totalSaved = 2E → pool = 2E.
+    // Sequenziell nach Bearbeitungs-Reihenfolge (Issue #368, Regel 2):
+    //   Tab B (09:00, FIRST) bekommt 1E (seinen vollen Bedarf aus dem Pool)
+    //   Tab C (09:30, LATER) bekommt 1E (verbleibenden Pool)
+    //   Tab D (10:00, LAST) bekommt 0E (Pool leer) → 1E offen
+    // Summe offen = 1E (= un-covered netExcess), konzentriert auf dem letzten Tab.
     w.state.reiter[1] = {
       name: 'B', hektar: 7.5, istHektar: 8, koerner: 100000, duenger: 200,
       entries: [{ einheit: 15, duenger: 1500, time: '09:00' }],
@@ -243,17 +246,14 @@ describe('Mehrbedarf-Tab verbleibend = 0 wenn durch Netting abgedeckt', () => {
 
     // Tab 0 (Ersparnis-Quelle) → 0E
     expect(computeRemaining(w.state.reiter[0], 0).remainingE).toBe(0);
-    // Tab 1, 2, 3 (Mehrbedarf, partial coverage): each ~0.33E remaining.
-    // Sum über alle 3 = 1E = un-covered netExcess. Test prüft die Summe.
-    const rem1 = computeRemaining(w.state.reiter[1], 1).remainingE;
-    const rem2 = computeRemaining(w.state.reiter[2], 2).remainingE;
-    const rem3 = computeRemaining(w.state.reiter[3], 3).remainingE;
-    const sum = rem1 + rem2 + rem3;
-    // Floating-Point-tolerant: jede Tab bleibt ≈ 1/3, Summe ≈ 1E.
-    expect(Math.abs(sum - 1)).toBeLessThan(0.05);
-    // Kein Tab zeigt den vollen 1E Mehrbedarf (Netting muss wirken).
-    expect(rem1).toBeLessThan(0.5);
-    expect(rem2).toBeLessThan(0.5);
-    expect(rem3).toBeLessThan(0.5);
+    // Sequenzielle Verteilung: B+C voll abgedeckt, D offen.
+    expect(computeRemaining(w.state.reiter[1], 1).remainingE).toBe(0);  // B first → 0
+    expect(computeRemaining(w.state.reiter[2], 2).remainingE).toBe(0);  // C next → 0
+    expect(computeRemaining(w.state.reiter[3], 3).remainingE).toBe(1);  // D last → 1 (pool empty)
+    // Sum = 1 = un-covered netExcess (3E excess − 2E pool = 1E)
+    const sum = computeRemaining(w.state.reiter[1], 1).remainingE
+              + computeRemaining(w.state.reiter[2], 2).remainingE
+              + computeRemaining(w.state.reiter[3], 3).remainingE;
+    expect(sum).toBe(1);
   });
 });

--- a/tests/54-sequentielle-netting.test.js
+++ b/tests/54-sequentielle-netting.test.js
@@ -1,0 +1,198 @@
+/**
+ * Tests for Issue #368 — Carryover-Netting: pro-rata → sequenziell.
+ *
+ * Carryover-Regel 2: Wenn die verfügbaren Ersparnisse nicht für alle
+ * Mehrbedarf-Tabs reichen, erfolgt die Netting-Abdeckung SEQUENZIELL nach
+ * Bearbeitungs-Reihenfolge (parseEntryTime(lastEntry.time) aufsteigend).
+ * Das zuerst bearbeitete Feld wird KOMPLETT abgedeckt, dann das nächste,
+ * bis die Ersparnis aufgebraucht ist. Tiebreaker gleicher time:
+ * Tab-Index aufsteigend (deterministisch).
+ *
+ * Konkretes Beispiel:
+ *   Tab 1: 10 ha SOLL 20 E, 9 ha IST → Ersparnis 2 E (Saat-Quelle)
+ *   Tab 2: 7,5 ha SOLL 15 E, 8 ha IST → Mehrbedarf 1 E (time 09:00, FIRST)
+ *   Tab 3: 7,5 ha SOLL 15 E, 8 ha IST → Mehrbedarf 1 E (time 10:00, LATER)
+ *   totalSaved = 2 E, totalExcess = 2 E → pool = 2 E
+ *
+ *   Erwartet (sequenziell):
+ *     Tab 2 nettedEinheit = 1 (komplett, erste Quelle, pool ≥ ihr Bedarf)
+ *     Tab 3 nettedEinheit = 1 (komplett, zweite Quelle, pool-rest = 1 ≥ 1)
+ *     Summe nettedEinheit = 2 E
+ *
+ *   Vor #368 (pro-rata): Tab 2 = 1 E, Tab 3 = 1 E (passt hier zufällig, weil
+ *   2 Mehrbedarf-Tabs à 1 E exakt 2 E Pool aufbrauchen).
+ *
+ * Schärferer Test (pool < 2*excess):
+ *   Tab 1: 10 ha SOLL 20 E, 9 ha IST → Ersparnis 2 E
+ *   Tab 2: 7,5 ha SOLL 15 E, 8 ha IST → Mehrbedarf 2 E (time 09:00, FIRST)
+ *   Tab 3: 7,5 ha SOLL 15 E, 8 ha IST → Mehrbedarf 2 E (time 10:00, LATER)
+ *   totalSaved = 2 E, totalExcess = 4 E → pool = 2 E
+ *
+ *   Erwartet (sequenziell):
+ *     Tab 2 nettedEinheit = 2 (komplett, erste Quelle)
+ *     Tab 3 nettedEinheit = 0 (nichts mehr übrig)
+ *
+ *   Vor #368 (pro-rata): Tab 2 = 1, Tab 3 = 1 (BUG).
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createDom } from './helpers.js';
+
+describe('Sequenzielle Carryover-Netting (Issue #368)', () => {
+  let w;
+
+  beforeEach(() => {
+    const result = createDom();
+    w = result.window;
+  });
+
+  // ── Scharfes Szenario: pool < 2 × excess ───────────────────────────────
+  //
+  // Tab 1 (10/9 ha): Ersparnis 2 E Saat + 200 kg Dünger.
+  // Tab 2 (7/8 ha): Mehrbedarf 2 E Saat + 200 kg Dünger (time 09:00, FIRST).
+  // Tab 3 (7/8 ha): Mehrbedarf 2 E Saat + 200 kg Dünger (time 10:00, LATER).
+  // totalSaved = 2 E / 200 kg. totalExcess = 4 E / 400 kg → pool = 2 E / 200 kg.
+  //
+  // Erwartet (sequenziell nach Bearbeitungs-Reihenfolge):
+  //   Tab 2 nettedEinheit = 2  (komplett, erste Quelle, pool ≥ sein Bedarf)
+  //   Tab 3 nettedEinheit = 0  (Pool leer nach Tab 2)
+  //
+  // Vor #368 (pro-rata): Tab 2 = 1, Tab 3 = 1 (BUG).
+  function setupPoolKleinerAlsExcess() {
+    w.state.koernerProEinheit = 50000;
+    w.state.reiter[0] = {
+      name: 'Acker 1', hektar: 10, istHektar: 9, koerner: 100000, duenger: 200,
+      entries: [{ einheit: 18, duenger: 1800, time: '08:00' }],
+      fahrgassenEnabled: false, fahrgassenBreite: 0
+    };
+    w.state.reiter[1] = {
+      name: 'Acker 2', hektar: 7, istHektar: 8, koerner: 100000, duenger: 200,
+      entries: [{ einheit: 14, duenger: 1400, time: '09:00' }],
+      fahrgassenEnabled: false, fahrgassenBreite: 0
+    };
+    w.state.reiter[2] = {
+      name: 'Acker 3', hektar: 7, istHektar: 8, koerner: 100000, duenger: 200,
+      entries: [{ einheit: 14, duenger: 1400, time: '10:00' }],
+      fahrgassenEnabled: false, fahrgassenBreite: 0
+    };
+    if (w.invalidateCarryoverCache) w.invalidateCarryoverCache();
+  }
+
+  it('Tab 2 (FIRST Mehrbedarf, 09:00) wird komplett abgedeckt: nettedEinheit === 2', () => {
+    setupPoolKleinerAlsExcess();
+    const co = w.getCarryover(1);
+    expect(co.nettedEinheit).toBe(2);
+  });
+
+  it('Tab 3 (LATER Mehrbedarf, 10:00) bekommt nichts mehr: nettedEinheit === 0', () => {
+    setupPoolKleinerAlsExcess();
+    const co = w.getCarryover(2);
+    expect(co.nettedEinheit).toBe(0);
+  });
+
+  it('Summe nettedEinheit über beide Mehrbedarf-Tabs === 2 (Pool-Größe, nicht 4)', () => {
+    setupPoolKleinerAlsExcess();
+    const sum = w.getCarryover(1).nettedEinheit + w.getCarryover(2).nettedEinheit;
+    expect(sum).toBe(2);
+  });
+
+  it('Tab 2 ist done (Mehrbedarf voll abgedeckt), Tab 3 nicht (Mehrbedarf offen)', () => {
+    setupPoolKleinerAlsExcess();
+    expect(w.isTabDone(w.state.reiter[1], 1)).toBe(true);
+    expect(w.isTabDone(w.state.reiter[2], 2)).toBe(false);
+  });
+
+  // ── Dünger: separater Pool, gleiche sequenzielle Regel ─────────────────
+  it('Dünger-Pool identisch sequenziell: Tab 2 nettedDuenger === 200, Tab 3 === 0', () => {
+    setupPoolKleinerAlsExcess();
+    // Ersparnis Tab 1 = 200 kg (sol=2000, ist=1800). Mehrbedarf Tab 2+3 = je 200 kg.
+    // Pool = 200. Erwartet: Tab 2 voll (200), Tab 3 leer (0).
+    expect(w.getCarryover(1).nettedDuenger).toBe(200);
+    expect(w.getCarryover(2).nettedDuenger).toBe(0);
+  });
+
+  // ── Edge: Tab-Reihenfolge ≠ time-Reihenfolge (Tab 3 first entry time ist später)
+  //   Hier hat Tab 2 time 11:00, Tab 3 time 09:00.
+  //   Sequenziell nach time: Tab 3 zuerst voll, Tab 2 leer.
+  it('Reihenfolge folgt lastEntry.time aufsteigend, NICHT Tab-Index', () => {
+    w.state.koernerProEinheit = 50000;
+    w.state.reiter[0] = {
+      name: 'Q', hektar: 10, istHektar: 9, koerner: 100000, duenger: 200,
+      entries: [{ einheit: 18, duenger: 1800, time: '08:00' }],
+      fahrgassenEnabled: false, fahrgassenBreite: 0
+    };
+    // Tab B (idx 1) hat SPÄTERE time (11:00), Tab C (idx 2) hat FRÜHERE time (09:00).
+    // Sequenziell: Tab C (09:00) zuerst voll, Tab B (11:00) leer.
+    // Ersparnis 2 E, Mehrbedarf je 2 E → pool = 2.
+    w.state.reiter[1] = {
+      name: 'B', hektar: 7, istHektar: 8, koerner: 100000, duenger: 200,
+      entries: [{ einheit: 14, duenger: 1400, time: '11:00' }],
+      fahrgassenEnabled: false, fahrgassenBreite: 0
+    };
+    w.state.reiter[2] = {
+      name: 'C', hektar: 7, istHektar: 8, koerner: 100000, duenger: 200,
+      entries: [{ einheit: 14, duenger: 1400, time: '09:00' }],
+      fahrgassenEnabled: false, fahrgassenBreite: 0
+    };
+    if (w.invalidateCarryoverCache) w.invalidateCarryoverCache();
+    expect(w.getCarryover(1).nettedEinheit).toBe(0);  // Tab B (11:00) später
+    expect(w.getCarryover(2).nettedEinheit).toBe(2);  // Tab C (09:00) früher
+  });
+
+  // ── Edge: gleiche time → Tiebreaker Tab-Index aufsteigend ──────────────
+  it('Tiebreaker gleicher time: niedrigerer Tab-Index zuerst', () => {
+    w.state.koernerProEinheit = 50000;
+    w.state.reiter[0] = {
+      name: 'Q', hektar: 10, istHektar: 9, koerner: 100000, duenger: 200,
+      entries: [{ einheit: 18, duenger: 1800, time: '08:00' }],
+      fahrgassenEnabled: false, fahrgassenBreite: 0
+    };
+    // Tab B (idx 1, time 09:00), Tab C (idx 2, time 09:00). Bei gleicher time: Tab B zuerst.
+    // Ersparnis 2 E, Mehrbedarf je 2 E → pool = 2. Tab B bekommt 2 (komplett), Tab C leer.
+    w.state.reiter[1] = {
+      name: 'B', hektar: 7, istHektar: 8, koerner: 100000, duenger: 200,
+      entries: [{ einheit: 14, duenger: 1400, time: '09:00' }],
+      fahrgassenEnabled: false, fahrgassenBreite: 0
+    };
+    w.state.reiter[2] = {
+      name: 'C', hektar: 7, istHektar: 8, koerner: 100000, duenger: 200,
+      entries: [{ einheit: 14, duenger: 1400, time: '09:00' }],
+      fahrgassenEnabled: false, fahrgassenBreite: 0
+    };
+    if (w.invalidateCarryoverCache) w.invalidateCarryoverCache();
+    expect(w.getCarryover(1).nettedEinheit).toBe(2);
+    expect(w.getCarryover(2).nettedEinheit).toBe(0);
+  });
+
+  // ── Edge: pool exakt = totalExcess → alle voll abgedeckt ───────────────
+  it('Pool === totalExcess (2 Mehrbedarf-Tabs à 1E, 2E Pool): beide voll', () => {
+    w.state.koernerProEinheit = 50000;
+    w.state.reiter[0] = {
+      name: 'Q', hektar: 10, istHektar: 9, koerner: 100000, duenger: 200,
+      entries: [{ einheit: 18, duenger: 1800, time: '08:00' }],
+      fahrgassenEnabled: false, fahrgassenBreite: 0
+    };
+    // 7.5/8 ha → Mehrbedarf 1 E. totalExcess = 2 E, totalSaved = 2 E → pool = 2.
+    w.state.reiter[1] = {
+      name: 'B', hektar: 7.5, istHektar: 8, koerner: 100000, duenger: 200,
+      entries: [{ einheit: 15, duenger: 1500, time: '09:00' }],
+      fahrgassenEnabled: false, fahrgassenBreite: 0
+    };
+    w.state.reiter[2] = {
+      name: 'C', hektar: 7.5, istHektar: 8, koerner: 100000, duenger: 200,
+      entries: [{ einheit: 15, duenger: 1500, time: '09:30' }],
+      fahrgassenEnabled: false, fahrgassenBreite: 0
+    };
+    if (w.invalidateCarryoverCache) w.invalidateCarryoverCache();
+    expect(w.getCarryover(1).nettedEinheit).toBe(1);
+    expect(w.getCarryover(2).nettedEinheit).toBe(1);
+  });
+
+  // ── Render-Site-Konsistenz: Tab 2 (done) zeigt 0, Tab 3 (offen) zeigt 2 ──
+  it('getTabRemaining: Tab 2 === 0, Tab 3 === 2 (Mehrbedarf offen)', () => {
+    setupPoolKleinerAlsExcess();
+    const rem2 = w.getTabRemaining(w.state.reiter[1], 1);
+    const rem3 = w.getTabRemaining(w.state.reiter[2], 2);
+    expect(rem2.remainingE).toBe(0);
+    expect(rem3.remainingE).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

Carryover-Regel 2 (User-definiert 2026-06-28): Wenn die verfügbaren Ersparnisse nicht für alle Mehrbedarf-Tabs reichen, muss die Netting-Abdeckung **sequenziell nach Bearbeitungs-Reihenfolge** erfolgen — das zuerst bearbeitete Feld wird KOMPLETT abgedeckt, dann das nächste, bis die Ersparnis aufgebraucht ist. Vor #368 war die Verteilung in `computeAllCarryovers()` Phase 0.5 pro-rata.

## Konkretes Beispiel
- Tab 1: 10/9 ha → Ersparnis 2 E Saat + 200 kg Dünger
- Tab 2: 7/8 ha (time 09:00, FIRST) → Mehrbedarf 2 E + 200 kg
- Tab 3: 7/8 ha (time 10:00, LATER) → Mehrbedarf 2 E + 200 kg
- pool = 2 E / 200 kg (totalSaved - totalExcess-Pool-Reduktion)

| | Vor #368 (pro-rata) | Nach #368 (sequenziell) |
|---|---|---|
| Tab 2 nettedEinheit | 1 (50%) ❌ | 2 (komplett) ✓ |
| Tab 3 nettedEinheit | 1 (50%) ❌ | 0 (nichts übrig) ✓ |
| Tab 2 verbleibend | 1 offen | 0 offen |
| Tab 3 verbleibend | 1 offen | 2 offen |

## Fix

**`public/js/calculations.js`** (`computeAllCarryovers`):
- Phase 0.5 sequenzielle Greedy-Zuweisung pro Material (Saat + Dünger getrennt — Regel 4)
- Sortierung: `parseEntryTime(lastEntry.time)` aufsteigend
- Tiebreaker gleicher `time`: Tab-Index aufsteigend (deterministisch)
- Pool-Formel `min(saved, exc) - netExcess` bleibt unverändert

**`public/js/render-drill.js`** (`renderDrillSummary`):
- Issue #347 hatte Mehrbedarf-Tabs aus `totalNeedE`/`Skip` ausgeklammert unter der Annahme, dass ihr Mehraufwand durch den Netto-Saldo-Pool vollständig absorbiert wird. Diese Annahme bricht unter sequenziellem Netting, wenn `pool < totalExcess`: dann bleibt ein Mehrbedarf-Tab UNTERDECKT und sein Rest (`istE - solE - co.nettedEinheit`) muss als real offener Bedarf in der globalen Drill-Summary (`ds_saat_remaining` / `ds_duenger_remaining`) erscheinen — konsistent mit `getTabRemaining()` und der User-Spec "Feld 3 zeigt 2 offen auf ALLEN Sites".

## Tests

- **`tests/54-sequentielle-netting.test.js`** (NEU, 9 Tests): RED-first Coverage für sequenzielle Zuteilung, time-Sortierung, Tab-Index-Tiebreaker, Edge-Cases (pool = totalExcess, pool < 2×excess).
- **`tests/53-mehrbedarf-tab-verbleibend.test.js`**: 3-Mehrbedarf-Tab-Test von pro-rata auf sequenzielle Erwartungen umgestellt (B+C voll, D offen).
- **`tests/05-drill-protocol.test.js`**: Drill-Summary-Erwartung von 9,0 auf 21,6 angepasst (Tab 0 voll ungedeckt, ehrliche Summe der offenen Arbeiten).

## Test-Status
- Branch:  864 passed / 0 failed (53 test files)
- dev (baseline, ohne Fix): 855 passed / 0 failed (52 test files)
- Delta:   +9 passed (neue sequenzielle Tests), 0 failed
- `pnpm lint` ✓

## 4-Site-Verifikation (JSDOM-Repro `.hermes/repro-368-4sites.mjs`)

Setup: 3 Tabs (Ersparnis-Quelle + 2× Mehrbedarf à 2E/200kg mit time 09:00/10:00).

| Site | Tab 1 (FIRST) | Tab 2 (LATER) |
|---|---|---|
| (a) `dtl_e_<i>` (Drill-Tab-Status) | leer (ready) | leer (need) |
| (b) Dashboard `einheitRem`/`duengerRem` | Acker 2: 0 offen | Acker 3: 2/200 offen |
| (c) `r_drill_e_rem_<i>` (Inline) | (n/a ohne active tab) | (n/a ohne active tab) |
| (d) `ds_saat_remaining` / `ds_duenger_remaining` | global: 2,0 Einheiten / 200 kg | |

Verdict: ✓ Tab 2 = 0 offen, Tab 3 = 2 offen auf allen Sites konsistent.

## CACHE_VERSION
v34 → v35 (Issue #353-#361 Batch-Konvention).

Closes #368

🤖 Generated with [Claude Code](https://claude.com/claude-code)