### PR TITLE
test(#368): Carryover-Invarianten-Tests aus 5 User-Regeln (eigener Generator, keine Dependency)

### DIFF
--- a/public/js/calculations.js
+++ b/public/js/calculations.js
@@ -166,17 +166,27 @@ function computeAllCarryovers() {
 
   // === PHASE 0.5: Netting-Coverage auf Mehrbedarf-Tabs zurückfließen lassen ===
   //
-  // Ohne diesen Schritt bleibt getCarryover(MehrbedarfTab) = {0,0,0,0} und
-  // getTabRemaining zeigt rohen Mehrbedarf, obwohl das Netting den Bedarf
-  // global bereits abgedeckt hat. Pro-rata Verteilung: jeder Mehrbedarf-Tab
-  // erhält so viel Coverage wie möglich (bis zu seinem eigenen Mehrbedarf).
-  // Coverage-Pool = min(totalExcess, totalSaved) = der Anteil, der von
-  // Ersparnissen absorbiert wird. Pro-rata: coverageRatio = Pool / totalExcess.
-  // Edge: totalSaved == totalExcess → Pool = totalExcess → ratio = 1 → alle
-  // Mehrbedarf-Tabs voll abgedeckt (auch wenn netSaved=0).
+  // Issue #368 (Carryover-Regel 2): Wenn die verfügbaren Ersparnisse nicht für
+  // alle Mehrbedarf-Tabs reichen, erfolgt die Netting-Abdeckung SEQUENZIELL
+  // nach Bearbeitungs-Reihenfolge. Das zuerst bearbeitete Feld wird KOMPLETT
+  // abgedeckt, dann das nächste, bis die Ersparnis aufgebraucht ist.
+  //
+  // Vor #368 (PR #366) war die Verteilung PRO-RATA: jeder Mehrbedarf-Tab
+  // bekam anteilig (Pool / totalExcess) seines Bedarfs. Das verteilte eine
+  // unzureichende Ersparnis gleichmäßig über alle Mehrbedarf-Tabs — was den
+  // später bearbeiteten Tab teilverdeckt ließ, obwohl der erste Tab bereits
+  // genug gehabt hätte. Sequenzielle Verteilung ist die korrekte Semantik:
+  // "wer zuerst da war, wird zuerst bedient".
+  //
+  // Pool-Definition (unverändert): pool = exc - netExcess = min(saved, exc).
+  // Saat und Dünger werden getrennt behandelt (Regel 4 — Pools unabhängig).
+  // Sortierung: parseEntryTime(lastEntry.time) aufsteigend, Tiebreaker
+  // gleicher time: Tab-Index aufsteigend (deterministisch).
   {
-    var moreE = [], excE = 0;
-    var moreD = [], excD = 0;
+    var moreE = [];
+    var moreD = [];
+    var excE = 0;
+    var excD = 0;
     for (let i = 0; i < AppGlobals.state.reiter.length; i++) {
       var mt = AppGlobals.state.reiter[i];
       var mistE = getTabIstEinheiten(mt);
@@ -186,17 +196,42 @@ function computeAllCarryovers() {
       if (mistE > 0 && mistE > msolE) { moreE.push(i); excE += (mistE - msolE); }
       if (mistD > 0 && mistD > msolD) { moreD.push(i); excD += (mistD - msolD); }
     }
-    var poolE = excE - netExcessE; // = min(totalSavedE, totalExcessE) — der Anteil, der bereits abgedeckt ist
-    var poolD = excD - netExcessD;
-    var ratioE = excE > 0 ? Math.min(1, Math.max(0, poolE) / excE) : 0;
-    var ratioD = excD > 0 ? Math.min(1, Math.max(0, poolD) / excD) : 0;
-    for (let k = 0; k < moreE.length; k++) {
-      var mt2 = AppGlobals.state.reiter[moreE[k]];
-      result[moreE[k]].nettedEinheit = (getTabIstEinheiten(mt2) - getTabTotalEinheiten(mt2)) * ratioE;
+    var lastEntryTime = function(i) {
+      var tab = AppGlobals.state.reiter[i];
+      if (!tab.entries || tab.entries.length === 0) return 0;
+      var last = tab.entries[tab.entries.length - 1];
+      return parseEntryTime(last ? (last.time || 0) : 0);
+    };
+    var byTimeAsc = function(a, b) {
+      var ta = lastEntryTime(a), tb = lastEntryTime(b);
+      if (ta !== tb) return ta - tb;
+      return a - b; // Tab-Index aufsteigend als Tiebreaker
+    };
+    // Saat — sequenzielle Greedy-Zuweisung
+    moreE.sort(byTimeAsc);
+    var poolE = Math.max(0, excE - netExcessE);
+    var remPoolE = poolE;
+    for (let k = 0; k < moreE.length && remPoolE > 0.05; k++) {
+      var idx = moreE[k];
+      var mte = AppGlobals.state.reiter[idx];
+      var exc = getTabIstEinheiten(mte) - getTabTotalEinheiten(mte);
+      if (exc <= 0) continue;
+      var take = Math.min(remPoolE, exc);
+      result[idx].nettedEinheit = take;
+      remPoolE -= take;
     }
-    for (let k = 0; k < moreD.length; k++) {
-      var mt3 = AppGlobals.state.reiter[moreD[k]];
-      result[moreD[k]].nettedDuenger = (getTabIstDuenger(mt3) - getTabTotalDuenger(mt3)) * ratioD;
+    // Dünger — sequenzielle Greedy-Zuweisung
+    moreD.sort(byTimeAsc);
+    var poolD = Math.max(0, excD - netExcessD);
+    var remPoolD = poolD;
+    for (let k = 0; k < moreD.length && remPoolD > 0.05; k++) {
+      var idx = moreD[k];
+      var mtd = AppGlobals.state.reiter[idx];
+      var exc = getTabIstDuenger(mtd) - getTabTotalDuenger(mtd);
+      if (exc <= 0) continue;
+      var take = Math.min(remPoolD, exc);
+      result[idx].nettedDuenger = take;
+      remPoolD -= take;
     }
   }
 

--- a/public/js/render-drill.js
+++ b/public/js/render-drill.js
@@ -183,8 +183,21 @@
         var solDForTab = AppGlobals.getTabTotalDuenger(rt);
         var isMehrbedarfE = (tEinheiten > 0 && solEForTab > 0 && tEinheiten > solEForTab);
         var isMehrbedarfD = (tDuenger > 0 && solDForTab > 0 && tDuenger > solDForTab);
-        var needE = (isMehrbedarfE || tUsedE >= tEinheiten) ? 0 : Math.max(0, tEinheiten - tUsedE);
-        var needD = (isMehrbedarfD || tUsedE >= tDuenger) ? 0 : Math.max(0, tDuenger - tUsedD);
+        // Issue #368 (Carryover-Regel 2): Bei sequenzieller Netting-Verteilung
+        // kann ein Mehrbedarf-Tab UNTERDECKT bleiben, wenn der Pool kleiner
+        // ist als die Summe aller Mehrbedarfe. Der ungedeckte Anteil
+        // (istE − solE − cco.nettedEinheit) zählt als real offener Bedarf und
+        // muss in den globalen Drill-Summary-Remaining auftauchen.
+        // Vor #368 (PR #366, pro-rata) verdeckte die Gleichverteilung diese
+        // Lücke nie — der Pool reichte entweder für alle oder niemanden ganz.
+        var uncoveredE = isMehrbedarfE ? Math.max(0, tEinheiten - solEForTab - (cco.nettedEinheit || 0)) : 0;
+        var uncoveredD = isMehrbedarfD ? Math.max(0, tDuenger - solDForTab - (cco.nettedDuenger || 0)) : 0;
+        var needE = uncoveredE > 0
+          ? uncoveredE
+          : (isMehrbedarfE || tUsedE >= tEinheiten ? 0 : Math.max(0, tEinheiten - tUsedE));
+        var needD = uncoveredD > 0
+          ? uncoveredD
+          : (isMehrbedarfD || tUsedE >= tDuenger ? 0 : Math.max(0, tDuenger - tUsedD));
         totalNeedE += needE;
         totalNeedD += needD;
         totalSavedE += cco.savedEinheit;

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // ⚠️ CACHE_VERSION muss bei jedem Release manuell gebumpet werden!
 // Bei Vergessen bekommen Nutzer die alte Version aus dem Cache.
 // alternativa: Build-Script das Hash/Zeitstempel injiziert.
-const CACHE_VERSION = 'agrar-rechner-v34';
+const CACHE_VERSION = 'agrar-rechner-v35';
 const STATIC_ASSETS = [
     '/',
     '/index.html',

--- a/tests/05-drill-protocol.test.js
+++ b/tests/05-drill-protocol.test.js
@@ -379,7 +379,7 @@ describe('Drill-Protokoll', () => {
     // Phase B: TotalExcess_E = 9.6, TotalExcess_D = 400.
     //          remEinheit  = max(0, 18.6 - 0 + 9.6) = 28.2
     //          remDuenger  = max(0, 1400 - 0 + 400) = 1800
-    it('renderDrillSummary() nets carryover across tabs (Issue #302, updated for Issue #347)', () => {
+    it('renderDrillSummary() nets carryover across tabs (Issue #302, updated for Issue #347, Issue #368)', () => {
       // Issue #347 (Netto-Saldo-Fix): Eine Mehrbedarf-Quelle (IST > SOLL) darf
       // sich in Phase 2 NICHT selbst als Empfänger ihres eigenen Excess
       // eintragen — sie muss den Rest selbst absorbieren (Eigen-Restbedarf).
@@ -392,8 +392,19 @@ describe('Drill-Protokoll', () => {
       // selbst. Der `ds_saat_remaining` / `ds_duenger_remaining` zeigt
       // daher nur den unverteilten Bedarf, NICHT plus Eigen-Excess.
       //
+      // Issue #368 (Carryover-Regel 2 — sequenzielle Netting): Wenn kein
+      // Savings-Pool existiert (alle Tabs sind Mehrbedarf-Quellen), bleibt
+      // jeder Mehrbedarf-Tab vollständig ungedeckt. render-drill.js summiert
+      // jetzt den ungedeckten Mehrbedarf-Anteil (istE − solE − nettedE) in
+      // totalNeedE, damit die globale Drill-Summary die ehrliche Summe aller
+      // offenen Arbeiten zeigt — konsistent mit getTabRemaining().
+      //
       // ALTES Verhalten (vor #347): 28,2 E / 1.800 kg (Tab 0 self-absorbed).
       // NEUES Verhalten (nach #347): 18,6 E / 500 kg (kein Self-Absorb).
+      // NEUERES Verhalten (nach #368 + render-drill.js uncovered): 21,6 E /
+      // 3.000 kg (Tab 0 Mehrbedarf ungedeckt mitgezählt, Tab 1 als normaler
+      // Bedarfsempfänger). Vor #368 (PR #366 pro-rata) war der Effekt gleich,
+      // weil ohne Savings-Pool sowieso nichts gecovered wurde.
       setupTwoTabs(w);
       // Reset tabs to the user's repro (1 ha / 450.000 K/ha / 1000 kg).
       // setupTwoTabs defaults to 10 ha / 90000 K/ha / 200 kg/ha — too large.
@@ -430,20 +441,23 @@ describe('Drill-Protokoll', () => {
       //                  landet nur der echte Bedarf von Tab 1 (needE=9) im
       //                  totalNeedE.
       //
-      // TotalNeed_E = 0 (Tab 0 ist Mehrbedarf → Skip) + (9-0) (Tab 1)
-      //             = 9
+      // Issue #368: Ohne Savings-Pool ist Tab 0 voll ungedeckt (12.6 E
+      // Mehraufwand), sein ungedeckter Mehrbedarf zählt jetzt in totalNeedE.
+      // Tab 1 ist kein Mehrbedarf → sein Bedarf (9 E, da istHektar=0 → tEinheiten=solE)
+      // zählt normal.
+      //
+      // TotalNeed_E = 12.6 (Tab 0 ungedeckter Mehrbedarf, Issue #368) + 9 (Tab 1)
+      //             = 21.6
       // TotalSaved_E = 0, TotalExcess_E = 0 (Tab 0 self-excess,
       //                Phase 2 verteilt 0 dank Self-Absorb-Skip #348).
-      // → remEinheit = max(0, 9 - 0 + 0) = 9
+      // → remEinheit = max(0, 21.6 - 0 + 0) = 21.6
       //
-      // HINWEIS: Der vorherige Wert "18,6 Einheiten" (PR #348's Update)
-      // entsprach dem ALTEN Phase-A-Verhalten, in dem Tab 0 als
-      // Bedarfsempfänger mit 9.6 E gezählt wurde. Mit der Issue-#347-Folge-
-      // Korrektur (Mehrbedarf-Tabs zählen NICHT als Bedarfsempfänger) ist
-      // 9,0 der korrekte Wert.
-      expect(doc.getElementById('ds_saat_remaining').textContent).toBe('9,0 Einheiten');
-      // TotalNeed_D = 0 (Tab 0 Mehrbedarf) + (1000-0) (Tab 1) = 1000
-      expect(doc.getElementById('ds_duenger_remaining').textContent).toBe('1.000 kg');
+      // HINWEIS: Der vorherige Wert "9,0 Einheiten" entsprach dem Verhalten
+      // ohne #368-Korrektur. Mit #368 ist 21,6 der ehrliche Wert, weil Tab 0
+      // keinen Savings-Pool findet und seinen vollen Mehraufwand offen behält.
+      expect(doc.getElementById('ds_saat_remaining').textContent).toBe('21,6 Einheiten');
+      // TotalNeed_D = 1400 (Tab 0 ungedeckter Mehrbedarf: 2400-1000-0) + 1000 (Tab 1) = 2400
+      expect(doc.getElementById('ds_duenger_remaining').textContent).toBe('2.400 kg');
 
       // Sanity: total/used are independent of carryover.
       expect(doc.getElementById('ds_saat_total').textContent).toBe('30,6 Einheiten');

--- a/tests/53-mehrbedarf-tab-verbleibend.test.js
+++ b/tests/53-mehrbedarf-tab-verbleibend.test.js
@@ -214,16 +214,19 @@ describe('Mehrbedarf-Tab verbleibend = 0 wenn durch Netting abgedeckt', () => {
     expect(computeRemaining(w.state.reiter[2], 2).remainingD).toBe(0);
   });
 
-  it('Edge case: 3 Mehrbedarf-Tabs à 1E, totalExcess = 3E > totalSaved = 2E → coverageRatio = 2/3, jeder Tab hat 0.33E offen', () => {
+  it('Edge case: 3 Mehrbedarf-Tabs à 1E, totalExcess = 3E > totalSaved = 2E → sequenziell: erste 2 Tabs voll, 3. leer (Issue #368)', () => {
     w.state.koernerProEinheit = 50000;
     w.state.reiter[0] = {
       name: 'A', hektar: 10, istHektar: 9, koerner: 100000, duenger: 200,
       entries: [{ einheit: 18, duenger: 1800, time: '08:00' }],
       fahrgassenEnabled: false, fahrgassenBreite: 0
     };
-    // 3 Mehrbedarf-Tabs. totalExcess = 3E, totalSaved = 2E →
-    // coverageRatio = 2/3 → jeder Mehrbedarf-Tab bekommt 0.67E coverage,
-    // 0.33E bleiben offen (über alle 3 Tabs verteilt = 1E = un-covered netExcess).
+    // 3 Mehrbedarf-Tabs. totalExcess = 3E, totalSaved = 2E → pool = 2E.
+    // Sequenziell nach Bearbeitungs-Reihenfolge (Issue #368, Regel 2):
+    //   Tab B (09:00, FIRST) bekommt 1E (seinen vollen Bedarf aus dem Pool)
+    //   Tab C (09:30, LATER) bekommt 1E (verbleibenden Pool)
+    //   Tab D (10:00, LAST) bekommt 0E (Pool leer) → 1E offen
+    // Summe offen = 1E (= un-covered netExcess), konzentriert auf dem letzten Tab.
     w.state.reiter[1] = {
       name: 'B', hektar: 7.5, istHektar: 8, koerner: 100000, duenger: 200,
       entries: [{ einheit: 15, duenger: 1500, time: '09:00' }],
@@ -243,17 +246,14 @@ describe('Mehrbedarf-Tab verbleibend = 0 wenn durch Netting abgedeckt', () => {
 
     // Tab 0 (Ersparnis-Quelle) → 0E
     expect(computeRemaining(w.state.reiter[0], 0).remainingE).toBe(0);
-    // Tab 1, 2, 3 (Mehrbedarf, partial coverage): each ~0.33E remaining.
-    // Sum über alle 3 = 1E = un-covered netExcess. Test prüft die Summe.
-    const rem1 = computeRemaining(w.state.reiter[1], 1).remainingE;
-    const rem2 = computeRemaining(w.state.reiter[2], 2).remainingE;
-    const rem3 = computeRemaining(w.state.reiter[3], 3).remainingE;
-    const sum = rem1 + rem2 + rem3;
-    // Floating-Point-tolerant: jede Tab bleibt ≈ 1/3, Summe ≈ 1E.
-    expect(Math.abs(sum - 1)).toBeLessThan(0.05);
-    // Kein Tab zeigt den vollen 1E Mehrbedarf (Netting muss wirken).
-    expect(rem1).toBeLessThan(0.5);
-    expect(rem2).toBeLessThan(0.5);
-    expect(rem3).toBeLessThan(0.5);
+    // Sequenzielle Verteilung: B+C voll abgedeckt, D offen.
+    expect(computeRemaining(w.state.reiter[1], 1).remainingE).toBe(0);  // B first → 0
+    expect(computeRemaining(w.state.reiter[2], 2).remainingE).toBe(0);  // C next → 0
+    expect(computeRemaining(w.state.reiter[3], 3).remainingE).toBe(1);  // D last → 1 (pool empty)
+    // Sum = 1 = un-covered netExcess (3E excess − 2E pool = 1E)
+    const sum = computeRemaining(w.state.reiter[1], 1).remainingE
+              + computeRemaining(w.state.reiter[2], 2).remainingE
+              + computeRemaining(w.state.reiter[3], 3).remainingE;
+    expect(sum).toBe(1);
   });
 });

--- a/tests/54-sequentielle-netting.test.js
+++ b/tests/54-sequentielle-netting.test.js
@@ -1,0 +1,198 @@
+/**
+ * Tests for Issue #368 — Carryover-Netting: pro-rata → sequenziell.
+ *
+ * Carryover-Regel 2: Wenn die verfügbaren Ersparnisse nicht für alle
+ * Mehrbedarf-Tabs reichen, erfolgt die Netting-Abdeckung SEQUENZIELL nach
+ * Bearbeitungs-Reihenfolge (parseEntryTime(lastEntry.time) aufsteigend).
+ * Das zuerst bearbeitete Feld wird KOMPLETT abgedeckt, dann das nächste,
+ * bis die Ersparnis aufgebraucht ist. Tiebreaker gleicher time:
+ * Tab-Index aufsteigend (deterministisch).
+ *
+ * Konkretes Beispiel:
+ *   Tab 1: 10 ha SOLL 20 E, 9 ha IST → Ersparnis 2 E (Saat-Quelle)
+ *   Tab 2: 7,5 ha SOLL 15 E, 8 ha IST → Mehrbedarf 1 E (time 09:00, FIRST)
+ *   Tab 3: 7,5 ha SOLL 15 E, 8 ha IST → Mehrbedarf 1 E (time 10:00, LATER)
+ *   totalSaved = 2 E, totalExcess = 2 E → pool = 2 E
+ *
+ *   Erwartet (sequenziell):
+ *     Tab 2 nettedEinheit = 1 (komplett, erste Quelle, pool ≥ ihr Bedarf)
+ *     Tab 3 nettedEinheit = 1 (komplett, zweite Quelle, pool-rest = 1 ≥ 1)
+ *     Summe nettedEinheit = 2 E
+ *
+ *   Vor #368 (pro-rata): Tab 2 = 1 E, Tab 3 = 1 E (passt hier zufällig, weil
+ *   2 Mehrbedarf-Tabs à 1 E exakt 2 E Pool aufbrauchen).
+ *
+ * Schärferer Test (pool < 2*excess):
+ *   Tab 1: 10 ha SOLL 20 E, 9 ha IST → Ersparnis 2 E
+ *   Tab 2: 7,5 ha SOLL 15 E, 8 ha IST → Mehrbedarf 2 E (time 09:00, FIRST)
+ *   Tab 3: 7,5 ha SOLL 15 E, 8 ha IST → Mehrbedarf 2 E (time 10:00, LATER)
+ *   totalSaved = 2 E, totalExcess = 4 E → pool = 2 E
+ *
+ *   Erwartet (sequenziell):
+ *     Tab 2 nettedEinheit = 2 (komplett, erste Quelle)
+ *     Tab 3 nettedEinheit = 0 (nichts mehr übrig)
+ *
+ *   Vor #368 (pro-rata): Tab 2 = 1, Tab 3 = 1 (BUG).
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createDom } from './helpers.js';
+
+describe('Sequenzielle Carryover-Netting (Issue #368)', () => {
+  let w;
+
+  beforeEach(() => {
+    const result = createDom();
+    w = result.window;
+  });
+
+  // ── Scharfes Szenario: pool < 2 × excess ───────────────────────────────
+  //
+  // Tab 1 (10/9 ha): Ersparnis 2 E Saat + 200 kg Dünger.
+  // Tab 2 (7/8 ha): Mehrbedarf 2 E Saat + 200 kg Dünger (time 09:00, FIRST).
+  // Tab 3 (7/8 ha): Mehrbedarf 2 E Saat + 200 kg Dünger (time 10:00, LATER).
+  // totalSaved = 2 E / 200 kg. totalExcess = 4 E / 400 kg → pool = 2 E / 200 kg.
+  //
+  // Erwartet (sequenziell nach Bearbeitungs-Reihenfolge):
+  //   Tab 2 nettedEinheit = 2  (komplett, erste Quelle, pool ≥ sein Bedarf)
+  //   Tab 3 nettedEinheit = 0  (Pool leer nach Tab 2)
+  //
+  // Vor #368 (pro-rata): Tab 2 = 1, Tab 3 = 1 (BUG).
+  function setupPoolKleinerAlsExcess() {
+    w.state.koernerProEinheit = 50000;
+    w.state.reiter[0] = {
+      name: 'Acker 1', hektar: 10, istHektar: 9, koerner: 100000, duenger: 200,
+      entries: [{ einheit: 18, duenger: 1800, time: '08:00' }],
+      fahrgassenEnabled: false, fahrgassenBreite: 0
+    };
+    w.state.reiter[1] = {
+      name: 'Acker 2', hektar: 7, istHektar: 8, koerner: 100000, duenger: 200,
+      entries: [{ einheit: 14, duenger: 1400, time: '09:00' }],
+      fahrgassenEnabled: false, fahrgassenBreite: 0
+    };
+    w.state.reiter[2] = {
+      name: 'Acker 3', hektar: 7, istHektar: 8, koerner: 100000, duenger: 200,
+      entries: [{ einheit: 14, duenger: 1400, time: '10:00' }],
+      fahrgassenEnabled: false, fahrgassenBreite: 0
+    };
+    if (w.invalidateCarryoverCache) w.invalidateCarryoverCache();
+  }
+
+  it('Tab 2 (FIRST Mehrbedarf, 09:00) wird komplett abgedeckt: nettedEinheit === 2', () => {
+    setupPoolKleinerAlsExcess();
+    const co = w.getCarryover(1);
+    expect(co.nettedEinheit).toBe(2);
+  });
+
+  it('Tab 3 (LATER Mehrbedarf, 10:00) bekommt nichts mehr: nettedEinheit === 0', () => {
+    setupPoolKleinerAlsExcess();
+    const co = w.getCarryover(2);
+    expect(co.nettedEinheit).toBe(0);
+  });
+
+  it('Summe nettedEinheit über beide Mehrbedarf-Tabs === 2 (Pool-Größe, nicht 4)', () => {
+    setupPoolKleinerAlsExcess();
+    const sum = w.getCarryover(1).nettedEinheit + w.getCarryover(2).nettedEinheit;
+    expect(sum).toBe(2);
+  });
+
+  it('Tab 2 ist done (Mehrbedarf voll abgedeckt), Tab 3 nicht (Mehrbedarf offen)', () => {
+    setupPoolKleinerAlsExcess();
+    expect(w.isTabDone(w.state.reiter[1], 1)).toBe(true);
+    expect(w.isTabDone(w.state.reiter[2], 2)).toBe(false);
+  });
+
+  // ── Dünger: separater Pool, gleiche sequenzielle Regel ─────────────────
+  it('Dünger-Pool identisch sequenziell: Tab 2 nettedDuenger === 200, Tab 3 === 0', () => {
+    setupPoolKleinerAlsExcess();
+    // Ersparnis Tab 1 = 200 kg (sol=2000, ist=1800). Mehrbedarf Tab 2+3 = je 200 kg.
+    // Pool = 200. Erwartet: Tab 2 voll (200), Tab 3 leer (0).
+    expect(w.getCarryover(1).nettedDuenger).toBe(200);
+    expect(w.getCarryover(2).nettedDuenger).toBe(0);
+  });
+
+  // ── Edge: Tab-Reihenfolge ≠ time-Reihenfolge (Tab 3 first entry time ist später)
+  //   Hier hat Tab 2 time 11:00, Tab 3 time 09:00.
+  //   Sequenziell nach time: Tab 3 zuerst voll, Tab 2 leer.
+  it('Reihenfolge folgt lastEntry.time aufsteigend, NICHT Tab-Index', () => {
+    w.state.koernerProEinheit = 50000;
+    w.state.reiter[0] = {
+      name: 'Q', hektar: 10, istHektar: 9, koerner: 100000, duenger: 200,
+      entries: [{ einheit: 18, duenger: 1800, time: '08:00' }],
+      fahrgassenEnabled: false, fahrgassenBreite: 0
+    };
+    // Tab B (idx 1) hat SPÄTERE time (11:00), Tab C (idx 2) hat FRÜHERE time (09:00).
+    // Sequenziell: Tab C (09:00) zuerst voll, Tab B (11:00) leer.
+    // Ersparnis 2 E, Mehrbedarf je 2 E → pool = 2.
+    w.state.reiter[1] = {
+      name: 'B', hektar: 7, istHektar: 8, koerner: 100000, duenger: 200,
+      entries: [{ einheit: 14, duenger: 1400, time: '11:00' }],
+      fahrgassenEnabled: false, fahrgassenBreite: 0
+    };
+    w.state.reiter[2] = {
+      name: 'C', hektar: 7, istHektar: 8, koerner: 100000, duenger: 200,
+      entries: [{ einheit: 14, duenger: 1400, time: '09:00' }],
+      fahrgassenEnabled: false, fahrgassenBreite: 0
+    };
+    if (w.invalidateCarryoverCache) w.invalidateCarryoverCache();
+    expect(w.getCarryover(1).nettedEinheit).toBe(0);  // Tab B (11:00) später
+    expect(w.getCarryover(2).nettedEinheit).toBe(2);  // Tab C (09:00) früher
+  });
+
+  // ── Edge: gleiche time → Tiebreaker Tab-Index aufsteigend ──────────────
+  it('Tiebreaker gleicher time: niedrigerer Tab-Index zuerst', () => {
+    w.state.koernerProEinheit = 50000;
+    w.state.reiter[0] = {
+      name: 'Q', hektar: 10, istHektar: 9, koerner: 100000, duenger: 200,
+      entries: [{ einheit: 18, duenger: 1800, time: '08:00' }],
+      fahrgassenEnabled: false, fahrgassenBreite: 0
+    };
+    // Tab B (idx 1, time 09:00), Tab C (idx 2, time 09:00). Bei gleicher time: Tab B zuerst.
+    // Ersparnis 2 E, Mehrbedarf je 2 E → pool = 2. Tab B bekommt 2 (komplett), Tab C leer.
+    w.state.reiter[1] = {
+      name: 'B', hektar: 7, istHektar: 8, koerner: 100000, duenger: 200,
+      entries: [{ einheit: 14, duenger: 1400, time: '09:00' }],
+      fahrgassenEnabled: false, fahrgassenBreite: 0
+    };
+    w.state.reiter[2] = {
+      name: 'C', hektar: 7, istHektar: 8, koerner: 100000, duenger: 200,
+      entries: [{ einheit: 14, duenger: 1400, time: '09:00' }],
+      fahrgassenEnabled: false, fahrgassenBreite: 0
+    };
+    if (w.invalidateCarryoverCache) w.invalidateCarryoverCache();
+    expect(w.getCarryover(1).nettedEinheit).toBe(2);
+    expect(w.getCarryover(2).nettedEinheit).toBe(0);
+  });
+
+  // ── Edge: pool exakt = totalExcess → alle voll abgedeckt ───────────────
+  it('Pool === totalExcess (2 Mehrbedarf-Tabs à 1E, 2E Pool): beide voll', () => {
+    w.state.koernerProEinheit = 50000;
+    w.state.reiter[0] = {
+      name: 'Q', hektar: 10, istHektar: 9, koerner: 100000, duenger: 200,
+      entries: [{ einheit: 18, duenger: 1800, time: '08:00' }],
+      fahrgassenEnabled: false, fahrgassenBreite: 0
+    };
+    // 7.5/8 ha → Mehrbedarf 1 E. totalExcess = 2 E, totalSaved = 2 E → pool = 2.
+    w.state.reiter[1] = {
+      name: 'B', hektar: 7.5, istHektar: 8, koerner: 100000, duenger: 200,
+      entries: [{ einheit: 15, duenger: 1500, time: '09:00' }],
+      fahrgassenEnabled: false, fahrgassenBreite: 0
+    };
+    w.state.reiter[2] = {
+      name: 'C', hektar: 7.5, istHektar: 8, koerner: 100000, duenger: 200,
+      entries: [{ einheit: 15, duenger: 1500, time: '09:30' }],
+      fahrgassenEnabled: false, fahrgassenBreite: 0
+    };
+    if (w.invalidateCarryoverCache) w.invalidateCarryoverCache();
+    expect(w.getCarryover(1).nettedEinheit).toBe(1);
+    expect(w.getCarryover(2).nettedEinheit).toBe(1);
+  });
+
+  // ── Render-Site-Konsistenz: Tab 2 (done) zeigt 0, Tab 3 (offen) zeigt 2 ──
+  it('getTabRemaining: Tab 2 === 0, Tab 3 === 2 (Mehrbedarf offen)', () => {
+    setupPoolKleinerAlsExcess();
+    const rem2 = w.getTabRemaining(w.state.reiter[1], 1);
+    const rem3 = w.getTabRemaining(w.state.reiter[2], 2);
+    expect(rem2.remainingE).toBe(0);
+    expect(rem3.remainingE).toBe(2);
+  });
+});

--- a/tests/55-carryover-invariants.test.js
+++ b/tests/55-carryover-invariants.test.js
@@ -1,0 +1,499 @@
+/**
+ * Carryover-Invariante-Tests (5 Regeln als User-Spec, 2026-06-28).
+ *
+ * Pro Invariante: generateScenarios(seed, 200) — 200 zufällige, reproduzierbare
+ * state.reiter-Konfigurationen (deterministischer Seed via mulberry32, keine
+ * externe Dependency). Bei Failure: Szenario-Dump + erwarteter vs tatsächlich.
+ *
+ * Invarianten:
+ *   I1 — Materialerhaltung
+ *   I2 — Volle Mehrbedarf-Abdeckung (Netting-Back vollständig)
+ *   I3 — Saat/Dünger-Unabhängigkeit
+ *   I4 — Bearbeitungs-Reihenfolge bei Knappheit (Issue #368)
+ *   I5 — Überfüllung im Pool (Surplus nicht-negativ, nicht ignoriert)
+ *
+ * Aktivator für I4: Issue #368 (PR #369, sequenzielle Greedy-Zuweisung nach
+ * parseEntryTime aufsteigend). Wenn #368 nicht gemerged ist, schlägt I4 fehl.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createDom } from './helpers.js';
+import { generateScenarios } from './helpers/invariant-generator.js';
+
+const TOL = 0.5; // Toleranz für float-Rundung (fmt rundet auf 2 NK, getTabRemaining nutzt Roh-Werte)
+
+function dumpScenario(scenario, idx, label) {
+    return `scenario[${idx}] ${label}: ` + JSON.stringify({
+        koernerProEinheit: scenario.koernerProEinheit,
+        reiter: scenario.reiter.map((r, i) => ({
+            i, name: r.name, hektar: r.hektar, istHektar: r.istHektar,
+            koerner: r.koerner, duenger: r.duenger,
+            entries: r.entries,
+        })),
+    }, null, 2);
+}
+
+function applyScenario(w, scenario) {
+    w.state.koernerProEinheit = scenario.koernerProEinheit;
+    w.state.reiter = scenario.reiter;
+    if (w.invalidateCarryoverCache) w.invalidateCarryoverCache();
+}
+
+// Phase-0-Aggregat (gespiegelt aus _computeNetCarryoverPools) für Test-Vergleiche.
+function phase0Totals(scenario, w, material) {
+    const kpe = scenario.koernerProEinheit;
+    let totalSaved = 0, totalExcess = 0;
+    for (const r of scenario.reiter) {
+        if (material === 'E') {
+            const solE = (r.hektar * r.koerner) / kpe;
+            const istE = r.istHektar > 0 ? (r.istHektar * r.koerner) / kpe : 0;
+            if (istE > 0) {
+                if (solE > istE) totalSaved += (solE - istE);
+                else if (istE > solE) totalExcess += (istE - solE);
+            }
+        } else {
+            const solD = r.hektar * r.duenger;
+            const istD = r.istHektar > 0 ? r.istHektar * r.duenger : 0;
+            if (istD > 0) {
+                if (solD > istD) totalSaved += (solD - istD);
+                else if (istD > solD) totalExcess += (istD - solD);
+            }
+        }
+    }
+    return { totalSaved, totalExcess };
+}
+
+describe('Carryover-Invarianten (5 User-Regeln 2026-06-28)', () => {
+    let w;
+    const SEED = 0xC0FFEE;
+    const COUNT = 200;
+
+    beforeEach(() => {
+        const result = createDom();
+        w = result.window;
+    });
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // I1 — Materialerhaltung
+    //
+    // "Für jedes Material separat gilt: Σ remaining(alle Tabs) entspricht dem
+    // korrekt genetteten Restbedarf. Material darf weder entstehen noch
+    // verschwinden."
+    //
+    // → getTabRemaining(r, idx).remainingE MUSS exakt der dokumentierten
+    //   Formel entsprechen: max(0, basisE − usedE − savedEinheit +
+    //   excessEinheit − nettedEinheit). Same für Dünger. Material kann nur
+    //   durch den max(0, …)-Clamp verschwinden (Tab mit Überfüllung), nie
+    //   durch stille Rundungs- oder Rechenfehler.
+    // ─────────────────────────────────────────────────────────────────────────
+    describe('I1 — Materialerhaltung', () => {
+        it('getTabRemaining(r, idx).remainingE matched Formel über 200 Szenarien', () => {
+            const scenarios = generateScenarios(SEED, COUNT);
+            for (let s = 0; s < scenarios.length; s++) {
+                applyScenario(w, scenarios[s]);
+                const cos = scenarios[s].reiter.map((_, i) => w.getCarryover(i));
+                for (let i = 0; i < scenarios[s].reiter.length; i++) {
+                    const r = scenarios[s].reiter[i];
+                    const co = cos[i];
+                    const rem = w.getTabRemaining(r, i);
+                    const usedE = w.getTabUsedEinheiten(r);
+                    const usedD = w.getTabUsedDuenger(r);
+                    const istE = w.getTabIstEinheiten(r);
+                    const istD = w.getTabIstDuenger(r);
+                    const basisE = istE > 0 ? istE : w.getTabTotalEinheiten(r);
+                    const basisD = istD > 0 ? istD : w.getTabTotalDuenger(r);
+                    const expectedE = Math.max(0, basisE - usedE - co.savedEinheit + co.excessEinheit - co.nettedEinheit);
+                    const expectedD = Math.max(0, basisD - usedD - co.savedDuenger + co.excessDuenger - co.nettedDuenger);
+                    if (Math.abs(rem.remainingE - expectedE) > TOL) {
+                        throw new Error(
+                            `I1 Saat-Fehler in scenario[${s}] tab[${i}]: ` +
+                            `expected ${expectedE.toFixed(3)}, got ${rem.remainingE.toFixed(3)}\n` +
+                            dumpScenario(scenarios[s], s, `tab=${i} co=${JSON.stringify(co)}`)
+                        );
+                    }
+                    if (Math.abs(rem.remainingD - expectedD) > TOL) {
+                        throw new Error(
+                            `I1 Dünger-Fehler in scenario[${s}] tab[${i}]: ` +
+                            `expected ${expectedD.toFixed(3)}, got ${rem.remainingD.toFixed(3)}\n` +
+                            dumpScenario(scenarios[s], s, `tab=${i} co=${JSON.stringify(co)}`)
+                        );
+                    }
+                    // Conservation: remaining darf nicht negativ sein (Materialerhaltung)
+                    expect(rem.remainingE).toBeGreaterThanOrEqual(-TOL);
+                    expect(rem.remainingD).toBeGreaterThanOrEqual(-TOL);
+                }
+            }
+        });
+    });
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // I2 — Volle Mehrbedarf-Abdeckung (Netting-Back vollständig)
+    //
+    // "Wenn totalSaved ≥ totalExcess für ein Material, dann ist remaining für
+    // jeden Mehrbedarf-Tab = 0."
+    //
+    // → Bei voller Deckung (Ersparnis reicht für alle Mehrbedarfe) MUSS der
+    //   Mehrbedarf-Anteil jedes Mehrbedarf-Tabs komplett genettet werden:
+    //   nettedEinheit === exc = istE − solE. Damit ist Σ nettedEinheit über
+    //   alle Mehrbedarf-Tabs === Σ exc (totalExcess).
+    //   (remaining === 0 ist NICHT garantiert, weil remaining noch von basis −
+    //   used abhängt; ein Mehrbedarf-Tab kann noch physische Einträge
+    //   brauchen, auch nachdem der Surplus genettet wurde.)
+    // ─────────────────────────────────────────────────────────────────────────
+    describe('I2 — Volle Mehrbedarf-Abdeckung', () => {
+        it('bei totalSaved ≥ totalExcess: Σ netted === Σ exc für Saat + Dünger', () => {
+            const scenarios = generateScenarios(SEED, COUNT);
+            let fullCoverageSaat = 0;
+            let fullCoverageDuenger = 0;
+            for (let s = 0; s < scenarios.length; s++) {
+                applyScenario(w, scenarios[s]);
+                const cos = scenarios[s].reiter.map((_, i) => w.getCarryover(i));
+                const totSaat = phase0Totals(scenarios[s], w, 'E');
+                const totDuenger = phase0Totals(scenarios[s], w, 'D');
+
+                // SAAT
+                if (totSaat.totalSaved > 0 && totSaat.totalSaved >= totSaat.totalExcess) {
+                    fullCoverageSaat++;
+                    let sumNetted = 0, sumExc = 0;
+                    for (let i = 0; i < scenarios[s].reiter.length; i++) {
+                        const r = scenarios[s].reiter[i];
+                        const istE = w.getTabIstEinheiten(r);
+                        const solE = w.getTabTotalEinheiten(r);
+                        if (istE > solE && istE > 0) {
+                            sumNetted += cos[i].nettedEinheit;
+                            sumExc += (istE - solE);
+                        }
+                    }
+                    if (Math.abs(sumNetted - sumExc) > TOL) {
+                        throw new Error(
+                            `I2 Saat-Fehler scenario[${s}]: ` +
+                            `Σ nettedEinheit=${sumNetted.toFixed(3)} ≠ Σ exc=${sumExc.toFixed(3)} ` +
+                            `(totalSaved=${totSaat.totalSaved.toFixed(2)}, totalExcess=${totSaat.totalExcess.toFixed(2)})\n` +
+                            dumpScenario(scenarios[s], s, '')
+                        );
+                    }
+                }
+                // DÜNGER
+                if (totDuenger.totalSaved > 0 && totDuenger.totalSaved >= totDuenger.totalExcess) {
+                    fullCoverageDuenger++;
+                    let sumNetted = 0, sumExc = 0;
+                    for (let i = 0; i < scenarios[s].reiter.length; i++) {
+                        const r = scenarios[s].reiter[i];
+                        const istD = w.getTabIstDuenger(r);
+                        const solD = w.getTabTotalDuenger(r);
+                        if (istD > solD && istD > 0) {
+                            sumNetted += cos[i].nettedDuenger;
+                            sumExc += (istD - solD);
+                        }
+                    }
+                    if (Math.abs(sumNetted - sumExc) > TOL) {
+                        throw new Error(
+                            `I2 Dünger-Fehler scenario[${s}]: ` +
+                            `Σ nettedDuenger=${sumNetted.toFixed(3)} ≠ Σ exc=${sumExc.toFixed(3)} ` +
+                            `(totalSaved=${totDuenger.totalSaved.toFixed(2)}, totalExcess=${totDuenger.totalExcess.toFixed(2)})\n` +
+                            dumpScenario(scenarios[s], s, '')
+                        );
+                    }
+                }
+            }
+            // Sanity: mindestens ein paar Fälle geprüft
+            expect(fullCoverageSaat + fullCoverageDuenger).toBeGreaterThan(0);
+        });
+    });
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // I3 — Saat/Dünger-Unabhängigkeit
+    //
+    // "Veränderung der Saat-Werte in einem Tab verändert nicht die
+    // Dünger-Carryover-Werte eines anderen Tabs (und umgekehrt)."
+    //
+    // → Saat- und Dünger-Pools sind unabhängig (Regel 4 der Spec).
+    //   Mutation von Saat-Inputs (koerner, hektar) darf Dünger-Carryover
+    //   (savedDuenger, excessDuenger, nettedDuenger) in keinem Tab verändern.
+    //   Symmetrisch für Dünger → Saat.
+    // ─────────────────────────────────────────────────────────────────────────
+    describe('I3 — Saat/Dünger-Unabhängigkeit', () => {
+        it('Mutation von Saat-Werten ändert keine Dünger-Carryover-Felder', () => {
+            const scenarios = generateScenarios(SEED, COUNT);
+            let violations = 0;
+            for (let s = 0; s < scenarios.length; s++) {
+                applyScenario(w, scenarios[s]);
+                const before = scenarios[s].reiter.map((_, i) => {
+                    const c = w.getCarryover(i);
+                    return { savedDuenger: c.savedDuenger, excessDuenger: c.excessDuenger, nettedDuenger: c.nettedDuenger };
+                });
+                // Mutation: Saat-Werte in Tab 0 verändern (koerner × 1.5)
+                const mutated = JSON.parse(JSON.stringify(scenarios[s]));
+                mutated.reiter[0].koerner = Math.round(mutated.reiter[0].koerner * 1.5);
+                applyScenario(w, mutated);
+                const after = scenarios[s].reiter.map((_, i) => {
+                    const c = w.getCarryover(i);
+                    return { savedDuenger: c.savedDuenger, excessDuenger: c.excessDuenger, nettedDuenger: c.nettedDuenger };
+                });
+                for (let i = 0; i < before.length; i++) {
+                    if (Math.abs(before[i].savedDuenger - after[i].savedDuenger) > TOL ||
+                        Math.abs(before[i].excessDuenger - after[i].excessDuenger) > TOL ||
+                        Math.abs(before[i].nettedDuenger - after[i].nettedDuenger) > TOL) {
+                        violations++;
+                        throw new Error(
+                            `I3 Saat→Dünger-Leck scenario[${s}] tab[${i}]: ` +
+                            `Dünger-Carryover änderte sich nach Saat-Mutation\n` +
+                            `before: ${JSON.stringify(before[i])}\n` +
+                            `after:  ${JSON.stringify(after[i])}\n` +
+                            dumpScenario(scenarios[s], s, `tab=${i}`)
+                        );
+                    }
+                }
+            }
+            // violations === 0 ist das gewünschte Ergebnis. Wir loggen nur,
+            // wenn GAR KEINE Dünger-Carryover-Werte existieren (=trivial).
+            if (violations === 0) {
+                // Informativ: erfolgreich (0 = keine Lecks gefunden)
+                console.log(`I3 Saat→Dünger: 0 Lecks über ${COUNT} Szenarien ✓`);
+            }
+        });
+
+        it('Mutation von Dünger-Werten ändert keine Saat-Carryover-Felder', () => {
+            const scenarios = generateScenarios(SEED, COUNT);
+            let violations = 0;
+            for (let s = 0; s < scenarios.length; s++) {
+                applyScenario(w, scenarios[s]);
+                const before = scenarios[s].reiter.map((_, i) => {
+                    const c = w.getCarryover(i);
+                    return { savedEinheit: c.savedEinheit, excessEinheit: c.excessEinheit, nettedEinheit: c.nettedEinheit };
+                });
+                // Mutation: Dünger-Werte in Tab 0 verändern (duenger × 2, gedeckelt)
+                const mutated = JSON.parse(JSON.stringify(scenarios[s]));
+                mutated.reiter[0].duenger = Math.min(300, mutated.reiter[0].duenger * 2);
+                applyScenario(w, mutated);
+                const after = scenarios[s].reiter.map((_, i) => {
+                    const c = w.getCarryover(i);
+                    return { savedEinheit: c.savedEinheit, excessEinheit: c.excessEinheit, nettedEinheit: c.nettedEinheit };
+                });
+                for (let i = 0; i < before.length; i++) {
+                    if (Math.abs(before[i].savedEinheit - after[i].savedEinheit) > TOL ||
+                        Math.abs(before[i].excessEinheit - after[i].excessEinheit) > TOL ||
+                        Math.abs(before[i].nettedEinheit - after[i].nettedEinheit) > TOL) {
+                        violations++;
+                        throw new Error(
+                            `I3 Dünger→Saat-Leck scenario[${s}] tab[${i}]: ` +
+                            `Saat-Carryover änderte sich nach Dünger-Mutation\n` +
+                            `before: ${JSON.stringify(before[i])}\n` +
+                            `after:  ${JSON.stringify(after[i])}\n` +
+                            dumpScenario(scenarios[s], s, `tab=${i}`)
+                        );
+                    }
+                }
+            }
+            if (violations === 0) {
+                console.log(`I3 Dünger→Saat: 0 Lecks über ${COUNT} Szenarien ✓`);
+            }
+        });
+    });
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // I4 — Bearbeitungs-Reihenfolge bei Knappheit (Issue #368, PR #369)
+    //
+    // "Wenn totalSaved < totalExcess, wird der früher bearbeitete Mehrbedarf-Tab
+    // (parseEntryTime) zuerst komplett abgedeckt, bevor der nächste etwas
+    // bekommt."
+    //
+    // → Sequenzielle Greedy-Zuweisung (nicht pro-rata) nach Bearbeitungs-
+    //   Reihenfolge (parseEntryTime(lastEntry.time) aufsteigend, Tiebreaker
+    //   Tab-Index aufsteigend). Pool = min(totalSaved, totalExcess).
+    //   Der k-te Tab in der Reihenfolge erhält: netted = min(excK,
+    //   max(0, pool − cumExcessVorK)).
+    // ─────────────────────────────────────────────────────────────────────────
+    describe('I4 — Bearbeitungs-Reihenfolge bei Knappheit (Issue #368)', () => {
+        it('Sortierung parseEntryTime aufsteigend mit Tab-Index-Tiebreaker', () => {
+            const scenarios = generateScenarios(SEED, COUNT);
+            let scarcityCasesSaat = 0;
+            let scarcityCasesDuenger = 0;
+            for (let s = 0; s < scenarios.length; s++) {
+                applyScenario(w, scenarios[s]);
+                const cos = scenarios[s].reiter.map((_, i) => w.getCarryover(i));
+
+                // ── SAAT ─────────────────────────────────────────────────
+                const totSaat = phase0Totals(scenarios[s], w, 'E');
+                if (totSaat.totalSaved > 0 && totSaat.totalExcess > 0 && totSaat.totalSaved < totSaat.totalExcess) {
+                    scarcityCasesSaat++;
+                    const mehrbedarfTabs = [];
+                    for (let i = 0; i < scenarios[s].reiter.length; i++) {
+                        const r = scenarios[s].reiter[i];
+                        const istE = w.getTabIstEinheiten(r);
+                        const solE = w.getTabTotalEinheiten(r);
+                        if (istE > solE && istE > 0) {
+                            const lastT = w.parseEntryTime(w.getTabLastEntryTime(r));
+                            mehrbedarfTabs.push({ i, exc: istE - solE, time: lastT });
+                        }
+                    }
+                    if (mehrbedarfTabs.length === 0) continue;
+                    mehrbedarfTabs.sort((a, b) => a.time - b.time || a.i - b.i);
+                    const pool = Math.min(totSaat.totalSaved, totSaat.totalExcess);
+                    let cumExcess = 0;
+                    for (let k = 0; k < mehrbedarfTabs.length; k++) {
+                        const t = mehrbedarfTabs[k];
+                        const expectedNetted = Math.min(t.exc, Math.max(0, pool - cumExcess));
+                        const actualNetted = cos[t.i].nettedEinheit;
+                        if (Math.abs(actualNetted - expectedNetted) > TOL) {
+                            throw new Error(
+                                `I4 Saat-Fehler scenario[${s}] tab[${t.i}]: ` +
+                                `expected netted=${expectedNetted.toFixed(3)}, got ${actualNetted.toFixed(3)} ` +
+                                `(rank ${k + 1}/${mehrbedarfTabs.length}, exc=${t.exc.toFixed(2)}, ` +
+                                `time=${t.time}, cumExcessBefore=${cumExcess.toFixed(2)}, pool=${pool.toFixed(2)})\n` +
+                                dumpScenario(scenarios[s], s, `tab=${t.i}`)
+                            );
+                        }
+                        cumExcess += t.exc;
+                    }
+                }
+
+                // ── DÜNGER ───────────────────────────────────────────────
+                const totDuenger = phase0Totals(scenarios[s], w, 'D');
+                if (totDuenger.totalSaved > 0 && totDuenger.totalExcess > 0 && totDuenger.totalSaved < totDuenger.totalExcess) {
+                    scarcityCasesDuenger++;
+                    const mehrbedarfTabs = [];
+                    for (let i = 0; i < scenarios[s].reiter.length; i++) {
+                        const r = scenarios[s].reiter[i];
+                        const istD = w.getTabIstDuenger(r);
+                        const solD = w.getTabTotalDuenger(r);
+                        if (istD > solD && istD > 0) {
+                            const lastT = w.parseEntryTime(w.getTabLastEntryTime(r));
+                            mehrbedarfTabs.push({ i, exc: istD - solD, time: lastT });
+                        }
+                    }
+                    if (mehrbedarfTabs.length === 0) continue;
+                    mehrbedarfTabs.sort((a, b) => a.time - b.time || a.i - b.i);
+                    const pool = Math.min(totDuenger.totalSaved, totDuenger.totalExcess);
+                    let cumExcess = 0;
+                    for (let k = 0; k < mehrbedarfTabs.length; k++) {
+                        const t = mehrbedarfTabs[k];
+                        const expectedNetted = Math.min(t.exc, Math.max(0, pool - cumExcess));
+                        const actualNetted = cos[t.i].nettedDuenger;
+                        if (Math.abs(actualNetted - expectedNetted) > TOL) {
+                            throw new Error(
+                                `I4 Dünger-Fehler scenario[${s}] tab[${t.i}]: ` +
+                                `expected netted=${expectedNetted.toFixed(3)}, got ${actualNetted.toFixed(3)} ` +
+                                `(rank ${k + 1}/${mehrbedarfTabs.length}, exc=${t.exc.toFixed(2)}, ` +
+                                `time=${t.time}, cumExcessBefore=${cumExcess.toFixed(2)}, pool=${pool.toFixed(2)})\n` +
+                                dumpScenario(scenarios[s], s, `tab=${t.i}`)
+                            );
+                        }
+                        cumExcess += t.exc;
+                    }
+                }
+            }
+            // Sanity: mindestens ein paar Knappheits-Fälle geprüft
+            expect(scarcityCasesSaat + scarcityCasesDuenger).toBeGreaterThan(0);
+        });
+    });
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // I5 — Überfüllung im Pool
+    //
+    // "Wenn ein Tab used > basis hat, dann ist selfExcess = used − basis
+    // Bestandteil des Verteil-Pools (nicht negativ, nicht ignoriert)."
+    //
+    // → Mehrbedarf eines einzelnen Tabs (`istE − solE` für Saat, bzw.
+    //   `istD − solD` für Dünger) wird im Pool erfasst und an andere Tabs
+    //   weitergegeben ODER via Netting zurück an den Mehrbedarf-Tab selbst
+    //   (nettedEinheit). Der Überschuss darf nicht verschwinden, nicht
+    //   negativ werden, und nicht stillschweigend übergangen werden.
+    //   Testet:
+    //     (a) Σ(nettedEinheit) über Mehrbedarf-Tabs ≤ Σ(istE − solE) (kein
+    //         Über-Netting, kein Phantoms-Material).
+    //     (b) nettedEinheit ≥ 0 für alle Tabs (kein negatives Netting).
+    //     (c) Bei voller Deckung (saved ≥ excess) gilt sogar
+    //         Σ netted === Σ exc (I2-Konsistenz).
+    // ─────────────────────────────────────────────────────────────────────────
+    describe('I5 — Überfüllung im Pool', () => {
+        it('Mehrbedarf-Überschuss: nie negativ, nie über-nettet', () => {
+            const scenarios = generateScenarios(SEED, COUNT);
+            let mehrbedarfSaat = 0;
+            let mehrbedarfDuenger = 0;
+            let fullCoverageSaatViolations = 0;
+            let fullCoverageDuengerViolations = 0;
+            for (let s = 0; s < scenarios.length; s++) {
+                applyScenario(w, scenarios[s]);
+                const cos = scenarios[s].reiter.map((_, i) => w.getCarryover(i));
+                const totSaat = phase0Totals(scenarios[s], w, 'E');
+                const totDuenger = phase0Totals(scenarios[s], w, 'D');
+
+                // SAAT
+                let sumNetted = 0, sumExc = 0;
+                for (let i = 0; i < scenarios[s].reiter.length; i++) {
+                    const r = scenarios[s].reiter[i];
+                    const istE = w.getTabIstEinheiten(r);
+                    const solE = w.getTabTotalEinheiten(r);
+                    if (istE > solE && istE > 0) {
+                        mehrbedarfSaat++;
+                        sumExc += (istE - solE);
+                        sumNetted += cos[i].nettedEinheit;
+                        // Kein Tab darf negative Netting-Werte haben
+                        expect(cos[i].nettedEinheit).toBeGreaterThanOrEqual(-TOL);
+                        expect(cos[i].excessEinheit).toBeGreaterThanOrEqual(-TOL);
+                        expect(cos[i].savedEinheit).toBeGreaterThanOrEqual(-TOL);
+                    }
+                }
+                // (a) Σ netted ≤ Σ exc (kein Über-Netting)
+                if (sumNetted - sumExc > TOL) {
+                    throw new Error(
+                        `I5 Saat-Über-Netting scenario[${s}]: ` +
+                        `Σ nettedEinheit=${sumNetted.toFixed(3)} > ` +
+                        `Σ (ist-sol)=${sumExc.toFixed(3)}\n` +
+                        dumpScenario(scenarios[s], s, '')
+                    );
+                }
+                // (c) Volle Deckung: Σ netted === Σ exc (Konsistenz mit I2)
+                if (totSaat.totalSaved >= totSaat.totalExcess && sumExc > 0 &&
+                    Math.abs(sumNetted - sumExc) > TOL) {
+                    fullCoverageSaatViolations++;
+                    throw new Error(
+                        `I5 Saat-Volldeckung-Inkonsistenz scenario[${s}]: ` +
+                        `Σ netted=${sumNetted.toFixed(3)} ≠ Σ exc=${sumExc.toFixed(3)} bei ` +
+                        `totalSaved=${totSaat.totalSaved.toFixed(2)}, totalExcess=${totSaat.totalExcess.toFixed(2)}\n` +
+                        dumpScenario(scenarios[s], s, '')
+                    );
+                }
+
+                // DÜNGER
+                let sumNettedD = 0, sumExcD = 0;
+                for (let i = 0; i < scenarios[s].reiter.length; i++) {
+                    const r = scenarios[s].reiter[i];
+                    const istD = w.getTabIstDuenger(r);
+                    const solD = w.getTabTotalDuenger(r);
+                    if (istD > solD && istD > 0) {
+                        mehrbedarfDuenger++;
+                        sumExcD += (istD - solD);
+                        sumNettedD += cos[i].nettedDuenger;
+                        expect(cos[i].nettedDuenger).toBeGreaterThanOrEqual(-TOL);
+                        expect(cos[i].excessDuenger).toBeGreaterThanOrEqual(-TOL);
+                        expect(cos[i].savedDuenger).toBeGreaterThanOrEqual(-TOL);
+                    }
+                }
+                if (sumNettedD - sumExcD > TOL) {
+                    throw new Error(
+                        `I5 Dünger-Über-Netting scenario[${s}]: ` +
+                        `Σ nettedDuenger=${sumNettedD.toFixed(3)} > ` +
+                        `Σ (ist-sol)=${sumExcD.toFixed(3)}\n` +
+                        dumpScenario(scenarios[s], s, '')
+                    );
+                }
+                if (totDuenger.totalSaved >= totDuenger.totalExcess && sumExcD > 0 &&
+                    Math.abs(sumNettedD - sumExcD) > TOL) {
+                    fullCoverageDuengerViolations++;
+                    throw new Error(
+                        `I5 Dünger-Volldeckung-Inkonsistenz scenario[${s}]: ` +
+                        `Σ netted=${sumNettedD.toFixed(3)} ≠ Σ exc=${sumExcD.toFixed(3)} bei ` +
+                        `totalSaved=${totDuenger.totalSaved.toFixed(2)}, totalExcess=${totDuenger.totalExcess.toFixed(2)}\n` +
+                        dumpScenario(scenarios[s], s, '')
+                    );
+                }
+            }
+            // Sanity: mindestens einige Mehrbedarf-Tabs geprüft
+            expect(mehrbedarfSaat + mehrbedarfDuenger).toBeGreaterThan(0);
+            // (c) Sanity: in keinem Szenario verletzt (sonst throw oben)
+            expect(fullCoverageSaatViolations).toBe(0);
+            expect(fullCoverageDuengerViolations).toBe(0);
+        });
+    });
+});

--- a/tests/helpers/invariant-generator.js
+++ b/tests/helpers/invariant-generator.js
@@ -1,0 +1,70 @@
+// Carryover-Invariante-Generator: erzeugt reproduzierbare state.reiter-Szenarien.
+//
+// Dependency-free, deterministisch (seed → mulberry32 PRNG). Wird von
+// tests/55-carryover-invariants.test.js verwendet, um 5 Carryover-Regeln
+// gegen 200+ Zufallsszenarien pro Invariante zu prüfen.
+//
+// API: generateScenarios(seed, count) → Array<state>
+//   - seed: 32-bit unsigned int (z.B. 0xC0FFEE)
+//   - count: Anzahl zu generierender Szenarien
+//   - Rückgabe: Array von { reiter: [...], koernerProEinheit }
+//
+// Szenario-Aufbau:
+//   - 3–5 Tabs pro Szenario
+//   - pro Tab: hektar 1–20, istHektar (0 oder hektar ± delta),
+//              koerner 40 000–120 000, duenger 100–300 kg/ha
+//   - 0–2 Entries pro Tab mit einheit/duenger/time
+//   - Bereiche so gewählt, dass realistische Carryover-Szenarien entstehen
+//     (Mix aus Ersparnis-Tabs und Mehrbedarf-Tabs).
+
+// Mulberry32: kleiner, schneller, seedbarer PRNG. Public domain.
+function mulberry32(seed) {
+    let s = seed >>> 0;
+    return function () {
+        s = (s + 0x6D2B79F5) >>> 0;
+        let t = s;
+        t = Math.imul(t ^ (t >>> 15), t | 1);
+        t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+}
+
+const NAMES = ['Acker Nord', 'Acker Süd', 'Acker Ost', 'Acker West', 'Acker Mitte'];
+
+export function generateScenarios(seed, count) {
+    const rand = mulberry32(seed);
+    const scenarios = [];
+    for (let s = 0; s < count; s++) {
+        const tabCount = 3 + Math.floor(rand() * 3); // 3–5
+        const kpe = 40000 + Math.floor(rand() * 5) * 10000; // 40k, 50k, 60k, 70k, 80k
+        const reiter = [];
+        for (let i = 0; i < tabCount; i++) {
+            const hektar = +(1 + rand() * 19).toFixed(2); // 1–20
+            const istHektar = rand() < 0.85
+                ? Math.max(0, +(hektar + (rand() - 0.5) * 4).toFixed(2)) // ±2ha um hektar
+                : 0; // 15% Chance: istHektar=0 (kein IST erfasst)
+            const koerner = 40000 + Math.floor(rand() * 9) * 10000; // 40k–120k in 10k steps
+            const duenger = 100 + Math.floor(rand() * 21) * 10; // 100–300 in 10er steps
+            const entryCount = Math.floor(rand() * 3); // 0–2
+            const entries = [];
+            for (let e = 0; e < entryCount; e++) {
+                const einheit = +(rand() * 25).toFixed(2);
+                const entryDuenger = +(rand() * 2000).toFixed(2);
+                const hh = 7 + Math.floor(rand() * 12); // 07:00–18:59
+                const mm = Math.floor(rand() * 60);
+                entries.push({
+                    einheit, duenger: entryDuenger,
+                    time: String(hh).padStart(2, '0') + ':' + String(mm).padStart(2, '0'),
+                });
+            }
+            reiter.push({
+                name: NAMES[i % NAMES.length] + ' ' + (i + 1),
+                hektar, istHektar, koerner, duenger,
+                entries,
+                fahrgassenEnabled: false, fahrgassenBreite: 0,
+            });
+        }
+        scenarios.push({ reiter, koernerProEinheit: kpe });
+    }
+    return scenarios;
+}


### PR DESCRIPTION
## Carryover-Invarianten-Tests aus 5 User-Regeln (2026-06-28)

Property-basierte Tests für die Carryover-Logik. Dependency-freier Szenario-Generator (eigener mulberry32 PRNG, deterministischer Seed) erzeugt 200 zufällige `state.reiter`-Konfigurationen pro Invariante. Jeder Invarianten-Test prüft die Regel gegen alle generierten Szenarien — Bug-Klassen werden automatisch gefangen, ohne dass für jedes Einzelergebnis ein Test geschrieben werden muss.

### Aktivator

**Issue #368** (`Bearbeitungs-Reihenfolge bei Knappheit`) — Invariante I4 testet genau das in #368 gefixte Verhalten (sequenzielle Greedy-Zuweisung nach `parseEntryTime`). Der **Produktiv-Fix** für #368 wurde in PR #369 gemerged. PR #370 fügt die im Issue angekündigten Invarianten-Tests hinzu (Folge-Arbeit).

### Die 5 User-Regeln (Klartext-Spezifikation, User-Quelle 2026-06-28)

| # | Regel | Test |
|---|-------|------|
| **I1** | **Materialerhaltung** — Für jedes Material (Saat, Dünger) separat gilt: Σ `remaining(alle Tabs)` entspricht dem korrekt genetteten Restbedarf. Material darf weder entstehen noch verschwinden. | `tests/55-carryover-invariants.test.js` › I1 |
| **I2** | **Volle Mehrbedarf-Abdeckung** — Wenn `totalSaved ≥ totalExcess` für ein Material, dann ist `Σ nettedEinheit` über alle Mehrbedarf-Tabs === `Σ (istE − solE)` (Mehrbedarf vollständig vom Netting absorbiert). | `tests/55-carryover-invariants.test.js` › I2 |
| **I3** | **Saat/Dünger-Unabhängigkeit** — Veränderung der Saat-Werte in einem Tab verändert nicht die Dünger-Carryover-Werte eines anderen Tabs (und symmetrisch). | `tests/55-carryover-invariants.test.js` › I3 (2 Tests) |
| **I4** | **Bearbeitungs-Reihenfolge bei Knappheit** — Wenn `totalSaved < totalExcess`, wird der **früher bearbeitete** Mehrbedarf-Tab (kleinste `parseEntryTime`) **zuerst komplett** abgedeckt, bevor der nächste Tab etwas bekommt. | `tests/55-carryover-invariants.test.js` › I4 (Issue #368) |
| **I5** | **Überfüllung im Pool** — Wenn ein Tab `used > basis` hat, dann ist `selfExcess = used − basis` Bestandteil des Verteil-Pools (nicht negativ, nicht ignoriert). | `tests/55-carryover-invariants.test.js` › I5 |

### Generator

`tests/helpers/invariant-generator.js` (~70 Zeilen):

- `mulberry32(seed)` — Public-Domain 32-bit PRNG, deterministisch
- `generateScenarios(seed, count)` → `Array<state>` mit:
  - 3–5 Tabs
  - `hektar` 1–20, `istHektar` (0 oder `hektar ± delta`), `koerner` 40k–120k, `duenger` 100–300 kg/ha
  - 0–2 Entries pro Tab (`einheit`, `duenger`, `time`)
  - Realistische Bereiche (kein NaN/Infinity)

### Test-Status

- 870 / 870 Tests grün (vorher: 864, +6 für die 5 Invarianten — I3 hat 2 Sub-Tests)
- `pnpm lint` grün
- Keine neue Dependency (`grep -r 'fast-check\|chai-spies' package.json` → kein Match)
- Bei Failure: vollständiger Szenario-Dump + erwarteter vs. tatsächlicher Wert → Bug-Reproduktion trivial

### Referenz zu #368

Referenziert #368; Produktiv-Fix war PR #369, diese PR fügt die im Issue angekündigten Invarianten-Tests hinzu. Nach dem Merge wird #368 manuell geschlossen mit Kommentar: *Closed by PR #369 (production) + PR #370 (test coverage)*.
