### PR TITLE
fix(#371) Phase 2 — netExcess um ΣPhase0.5_netted reduzieren (Doppelzählung)

### DIFF
--- a/public/js/calculations.js
+++ b/public/js/calculations.js
@@ -340,7 +340,16 @@ function computeAllCarryovers() {
   // Self-Mehrbedarf (used > basis) wird ignoriert — keine Verteilung.
   for (var mat2 = 0; mat2 < 2; mat2++) {
     var isSaatPass2 = (mat2 === 0);
-    var remExcess = isSaatPass2 ? netExcessE : netExcessD;
+    // Phase 0.5 hat bereits Σ nettedEinheit/nettedDuenger abgedeckt —
+    // Phase 2 darf nur den REST verteilen (sonst Doppelzählung der unfilled-Capacity).
+    var totalNettedE = 0, totalNettedD = 0;
+    for (var _i = 0; _i < result.length; _i++) {
+      totalNettedE += result[_i].nettedEinheit;
+      totalNettedD += result[_i].nettedDuenger;
+    }
+    var remExcess = isSaatPass2
+      ? Math.max(0, netExcessE - totalNettedE)
+      : Math.max(0, netExcessD - totalNettedD);
 
     // Tabs mit Capacity sammeln + sortieren.
     // Capacity = max(0, basis − used − saved_received), IST-basiert.

--- a/tests/100-phase2-double-count-edge.test.js
+++ b/tests/100-phase2-double-count-edge.test.js
@@ -1,0 +1,139 @@
+/**
+ * Edge-Cases für Phase-2-Reduktion (#371 Teil 3)
+ *
+ * Fix: remExcess = max(0, netExcess - ΣPhase0.5_netted). Phase 2 darf den
+ * Teil nicht doppelt vergeben, den Phase 0.5 bereits aus dem unfilled-Pool
+ * an Mehrbedarf-Tabs zugewiesen hat.
+ *
+ * Einheit-Helpers (siehe tests/98): koerner=80000, kpe=50000 → 1,6E pro ha.
+ * istE = istHektar * 1,6  (= 80000/50000).  solE = hektar * 1,6.
+ * usedE = last entry.einheit.  Duenger linear in kg/ha.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createDom } from './helpers.js';
+
+describe('#371 Edge-Cases — Phase 2 Doppelzählung', () => {
+    let w;
+    beforeEach(() => {
+        const result = createDom();
+        w = result.window;
+        w.state.koernerProEinheit = 50000; // → 80000/50000 = 1,6E/ha
+    });
+
+    /**
+     * Edge-Case A: Pool ≥ Mehrbedarf
+     * Tab1: Mehrbedarf 1.6E (10ha, ist=11ha, used=17.6 → used >= istE)
+     * Tab2: unfilled 5.0E (4ha, ist=4ha → solE=6.4, used=1.4)
+     *
+     * poolE = max(0, 6.4 - 1.4) + max(0, 6.4 - 6.4) = 5.0 + 0 = 5.0
+     * mehrbedarfE = 17.6 - 16.0 = 1.6
+     * Phase 0.5: tab1.nettedEinheit = min(5.0, 1.6) = 1.6, remPool=3.4
+     * Phase 2: remExcess = max(0, 1.6 - 1.6) = 0 → KEIN excess verteilt
+     *
+     * Verifiziert: Tab3 (Capacity) bleibt ohne Phase-2-Verteilung.
+     */
+    it('Edge A: Pool ≥ Mehrbedarf → Phase 2 macht nichts (Tab3 kein excess)', () => {
+        w.state.reiter[0] = {
+            name: 'Mehrbedarf', hektar: 10, istHektar: 11, koerner: 80000, duenger: 200,
+            // solE=16, istE=17.6, usedE=17.6 → used >= istE
+            entries: [{ einheit: 17.6, duenger: 2000, time: '11:00' }],
+            fahrgassenEnabled: false, fahrgassenBreite: 0
+        };
+        w.state.reiter[1] = {
+            // solE=6.4, istE=6.4, usedE=1.4 → unfilled=5.0E (Pool-Quelle)
+            name: 'PoolQuelle', hektar: 4, istHektar: 4, koerner: 80000, duenger: 200,
+            entries: [{ einheit: 1.4, duenger: 200, time: '12:00' }],
+            fahrgassenEnabled: false, fahrgassenBreite: 0
+        };
+        w.state.reiter[2] = {
+            // Capacity-Tab, kein istHektar → unfilled-Beitrag=0, aber cap>0
+            // sol=5*1.6=8, used=2 → cap=6
+            name: 'Capacity', hektar: 5, istHektar: 0, koerner: 80000, duenger: 200,
+            entries: [{ einheit: 2, duenger: 500, time: '13:00' }],
+            fahrgassenEnabled: false, fahrgassenBreite: 0
+        };
+        if (w.invalidateCarryoverCache) w.invalidateCarryoverCache();
+
+        const co1 = w.getCarryover(0);
+        const co3 = w.getCarryover(2);
+        // Phase 0.5 deckt den vollen Mehrbedarf → Tab1 netted = 1.6
+        expect(co1.nettedEinheit).toBeCloseTo(1.6, 1);
+        // Phase 2 hat 0 Rest → Tab3 bekommt KEIN excess
+        expect(co3.excessEinheit).toBeCloseTo(0, 1);
+    });
+
+    /**
+     * Edge-Case B: Pool = 0 → Phase 2 verteilt vollen netExcess (Status quo).
+     * Tab1: Mehrbedarf 1.6E (10ha, ist=11ha, used=17.6)
+     * Tab2: Capacity ohne istHektar, used=2 → cap=6, unfilled-Beitrag=0
+     *
+     * poolE = 0 (kein Tab mit mistE>0 und unfilled).
+     * netExcessE = 1.6, Phase 0.5 verteilt 0.
+     * Phase 2: remExcess = max(0, 1.6 - 0) = 1.6 → verteilt auf Tab2 (cap=6)
+     *
+     * Verifiziert: Tab2.excessEinheit = 1.6 (Status-quo-Verhalten erhalten).
+     */
+    it('Edge B: kein Pool → Phase 2 verteilt vollen netExcess (Status quo)', () => {
+        w.state.reiter[0] = {
+            name: 'Mehrbedarf', hektar: 10, istHektar: 11, koerner: 80000, duenger: 200,
+            entries: [{ einheit: 17.6, duenger: 2000, time: '11:00' }],
+            fahrgassenEnabled: false, fahrgassenBreite: 0
+        };
+        w.state.reiter[1] = {
+            // Capacity ohne istHektar → kein pool-Beitrag, cap > 0
+            name: 'Capacity', hektar: 5, istHektar: 0, koerner: 80000, duenger: 200,
+            entries: [{ einheit: 2, duenger: 500, time: '12:00' }],
+            fahrgassenEnabled: false, fahrgassenBreite: 0
+        };
+        if (w.invalidateCarryoverCache) w.invalidateCarryoverCache();
+
+        const co1 = w.getCarryover(0);
+        const co2 = w.getCarryover(1);
+        // Phase 0.5: poolE = 0 → nichts verteilt
+        expect(co1.nettedEinheit).toBeCloseTo(0, 1);
+        // Phase 2: remExcess = 1.6 - 0 = 1.6 → Tab2 cap = 6 → 1.6 verteilt
+        expect(co2.excessEinheit).toBeCloseTo(1.6, 1);
+    });
+
+    /**
+     * Edge-Case C: Pool < Mehrbedarf → Phase 2 verteilt die Restdifferenz.
+     * Tab1: Mehrbedarf 3.2E (10ha, ist=12ha, used=19.2)
+     * Tab2: unfilled 1.0E (4ha, ist=4ha → solE=6.4, used=5.4)
+     *
+     * poolE = max(0, 6.4 - 5.4) = 1.0
+     * mehrbedarfE = 19.2 - 16.0 = 3.2
+     * Phase 0.5: tab1.nettedEinheit = min(1.0, 3.2) = 1.0, remPool=0
+     * Phase 2: remExcess = max(0, 3.2 - 1.0) = 2.2 → auf Tab3 capacity
+     *
+     * Verifiziert die TEILWEISE-Reduktion (nicht voller Mehrbedarf gedeckt,
+     * also Phase 2 hat tatsächlich noch zu verteilen — ohne Fix wäre die
+     * Verteilung = 3.2 statt 2.2 → Doppelzählung von 1.0).
+     */
+    it('Edge C: Pool < Mehrbedarf → Phase 2 verteilt Rest (Differenz = Mehrbedarf − Pool)', () => {
+        w.state.reiter[0] = {
+            name: 'Mehrbedarf', hektar: 10, istHektar: 12, koerner: 80000, duenger: 200,
+            entries: [{ einheit: 19.2, duenger: 2000, time: '11:00' }],
+            fahrgassenEnabled: false, fahrgassenBreite: 0
+        };
+        w.state.reiter[1] = {
+            // solE=6.4, istE=6.4, usedE=5.4 → unfilled=1.0
+            name: 'PoolQuelle', hektar: 4, istHektar: 4, koerner: 80000, duenger: 200,
+            entries: [{ einheit: 5.4, duenger: 700, time: '12:00' }],
+            fahrgassenEnabled: false, fahrgassenBreite: 0
+        };
+        w.state.reiter[2] = {
+            // Capacity, cap groß, keine pool-Quelle (kein istHektar)
+            name: 'Capacity', hektar: 10, istHektar: 0, koerner: 80000, duenger: 200,
+            entries: [{ einheit: 2, duenger: 500, time: '13:00' }],
+            fahrgassenEnabled: false, fahrgassenBreite: 0
+        };
+        if (w.invalidateCarryoverCache) w.invalidateCarryoverCache();
+
+        const co1 = w.getCarryover(0);
+        const co3 = w.getCarryover(2);
+        // Phase 0.5 deckt 1.0 von 3.2 → netted = 1.0
+        expect(co1.nettedEinheit).toBeCloseTo(1.0, 1);
+        // Phase 2 hat noch 2.2 zu verteilen (NICHT 3.2 wie ohne Fix)
+        expect(co3.excessEinheit).toBeCloseTo(2.2, 1);
+    });
+});

--- a/tests/97-debug-371.test.js
+++ b/tests/97-debug-371.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createDom } from './helpers.js';
+
+describe('DEBUG #371 — Tab3 Carryover Details', () => {
+    let w;
+    beforeEach(() => {
+        const result = createDom();
+        w = result.window;
+        w.state.koernerProEinheit = 50000;
+    });
+
+    it('zeigt alle carryover values für alle Tabs', () => {
+        w.state.reiter[0] = {
+            name: 'A1', hektar: 15, istHektar: 16, koerner: 80000, duenger: 200,
+            entries: [{ einheit: 24, duenger: 3000, time: '11:00' }],
+            fahrgassenEnabled: false, fahrgassenBreite: 0
+        };
+        w.state.reiter[1] = {
+            name: 'A2', hektar: 7.5, istHektar: 7.5, koerner: 80000, duenger: 200,
+            entries: [{ einheit: 12, duenger: 1500, time: '12:00' }],
+            fahrgassenEnabled: false, fahrgassenBreite: 0
+        };
+        w.state.reiter[2] = {
+            name: 'A3', hektar: 5, istHektar: 5, koerner: 80000, duenger: 200,
+            entries: [{ einheit: 6.4, duenger: 800, time: '13:00' }],
+            fahrgassenEnabled: false, fahrgassenBreite: 0
+        };
+        if (w.invalidateCarryoverCache) w.invalidateCarryoverCache();
+
+        for (let i = 0; i < 3; i++) {
+            const co = w.getCarryover(i);
+            const r = w.state.reiter[i];
+            const basisE = w.getTabIstEinheiten(r);
+            const usedE = w.getTabUsedEinheiten(r);
+            const rem = w.getTabRemaining(r, i);
+            console.log(`Tab${i+1}: basis=${basisE.toFixed(1)} used=${usedE.toFixed(1)}`,
+                `saved=${co.savedEinheit.toFixed(2)} excess=${co.excessEinheit.toFixed(2)}`,
+                `netted=${co.nettedEinheit.toFixed(2)} → remaining=${rem.remainingE.toFixed(2)}`,
+                `(formel: ${basisE.toFixed(1)}-${usedE.toFixed(1)}-${co.savedEinheit.toFixed(1)}+${co.excessEinheit.toFixed(1)}-${co.nettedEinheit.toFixed(1)})`);
+        }
+        expect(true).toBe(true);
+    });
+});

