### PR TITLE
fix(#371): Carryover Phase 0.5 Pool = unfilled + Ersparnis

### DIFF
--- a/public/js/calculations.js
+++ b/public/js/calculations.js
@@ -178,7 +178,18 @@ function computeAllCarryovers() {
   // genug gehabt hätte. Sequenzielle Verteilung ist die korrekte Semantik:
   // "wer zuerst da war, wird zuerst bedient".
   //
-  // Pool-Definition (unverändert): pool = exc - netExcess = min(saved, exc).
+  // Issue #371 (Carryover-Regel 6): Pool-Definition erweitert. Vorher war der
+  // Pool = min(saved, exc) = max(0, exc − netExcess), i.e. nur die IST<SOLL-
+  // Ersparnis aus neutralen Tabs. Physisch wurde das Mehrbedarf-Material
+  // aber auch aus NOCH-UNGEFÜLLTEN Tabs entnommen (used < basis), nicht nur
+  // aus Ersparnis-Tabs (istE < solE). Korrekt: Pool = Σ tabE_contrib für alle
+  // NICHT-Mehrbedarf-Tabs, wobei
+  //   tabE_contrib = max(0, basis − used)   // unfilled: physisch ungedrillt
+  //                 + max(0, sol − ist)       // Ersparnis: SOLL−IST Überhang
+  // Ein Tab ohne Einträge (used=0, istE=0 → basis=solE) trägt damit seinen
+  // vollen SOLL-Bedarf als "noch nicht angefasst"-Pool bei. Mehrbedarf-Tabs
+  // (IST > SOLL) sind Empfänger und werden ausgeschlossen.
+  //
   // Saat und Dünger werden getrennt behandelt (Regel 4 — Pools unabhängig).
   // Sortierung: parseEntryTime(lastEntry.time) aufsteigend, Tiebreaker
   // gleicher time: Tab-Index aufsteigend (deterministisch).
@@ -187,14 +198,41 @@ function computeAllCarryovers() {
     var moreD = [];
     var excE = 0;
     var excD = 0;
+    // Pool-Größe separat aggregieren (Regel 6, Issue #371):
+    // Σ (unfilled + Ersparnis) für alle NICHT-Mehrbedarf-Tabs.
+    var poolE = 0;
+    var poolD = 0;
     for (let i = 0; i < AppGlobals.state.reiter.length; i++) {
       var mt = AppGlobals.state.reiter[i];
       var mistE = getTabIstEinheiten(mt);
       var msolE = getTabTotalEinheiten(mt);
       var mistD = getTabIstDuenger(mt);
       var msolD = getTabTotalDuenger(mt);
-      if (mistE > 0 && mistE > msolE) { moreE.push(i); excE += (mistE - msolE); }
-      if (mistD > 0 && mistD > msolD) { moreD.push(i); excD += (mistD - msolD); }
+      var musedE = getTabUsedEinheiten(mt);
+      var musedD = getTabUsedDuenger(mt);
+      var mehrbedarfE = (mistE > 0 && mistE > msolE);
+      var mehrbedarfD = (mistD > 0 && mistD > msolD);
+      if (mehrbedarfE) {
+        moreE.push(i);
+        excE += (mistE - msolE);
+      } else {
+        // unfilled + Ersparnis. Nur Tabs mit istHektar>0 (mistE>0) tragen bei —
+        // ein Tab ohne istHektar (mistE=0) hat noch nichts Konkretes
+        // angefasst oder geplant, sein SOLL ist nicht "verfügbar umverteilbar".
+        if (mistE > 0) {
+          var basisE = mistE; // immer istE weil mistE>0
+          poolE += Math.max(0, basisE - musedE) + Math.max(0, msolE - mistE);
+        }
+      }
+      if (mehrbedarfD) {
+        moreD.push(i);
+        excD += (mistD - msolD);
+      } else {
+        if (mistD > 0) {
+          var basisD2 = mistD;
+          poolD += Math.max(0, basisD2 - musedD) + Math.max(0, msolD - mistD);
+        }
+      }
     }
     var lastEntryTime = function(i) {
       var tab = AppGlobals.state.reiter[i];
@@ -209,7 +247,6 @@ function computeAllCarryovers() {
     };
     // Saat — sequenzielle Greedy-Zuweisung
     moreE.sort(byTimeAsc);
-    var poolE = Math.max(0, excE - netExcessE);
     var remPoolE = poolE;
     for (let k = 0; k < moreE.length && remPoolE > 0.05; k++) {
       var idx = moreE[k];
@@ -222,7 +259,6 @@ function computeAllCarryovers() {
     }
     // Dünger — sequenzielle Greedy-Zuweisung
     moreD.sort(byTimeAsc);
-    var poolD = Math.max(0, excD - netExcessD);
     var remPoolD = poolD;
     for (let k = 0; k < moreD.length && remPoolD > 0.05; k++) {
       var idx = moreD[k];

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // ⚠️ CACHE_VERSION muss bei jedem Release manuell gebumpet werden!
 // Bei Vergessen bekommen Nutzer die alte Version aus dem Cache.
 // alternativa: Build-Script das Hash/Zeitstempel injiziert.
-const CACHE_VERSION = 'agrar-rechner-v35';
+const CACHE_VERSION = 'agrar-rechner-v36';
 const STATIC_ASSETS = [
     '/',
     '/index.html',

--- a/tests/55-carryover-invariants.test.js
+++ b/tests/55-carryover-invariants.test.js
@@ -62,6 +62,35 @@ function phase0Totals(scenario, w, material) {
     return { totalSaved, totalExcess };
 }
 
+// Phase-0.5-Pool (gespiegelt aus computeAllCarryovers, Issue #371).
+// Pool = Σ (unfilled + Ersparnis) für alle NICHT-Mehrbedarf-Tabs mit istE > 0
+// (bzw. istD > 0 für Dünger). Mehrbedarf-Tabs sind Empfänger und werden
+// ausgeschlossen. Ohne istE/D trägt ein Tab nichts bei (sein SOLL ist kein
+// "verfügbar umverteilbares" Material).
+function phase05Pool(scenario, w, material) {
+    const kpe = scenario.koernerProEinheit;
+    let pool = 0;
+    for (const r of scenario.reiter) {
+        if (material === 'E') {
+            const solE = (r.hektar * r.koerner) / kpe;
+            const istE = r.istHektar > 0 ? (r.istHektar * r.koerner) / kpe : 0;
+            if (istE <= 0) continue;
+            // Mehrbedarf-Tab ist Empfänger → excluded
+            if (istE > solE) continue;
+            const usedE = w.getTabUsedEinheiten(r);
+            pool += Math.max(0, istE - usedE) + Math.max(0, solE - istE);
+        } else {
+            const solD = r.hektar * r.duenger;
+            const istD = r.istHektar > 0 ? r.istHektar * r.duenger : 0;
+            if (istD <= 0) continue;
+            if (istD > solD) continue;
+            const usedD = w.getTabUsedDuenger(r);
+            pool += Math.max(0, istD - usedD) + Math.max(0, solD - istD);
+        }
+    }
+    return pool;
+}
+
 describe('Carryover-Invarianten (5 User-Regeln 2026-06-28)', () => {
     let w;
     const SEED = 0xC0FFEE;
@@ -128,19 +157,21 @@ describe('Carryover-Invarianten (5 User-Regeln 2026-06-28)', () => {
     // ─────────────────────────────────────────────────────────────────────────
     // I2 — Volle Mehrbedarf-Abdeckung (Netting-Back vollständig)
     //
-    // "Wenn totalSaved ≥ totalExcess für ein Material, dann ist remaining für
-    // jeden Mehrbedarf-Tab = 0."
+    // "Wenn der Phase-0.5-Pool ≥ totalExcess für ein Material, dann ist der
+    // Mehrbedarf jedes Mehrbedarf-Tabs komplett genettet."
     //
-    // → Bei voller Deckung (Ersparnis reicht für alle Mehrbedarfe) MUSS der
-    //   Mehrbedarf-Anteil jedes Mehrbedarf-Tabs komplett genettet werden:
-    //   nettedEinheit === exc = istE − solE. Damit ist Σ nettedEinheit über
-    //   alle Mehrbedarf-Tabs === Σ exc (totalExcess).
-    //   (remaining === 0 ist NICHT garantiert, weil remaining noch von basis −
-    //   used abhängt; ein Mehrbedarf-Tab kann noch physische Einträge
-    //   brauchen, auch nachdem der Surplus genettet wurde.)
+    // → Issue #371 (Regel 6): Pool wurde erweitert von min(totalSaved, totalExcess)
+    //   (= nur IST<SOLL-Ersparnis) auf Σ (unfilled + Ersparnis) über alle
+    //   NICHT-Mehrbedarf-Tabs. Damit gilt die volle Abdeckung jetzt auch in
+    //   Szenarien ohne Ersparnis-Tabs, in denen neutrale Tabs un-filled Material
+    //   beitragen (User-Verifikation: Tab3 hat used<basis, deckt Tab1 Mehrbedarf).
+    //   Bestehende Szenarien mit totalSaved ≥ totalExcess bleiben gültig, da
+    //   Ersparnis ⊂ phase05Pool. Neue Szenarien mit Pool aus neutralen
+    //   unfilled-Tabs kommen hinzu.
+    //   Schwächere Bedingung: phase05Pool ≥ totalExcess → volle Abdeckung.
     // ─────────────────────────────────────────────────────────────────────────
     describe('I2 — Volle Mehrbedarf-Abdeckung', () => {
-        it('bei totalSaved ≥ totalExcess: Σ netted === Σ exc für Saat + Dünger', () => {
+        it('bei phase05Pool ≥ totalExcess: Σ netted === Σ exc für Saat + Dünger', () => {
             const scenarios = generateScenarios(SEED, COUNT);
             let fullCoverageSaat = 0;
             let fullCoverageDuenger = 0;
@@ -151,7 +182,8 @@ describe('Carryover-Invarianten (5 User-Regeln 2026-06-28)', () => {
                 const totDuenger = phase0Totals(scenarios[s], w, 'D');
 
                 // SAAT
-                if (totSaat.totalSaved > 0 && totSaat.totalSaved >= totSaat.totalExcess) {
+                const poolSaat = phase05Pool(scenarios[s], w, 'E');
+                if (totSaat.totalExcess > 0 && poolSaat >= totSaat.totalExcess) {
                     fullCoverageSaat++;
                     let sumNetted = 0, sumExc = 0;
                     for (let i = 0; i < scenarios[s].reiter.length; i++) {
@@ -167,13 +199,14 @@ describe('Carryover-Invarianten (5 User-Regeln 2026-06-28)', () => {
                         throw new Error(
                             `I2 Saat-Fehler scenario[${s}]: ` +
                             `Σ nettedEinheit=${sumNetted.toFixed(3)} ≠ Σ exc=${sumExc.toFixed(3)} ` +
-                            `(totalSaved=${totSaat.totalSaved.toFixed(2)}, totalExcess=${totSaat.totalExcess.toFixed(2)})\n` +
+                            `(pool=${poolSaat.toFixed(2)}, totalExcess=${totSaat.totalExcess.toFixed(2)})\n` +
                             dumpScenario(scenarios[s], s, '')
                         );
                     }
                 }
                 // DÜNGER
-                if (totDuenger.totalSaved > 0 && totDuenger.totalSaved >= totDuenger.totalExcess) {
+                const poolDuenger = phase05Pool(scenarios[s], w, 'D');
+                if (totDuenger.totalExcess > 0 && poolDuenger >= totDuenger.totalExcess) {
                     fullCoverageDuenger++;
                     let sumNetted = 0, sumExc = 0;
                     for (let i = 0; i < scenarios[s].reiter.length; i++) {
@@ -189,7 +222,7 @@ describe('Carryover-Invarianten (5 User-Regeln 2026-06-28)', () => {
                         throw new Error(
                             `I2 Dünger-Fehler scenario[${s}]: ` +
                             `Σ nettedDuenger=${sumNetted.toFixed(3)} ≠ Σ exc=${sumExc.toFixed(3)} ` +
-                            `(totalSaved=${totDuenger.totalSaved.toFixed(2)}, totalExcess=${totDuenger.totalExcess.toFixed(2)})\n` +
+                            `(pool=${poolDuenger.toFixed(2)}, totalExcess=${totDuenger.totalExcess.toFixed(2)})\n` +
                             dumpScenario(scenarios[s], s, '')
                         );
                     }
@@ -293,15 +326,19 @@ describe('Carryover-Invarianten (5 User-Regeln 2026-06-28)', () => {
     // ─────────────────────────────────────────────────────────────────────────
     // I4 — Bearbeitungs-Reihenfolge bei Knappheit (Issue #368, PR #369)
     //
-    // "Wenn totalSaved < totalExcess, wird der früher bearbeitete Mehrbedarf-Tab
+    // "Wenn phase05Pool < totalExcess, wird der früher bearbeitete Mehrbedarf-Tab
     // (parseEntryTime) zuerst komplett abgedeckt, bevor der nächste etwas
     // bekommt."
     //
     // → Sequenzielle Greedy-Zuweisung (nicht pro-rata) nach Bearbeitungs-
     //   Reihenfolge (parseEntryTime(lastEntry.time) aufsteigend, Tiebreaker
-    //   Tab-Index aufsteigend). Pool = min(totalSaved, totalExcess).
+    //   Tab-Index aufsteigend). Pool = phase05Pool (Regel 6, Issue #371) =
+    //   Σ (unfilled + Ersparnis) über alle nicht-Mehrbedarf-Tabs mit istE > 0.
     //   Der k-te Tab in der Reihenfolge erhält: netted = min(excK,
     //   max(0, pool − cumExcessVorK)).
+    //   Trigger-Bedingung: Knappheit = phase05Pool < totalExcess. Vor #371
+    //   war es `totalSaved < totalExcess` (äquivalent für Szenarien ohne
+    //   unfilled-Quellen), jetzt umfassender.
     // ─────────────────────────────────────────────────────────────────────────
     describe('I4 — Bearbeitungs-Reihenfolge bei Knappheit (Issue #368)', () => {
         it('Sortierung parseEntryTime aufsteigend mit Tab-Index-Tiebreaker', () => {
@@ -314,7 +351,8 @@ describe('Carryover-Invarianten (5 User-Regeln 2026-06-28)', () => {
 
                 // ── SAAT ─────────────────────────────────────────────────
                 const totSaat = phase0Totals(scenarios[s], w, 'E');
-                if (totSaat.totalSaved > 0 && totSaat.totalExcess > 0 && totSaat.totalSaved < totSaat.totalExcess) {
+                const poolSaat = phase05Pool(scenarios[s], w, 'E');
+                if (totSaat.totalExcess > 0 && poolSaat < totSaat.totalExcess) {
                     scarcityCasesSaat++;
                     const mehrbedarfTabs = [];
                     for (let i = 0; i < scenarios[s].reiter.length; i++) {
@@ -328,18 +366,17 @@ describe('Carryover-Invarianten (5 User-Regeln 2026-06-28)', () => {
                     }
                     if (mehrbedarfTabs.length === 0) continue;
                     mehrbedarfTabs.sort((a, b) => a.time - b.time || a.i - b.i);
-                    const pool = Math.min(totSaat.totalSaved, totSaat.totalExcess);
                     let cumExcess = 0;
                     for (let k = 0; k < mehrbedarfTabs.length; k++) {
                         const t = mehrbedarfTabs[k];
-                        const expectedNetted = Math.min(t.exc, Math.max(0, pool - cumExcess));
+                        const expectedNetted = Math.min(t.exc, Math.max(0, poolSaat - cumExcess));
                         const actualNetted = cos[t.i].nettedEinheit;
                         if (Math.abs(actualNetted - expectedNetted) > TOL) {
                             throw new Error(
                                 `I4 Saat-Fehler scenario[${s}] tab[${t.i}]: ` +
                                 `expected netted=${expectedNetted.toFixed(3)}, got ${actualNetted.toFixed(3)} ` +
                                 `(rank ${k + 1}/${mehrbedarfTabs.length}, exc=${t.exc.toFixed(2)}, ` +
-                                `time=${t.time}, cumExcessBefore=${cumExcess.toFixed(2)}, pool=${pool.toFixed(2)})\n` +
+                                `time=${t.time}, cumExcessBefore=${cumExcess.toFixed(2)}, pool=${poolSaat.toFixed(2)})\n` +
                                 dumpScenario(scenarios[s], s, `tab=${t.i}`)
                             );
                         }
@@ -349,7 +386,8 @@ describe('Carryover-Invarianten (5 User-Regeln 2026-06-28)', () => {
 
                 // ── DÜNGER ───────────────────────────────────────────────
                 const totDuenger = phase0Totals(scenarios[s], w, 'D');
-                if (totDuenger.totalSaved > 0 && totDuenger.totalExcess > 0 && totDuenger.totalSaved < totDuenger.totalExcess) {
+                const poolDuenger = phase05Pool(scenarios[s], w, 'D');
+                if (totDuenger.totalExcess > 0 && poolDuenger < totDuenger.totalExcess) {
                     scarcityCasesDuenger++;
                     const mehrbedarfTabs = [];
                     for (let i = 0; i < scenarios[s].reiter.length; i++) {
@@ -363,18 +401,17 @@ describe('Carryover-Invarianten (5 User-Regeln 2026-06-28)', () => {
                     }
                     if (mehrbedarfTabs.length === 0) continue;
                     mehrbedarfTabs.sort((a, b) => a.time - b.time || a.i - b.i);
-                    const pool = Math.min(totDuenger.totalSaved, totDuenger.totalExcess);
                     let cumExcess = 0;
                     for (let k = 0; k < mehrbedarfTabs.length; k++) {
                         const t = mehrbedarfTabs[k];
-                        const expectedNetted = Math.min(t.exc, Math.max(0, pool - cumExcess));
+                        const expectedNetted = Math.min(t.exc, Math.max(0, poolDuenger - cumExcess));
                         const actualNetted = cos[t.i].nettedDuenger;
                         if (Math.abs(actualNetted - expectedNetted) > TOL) {
                             throw new Error(
                                 `I4 Dünger-Fehler scenario[${s}] tab[${t.i}]: ` +
                                 `expected netted=${expectedNetted.toFixed(3)}, got ${actualNetted.toFixed(3)} ` +
                                 `(rank ${k + 1}/${mehrbedarfTabs.length}, exc=${t.exc.toFixed(2)}, ` +
-                                `time=${t.time}, cumExcessBefore=${cumExcess.toFixed(2)}, pool=${pool.toFixed(2)})\n` +
+                                `time=${t.time}, cumExcessBefore=${cumExcess.toFixed(2)}, pool=${poolDuenger.toFixed(2)})\n` +
                                 dumpScenario(scenarios[s], s, `tab=${t.i}`)
                             );
                         }

--- a/tests/56-unfilled-pool-netting.test.js
+++ b/tests/56-unfilled-pool-netting.test.js
@@ -1,0 +1,199 @@
+/**
+ * Tests for Issue #371 — Carryover-Regel 6: unfilled-Pool als Netting-Quelle.
+ *
+ * Physische Realität: das Material für einen Mehrbedarf-Tab wurde aus
+ * noch-ungefüllten Tabs entnommen (used < basis). Das aktuelle Phase-0.5
+ * Pool-Definition `max(0, exc - netExcess) = min(saved, exc)` ignoriert
+ * diese unfilled Amounts vollständig — d.h. wenn es KEINE Ersparnis-Tabs
+ * (IST<SOLL) gibt, wird auch nichts genettet. Korrekt muss die Pool-Definition
+ * die Summe aller unfilled Amounts (basis - used) in Nicht-Mehrbedarf-Tabs
+ * erfassen (Regel 6 der Carryover-Spec).
+ *
+ * Konkretes User-Szenario (vom User bestätigt, 2026-06-30):
+ *
+ *   Tab 1: 15ha SOLL, 16ha IST, voll          → Mehrbedarf 1,6E Saat, exc=200kg Dünger
+ *   Tab 2: 7,5ha SOLL=IST, voll                → neutral
+ *   Tab 3: 5ha SOLL=IST, teils (1,6E unfilled) → neutral, Pool-Quelle 1,6E Saat + 200kg Dünger
+ *
+ *   koernerProEinheit = 50000, koerner = 80000 → 1ha = 1,6 Einheiten, duenger = 200 kg/ha
+ *     Tab 1: SOLL=24,0E, IST=25,6E, exc=1,6E (Mehrbedarf)
+ *            Dünger: SOLL=3000kg, IST=3200kg, exc=200kg
+ *     Tab 2: SOLL=IST=12,0E, voll → unfilled=0
+ *     Tab 3: SOLL=IST=8,0E, used=6,4E → unfilled=1,6E
+ *            Dünger: SOLL=IST=1000kg, used=800kg → unfilled=200kg
+ *
+ *   Erwartet mit Regel 6: PoolE = 0+1,6 = 1,6 → Tab1 nettedEinheit=1,6 → remaining=0
+ *                         PoolD = 0+200 = 200 → Tab1 nettedDuenger=200 → remaining=0
+ *
+ *   Aktuell (vor #371): PoolE = max(0, excE - netExcessE) = max(0, 1,6−1,6) = 0
+ *                        → Tab1 nettedEinheit=0 → remaining=1,6E (BUG).
+ *
+ *   Tab 2 und Tab 3 sind "NICHT Mehrbedarf" — daher tragen sie zum Pool bei.
+ *   Tab 1 ist Mehrbedarf-Empfänger → aus Pool ausgeschlossen.
+ *
+ *   Edge-Case 1: unfilled < Mehrbedarf (1,0E < 1,6E) → Pool kann nur 1,0E decken,
+ *                Tab1 netted=1,0, remaining=0,6E.
+ *   Edge-Case 2: kein unfilled in anderen Tabs (Tab2+Tab3 voll) → Pool=0,
+ *                netted=0, Tab1 zeigt exc=1,6E.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createDom } from './helpers.js';
+
+describe('Carryover Regel 6 — unfilled-Pool als Netting-Quelle (Issue #371)', () => {
+    let w;
+
+    beforeEach(() => {
+        const result = createDom();
+        w = result.window;
+        w.state.koernerProEinheit = 50000;
+    });
+
+    // ── User-Hauptszenario ─────────────────────────────────────────────────
+    //
+    // Tab 1: 15ha SOLL, 16ha IST, used=25,6E (= basis). Mehrbedarf 1,6E.
+    // Tab 2: 7,5ha SOLL=IST, used=12E (= basis). Neutral, leerer Pool.
+    // Tab 3: 5ha SOLL=IST, used=6,4E (basis−1,6E). Pool-Quelle 1,6E Saat + 200kg Dünger.
+    function setupUserScenario() {
+        w.state.reiter[0] = {
+            name: 'Acker 1', hektar: 15, istHektar: 16, koerner: 80000, duenger: 200,
+            entries: [{ einheit: 25.6, duenger: 3200, time: '11:00' }],
+            fahrgassenEnabled: false, fahrgassenBreite: 0
+        };
+        w.state.reiter[1] = {
+            name: 'Acker 2', hektar: 7.5, istHektar: 7.5, koerner: 80000, duenger: 200,
+            entries: [{ einheit: 12, duenger: 1500, time: '12:00' }],
+            fahrgassenEnabled: false, fahrgassenBreite: 0
+        };
+        w.state.reiter[2] = {
+            name: 'Acker 3', hektar: 5, istHektar: 5, koerner: 80000, duenger: 200,
+            entries: [{ einheit: 6.4, duenger: 800, time: '13:00' }],
+            fahrgassenEnabled: false, fahrgassenBreite: 0
+        };
+        if (w.invalidateCarryoverCache) w.invalidateCarryoverCache();
+    }
+
+    it('User-Szenario: Tab1 (Mehrbedarf) zeigt remaining Saat = 0', () => {
+        setupUserScenario();
+        const r1 = w.state.reiter[0];
+        const rem = w.getTabRemaining(r1, 0);
+        // Erwartet: 1,6E Pool aus Tab3 → nettedEinheit=1,6
+        //   remaining = max(0, 25,6 − 25,6 − 0 + 0 − 1,6) = 0
+        expect(rem.remainingE).toBeCloseTo(0, 1);
+    });
+
+    it('User-Szenario: Tab1 zeigt remaining Dünger = 0', () => {
+        setupUserScenario();
+        const r1 = w.state.reiter[0];
+        const rem = w.getTabRemaining(r1, 0);
+        // Pool=200kg aus Tab3 → nettedDuenger=200
+        //   remaining = max(0, 3200 − 3200 − 0 + 0 − 200) = 0
+        expect(rem.remainingD).toBeCloseTo(0, 1);
+    });
+
+    it('User-Szenario: Tab1 nettedEinheit === 1,6 (komplette Pool-Zuweisung)', () => {
+        setupUserScenario();
+        const co = w.getCarryover(0);
+        expect(co.nettedEinheit).toBeCloseTo(1.6, 1);
+    });
+
+    it('User-Szenario: Tab1 nettedDuenger === 200 (komplette Pool-Zuweisung)', () => {
+        setupUserScenario();
+        const co = w.getCarryover(0);
+        expect(co.nettedDuenger).toBeCloseTo(200, 0);
+    });
+
+    it('User-Szenario: Tab3 (Pool-Quelle) bleibt unverändert (netted=0, saved=0)', () => {
+        setupUserScenario();
+        const co = w.getCarryover(2);
+        // Tab3 ist neutral — unfilled wird nur als Pool-Größe erfasst, NICHT als
+        // savedCarryover dieses Tabs.
+        expect(co.nettedEinheit).toBe(0);
+        expect(co.nettedDuenger).toBe(0);
+        expect(co.savedEinheit).toBe(0);
+        expect(co.savedDuenger).toBe(0);
+    });
+
+    // ── Edge-Case 1: unfilled < Mehrbedarf ─────────────────────────────────
+
+    it('Edge: unfilled 1,0E < Mehrbedarf 1,6E → Tab1 netted=1,0 (Pool aufgebraucht)', () => {
+        // Tab3: used=7,0E → unfilled=1,0E (statt 1,6E).
+        // Pool=1,0E < exc=1,6E → Tab1 netted=1,0 (Pool leer), 0,6E Mehrbedarf UNABDECKT.
+        w.state.reiter[0] = {
+            name: 'Acker 1', hektar: 15, istHektar: 16, koerner: 80000, duenger: 200,
+            entries: [{ einheit: 25.6, duenger: 3200, time: '11:00' }],
+            fahrgassenEnabled: false, fahrgassenBreite: 0
+        };
+        w.state.reiter[1] = {
+            name: 'Acker 2', hektar: 7.5, istHektar: 7.5, koerner: 80000, duenger: 200,
+            entries: [{ einheit: 12, duenger: 1500, time: '12:00' }],
+            fahrgassenEnabled: false, fahrgassenBreite: 0
+        };
+        w.state.reiter[2] = {
+            name: 'Acker 3', hektar: 5, istHektar: 5, koerner: 80000, duenger: 200,
+            entries: [{ einheit: 7, duenger: 875, time: '13:00' }], // used=7 → unfilled=1E
+            fahrgassenEnabled: false, fahrgassenBreite: 0
+        };
+        w.invalidateCarryoverCache();
+        const co = w.getCarryover(0);
+        // Pool=1,0E < exc=1,6E → Tab1 bekommt 1,0 aus dem Pool, 0,6E bleibt offen.
+        expect(co.nettedEinheit).toBeCloseTo(1.0, 1);
+        // exc − netted = 1,6 − 1,0 = 0,6 → das ist der ungedeckte Mehrbedarf-Anteil,
+        // der im UI als "Mehrbedarf verbleibend" angezeigt wird (exc - netted, nicht
+        // getTabRemaining.remainingE — siehe renderResults für die genaue Anzeige).
+        expect(1.6 - co.nettedEinheit).toBeCloseTo(0.6, 1);
+    });
+
+    // ── Edge-Case 2: kein unfilled in anderen Tabs ────────────────────────
+
+    it('Edge: kein unfilled in anderen Tabs → Tab1 netted=0 (kein Pool)', () => {
+        // Tab2 und Tab3 sind vollständig gefüllt → unfilled = 0.
+        w.state.reiter[0] = {
+            name: 'Acker 1', hektar: 15, istHektar: 16, koerner: 80000, duenger: 200,
+            entries: [{ einheit: 25.6, duenger: 3200, time: '11:00' }],
+            fahrgassenEnabled: false, fahrgassenBreite: 0
+        };
+        w.state.reiter[1] = {
+            name: 'Acker 2', hektar: 7.5, istHektar: 7.5, koerner: 80000, duenger: 200,
+            entries: [{ einheit: 12, duenger: 1500, time: '12:00' }],
+            fahrgassenEnabled: false, fahrgassenBreite: 0
+        };
+        w.state.reiter[2] = {
+            name: 'Acker 3', hektar: 5, istHektar: 5, koerner: 80000, duenger: 200,
+            entries: [{ einheit: 8, duenger: 1000, time: '13:00' }], // voll
+            fahrgassenEnabled: false, fahrgassenBreite: 0
+        };
+        w.invalidateCarryoverCache();
+        const co = w.getCarryover(0);
+        // Pool=0 → Tab1 netted=0
+        expect(co.nettedEinheit).toBe(0);
+        expect(co.nettedDuenger).toBe(0);
+    });
+
+    // ── Edge-Case 3: mehrere unfilled-Quellen ─────────────────────────────
+
+    it('Edge: mehrere unfilled-Quellen — Pool = Summe über alle nicht-Mehrbedarf-Tabs', () => {
+        // Tab1: Mehrbedarf 1,6E. Tab2: 0,6E unfilled. Tab3: 1,0E unfilled.
+        // Pool = 0,6 + 1,0 = 1,6E → deckt komplett.
+        w.state.reiter[0] = {
+            name: 'Acker 1', hektar: 15, istHektar: 16, koerner: 80000, duenger: 200,
+            entries: [{ einheit: 25.6, duenger: 3200, time: '11:00' }],
+            fahrgassenEnabled: false, fahrgassenBreite: 0
+        };
+        w.state.reiter[1] = {
+            name: 'Acker 2', hektar: 7.5, istHektar: 7.5, koerner: 80000, duenger: 200,
+            // used=11,4 → unfilled=0,6E (basis=12)
+            entries: [{ einheit: 11.4, duenger: 1425, time: '12:00' }],
+            fahrgassenEnabled: false, fahrgassenBreite: 0
+        };
+        w.state.reiter[2] = {
+            name: 'Acker 3', hektar: 5, istHektar: 5, koerner: 80000, duenger: 200,
+            // used=7 → unfilled=1,0E (basis=8)
+            entries: [{ einheit: 7, duenger: 875, time: '13:00' }],
+            fahrgassenEnabled: false, fahrgassenBreite: 0
+        };
+        w.invalidateCarryoverCache();
+        const co = w.getCarryover(0);
+        // Pool = 0,6 + 1,0 = 1,6E = exc → Tab1 komplett abgedeckt
+        expect(co.nettedEinheit).toBeCloseTo(1.6, 1);
+    });
+});


### PR DESCRIPTION
## Summary
Fixes #371 — Phase-0.5 Pool für Mehrbedarf-Netting wird erweitert von `min(saved, exc) = max(0, exc − netExcess)` (nur IST<SOLL-Ersparnis) auf `Σ (unfilled + Ersparnis)` über alle NICHT-Mehrbedarf-Tabs mit istE > 0.

Damit fließt auch ungenutztes Material aus **neutralen** Tabs (istE === solE, aber used < basis) als Netting-Coverage auf Mehrbedarf-Tabs zurück — was vorher nur bei expliziten Ersparnis-Tabs (IST < SOLL) funktionierte.

## User-Szenario (Verifikation)
Tab 1 (15ha SOLL, 16ha IST, voll) → Mehrbedarf 1,6E Saat + 200kg Dünger
Tab 2 (7,5ha SOLL=IST, voll)       → neutral
Tab 3 (5ha SOLL=IST, teils)        → neutral, 1,6E unfilled + 200kg unfilled

- Vor #371: Tab 1 zeigt `1,6E verbleibend` (Pool = max(0, 1,6−1,6) = 0).
- Mit Fix: Tab 1 zeigt `0,0E verbleibend` (Pool = 0+1,6 = 1,6).

## Implementierung
`public/js/calculations.js` — Phase 0.5 in `computeAllCarryovers()`. Pool-Aggregation läuft inline mit der Mehrbedarf-Tab-Sammlung (kein zweiter Loop über reiter[] nötig).

```js
// Pro Tab (Saat, analog Dünger):
if (mehrbedarfE) {
  moreE.push(i); excE += (mistE - msolE);
} else if (mistE > 0) {
  // Tab hat IST geplant → physisches "noch zu verbrauchen"-Material zählt
  poolE += Math.max(0, mistE - musedE) + Math.max(0, msolE - mistE);
}
```

Mehrbedarf-Tabs (IST > SOLL) bleiben Empfänger. Tabs ohne istE (mistE === 0) tragen nicht bei — ihr SOLL ist nicht "verfügbar umverteilbar", nur ein noch-nicht-bearbeiteter Plan.

Die anschliessende sequenzielle Greedy-Zuweisung (Regel 2+3, Issue #368, parseEntryTime aufsteigend + Tab-Index-Tiebreaker) bleibt **unverändert**.

## Tests
| Test-Datei | Status | Inhalt |
|---|---|---|
| **NEU** tests/56-unfilled-pool-netting.test.js | 8/8 grün | User-Szenario (Mehrbedarf + neutral-unfilled → remaining=0); Edge: unfilled < Mehrbedarf (netted=Pool-Größe, exc−netted > 0 sichtbar); Edge: kein unfilled (netted=0); Edge: mehrere unfilled-Quellen (Pool = Summe). |
| tests/55-carryover-invariants.test.js (I2 + I4) | ANPASS | I2 Trigger erweitert: `phase05Pool ≥ totalExcess` (statt `totalSaved ≥ totalExcess`). I4 Trigger + erwarteter Pool neu auf `phase05Pool`. |
| Alle übrigen (53 Files, ~860 Tests) | grün | Keine Regression. Insbesondere tests/54-sequentielle-netting (Ersparnis-Tabs) und tests/05-drill-protocol (Tab ohne istE) bleiben grün — die additive Pool-Formel deckt beide Quellen ab (Ersparnis-Tabs: max(0, sol−ist) > 0; Neutral-unfilled-Tabs: max(0, istE−used) > 0). |

## Test/lint
- `pnpm test` → 878/878 grün, 55 Files, ~71s
- `pnpm lint` → grün

## Out of scope
Keine Änderung an `getTabRemaining`, `isTabDone`, Render-Sites (render-results.js, render-drill.js, render-dashboard.js) — die Anzeige-Sites profitieren automatisch, weil `co.nettedEinheit` jetzt öfter/größer ist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)