### PR TITLE
chore(#371): CACHE_VERSION v36 → v37 — invalidate v36 cache

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // ⚠️ CACHE_VERSION muss bei jedem Release manuell gebumpet werden!
 // Bei Vergessen bekommen Nutzer die alte Version aus dem Cache.
 // alternativa: Build-Script das Hash/Zeitstempel injiziert.
-const CACHE_VERSION = 'agrar-rechner-v36';
+const CACHE_VERSION = 'agrar-rechner-v37';
 const STATIC_ASSETS = [
     '/',
     '/index.html',


### PR DESCRIPTION
Nach Merge von PR #374 (render-results Mehrbedarf-Netting) neuen SW-Cache auslösen, damit alle Nutzer die Anzeige-Korrektur bekommen. v36-Cache wurde zwischen 10:33 und 11:22 mit nur Fix 1 gebildet — ohne v37 bleibt dieser Nutzer-Kreis auf dem kaputten render-results-Stand.