--- a/tests/98-planner-verify-371-real.test.js
+++ b/tests/98-planner-verify-371-real.test.js
@@ -1,0 +1,58 @@
+/**
+ * PLANNER VERIFY #371 — Vollständiges Szenario (Tab1=0, Tab3=1.6 unfilled)
+ * Real-Szenario: used=SOLL (Fahrer füllt nach Plan, fährt dann weiter).
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createDom } from './helpers.js';
+
+describe('PLANNER VERIFY #371 — Tab1=0, Tab3=1.6 unfilled', () => {
+    let w;
+    beforeEach(() => {
+        const result = createDom();
+        w = result.window;
+        w.state.koernerProEinheit = 50000;
+    });
+
+    function setup() {
+        w.state.reiter[0] = {
+            name: 'A1', hektar: 15, istHektar: 16, koerner: 80000, duenger: 200,
+            entries: [{ einheit: 24, duenger: 3000, time: '11:00' }],
+            fahrgassenEnabled: false, fahrgassenBreite: 0
+        };
+        w.state.reiter[1] = {
+            name: 'A2', hektar: 7.5, istHektar: 7.5, koerner: 80000, duenger: 200,
+            entries: [{ einheit: 12, duenger: 1500, time: '12:00' }],
+            fahrgassenEnabled: false, fahrgassenBreite: 0
+        };
+        w.state.reiter[2] = {
+            name: 'A3', hektar: 5, istHektar: 5, koerner: 80000, duenger: 200,
+            entries: [{ einheit: 6.4, duenger: 800, time: '13:00' }],
+            fahrgassenEnabled: false, fahrgassenBreite: 0
+        };
+        if (w.invalidateCarryoverCache) w.invalidateCarryoverCache();
+    }
+
+    it('ALLE 3 Tabs — Vollständige Verifikation', () => {
+        setup();
+        for (let i = 0; i < 3; i++) {
+            const co = w.getCarryover(i);
+            const rem = w.getTabRemaining(w.state.reiter[i], i);
+            console.log(`Tab${i+1} (${w.state.reiter[i].name}):`,
+                `nettedE=${co.nettedEinheit.toFixed(2)}`,
+                `remainingE=${rem.remainingE.toFixed(3)}`,
+                `nettedD=${co.nettedDuenger.toFixed(0)}`,
+                `remainingD=${rem.remainingD.toFixed(0)}`);
+        }
+        // Tab1 (Mehrbedarf) → 0
+        const rem1 = w.getTabRemaining(w.state.reiter[0], 0);
+        expect(rem1.remainingE).toBeCloseTo(0, 1);
+        expect(rem1.remainingD).toBeCloseTo(0, 1);
+        // Tab2 (neutral voll) → 0
+        const rem2 = w.getTabRemaining(w.state.reiter[1], 1);
+        expect(rem2.remainingE).toBeCloseTo(0, 1);
+        // Tab3 (unfilled) → 1.6
+        const rem3 = w.getTabRemaining(w.state.reiter[2], 2);
+        expect(rem3.remainingE).toBeCloseTo(1.6, 1);
+        expect(rem3.remainingD).toBeCloseTo(200, 0);
+    });
+});


### PR DESCRIPTION
## Summary

Fix #371 (Teil 3): Phase 2 in `computeAllCarryovers` (`public/js/calculations.js`)
doppelte die unfilled-Capacity von Tabs, die bereits in Phase 0.5 als Pool-Quelle
für Mehrbedarf-Coverage dienten.

## Szenario (Beweis durch `tests/97-debug-371.test.js`)

Tab1: hektar=15, istHektar=16, used=24 → Mehrbedarf 1,6E
Tab2: hektar=7,5, istHektar=7,5, used=12 → neutral, voll
Tab3: hektar=5, istHektar=5, used=6,4 → neutral, 1,6E unfilled

| Phase | Vor Fix                                  | Nach Fix                       |
|-------|------------------------------------------|--------------------------------|
| 0.5   | Tab1.nettedEinheit = 1,6 (aus Tab3-Pool) | unverändert                    |
| 2     | Tab3.excessEinheit = 1,6 (zusätzlich) ❌  | remExcess = 0 → kein excess ✅  |
| → Tab3 remaining | 3,2 (Doppelzählung) ❌                     | **1,6** ✅                       |

## Fix-Diff (`public/js/calculations.js:341-353`)

```js
var remExcess = isSaatPass2
  ? Math.max(0, netExcessE - totalNettedE)   // war: netExcessE
  : Math.max(0, netExcessD - totalNettedD);  // war: netExcessD
```

wobei `totalNettedE` / `totalNettedD` = Σ Phase 0.5 (bereits abgedeckter Mehrbedarf).

## Tests

- **NEU** `tests/98-planner-verify-371-real.test.js` (vom planner erstellt) — Real-Szenario Tab1=0, Tab3=1,6 unfilled → GRÜN (vor Fix: ROT mit Tab3 remaining=3,2)
- **NEU** `tests/100-phase2-double-count-edge.test.js` — drei Edge-Cases:
  - A: Pool ≥ Mehrbedarf → Phase 2 macht nichts (Tab3 kein excess)
  - B: kein Pool → Phase 2 verteilt vollen netExcess (Status quo unverändert)
  - C: Pool < Mehrbedarf → Phase 2 verteilt die Restdifferenz
- `tests/97-debug-371.test.js` (vom planner) — Debug-Print zeigt jetzt Tab3 remaining=1,60 (vorher 3,20)

## Verify

```
pnpm test  → 894/894 tests grün
pnpm lint  → clean
```

Closes #371

## Kontext

Teil 3 einer 3-teiligen Fix-Serie:
- #374 (Teil 1+2): Phase 0.5 + render-results.js zieht Cross-Tab-Netting ab
- t_86224c96 / PR #373: Phase 0.5 (unfilled-Pool als Netting-Quelle)
- **PR (Teil 3): verhindert Doppelzählung in Phase 2**
