### PR TITLE
feat(#377): Manuelle Fertig-Markierung pro Tab — done-Flag + UI + Locking

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -704,6 +704,43 @@ font-size: 0.75rem;
       border-color: var(--color-primary);
       outline: none;
     }
+    .drill-tab-row .drill-tab-values input:disabled {
+      background: var(--color-bg-disabled, #f3f3f3);
+      color: var(--color-text-hint);
+      cursor: not-allowed;
+      opacity: 0.65;
+    }
+    /* Issue #377: Toggle-Button "Feld fertig" pro Reiter. Default neutral
+       (grauer Rahmen), aktiv grün gefüllt. Klickbar auch auf Touch. */
+    .drill-done-btn {
+      flex-shrink: 0;
+      padding: 6px 10px;
+      font-size: 0.78rem;
+      font-weight: 600;
+      border-radius: 6px;
+      border: 1px solid var(--color-divider);
+      background: var(--color-bg);
+      color: var(--color-text-label-strong);
+      cursor: pointer;
+      transition: background 0.15s, border-color 0.15s, color 0.15s;
+      touch-action: manipulation;
+      white-space: nowrap;
+    }
+    .drill-done-btn:hover {
+      border-color: var(--color-primary);
+    }
+    .drill-done-btn.active {
+      background: var(--color-primary);
+      border-color: var(--color-primary-dark);
+      color: var(--color-ios-banner-text);
+    }
+    .drill-done-btn:active {
+      transform: scale(0.96);
+    }
+    .drill-tab-row.done {
+      background: rgba(76, 175, 80, 0.06);
+      border: 1px solid rgba(76, 175, 80, 0.25);
+    }
     .btn-add {
       width: 100%;
       padding: 12px;

--- a/public/js/render-drill.js
+++ b/public/js/render-drill.js
@@ -18,8 +18,11 @@
       if (!container) return;
       container.innerHTML = '';
       AppGlobals.state.reiter.forEach(function(r, i) {
+        // Issue #377: `done` ist ein expliziter User-Toggle (NICHT von used>=SOLL
+        // abgeleitet — das ist nur ein Hinweis). Default false für neue/alte Tabs.
+        var isDone = r.done === true;
         var row = document.createElement('div');
-        row.className = 'drill-tab-row';
+        row.className = 'drill-tab-row' + (isDone ? ' done' : '');
         var prioBtn = document.createElement('button');
         prioBtn.className = 'drill-prio-btn';
         prioBtn.id = 'dtl_prio_' + i;
@@ -59,6 +62,9 @@
           var statusEl = document.createElement('div');
           statusEl.id = 'dtl_need_' + i;
           statusEl.className = 'drill-tab-need';
+          // Issue #377: "✓ fertig"-Hinweis bleibt als visueller Status, wenn
+          // used >= SOLL — ist aber explizit KEIN Hinweis auf den User-Toggle
+          // `done`. Letzterer wird über den grünen Button separat gesetzt.
           if (remaining <= 0.05 && remainingD <= 0.05) {
             statusEl.textContent = '✓ fertig';
             statusEl.classList.add('done');
@@ -74,12 +80,17 @@
           nameWrap.appendChild(statusEl);
         }
         row.appendChild(nameWrap);
+        // Issue #377: Einheiten- und Dünger-Inputs sind reine Anzeige-Felder
+        // (Werte werden aus dem Verteilungsplan in dtl_e_<i>/dtl_d_<i>
+        // geschrieben). `disabled` verhindert User-Eingaben und macht visuell
+        // klar, dass der Tab abgeschlossen ist.
         var einheitIn = document.createElement('input');
         einheitIn.type = 'text';
         einheitIn.inputMode = 'decimal';
         einheitIn.id = 'dtl_e_' + i;
         einheitIn.placeholder = 'Einheiten';
         einheitIn.dataset.tabIdx = String(i);
+        if (isDone) einheitIn.disabled = true;
         einheitIn.oninput = function() {
           AppGlobals.drillCalcDebounced();
         };
@@ -90,10 +101,34 @@
         duengerIn.id = 'dtl_d_' + i;
         duengerIn.placeholder = 'kg Dünger';
         duengerIn.dataset.tabIdx = String(i);
+        if (isDone) duengerIn.disabled = true;
         duengerIn.oninput = function() {
           AppGlobals.drillCalcDebounced();
         };
         row.appendChild(duengerIn);
+        // Issue #377: Toggle-Button "Feld fertig" / "Fertig zurücknehmen".
+        // Setzt state.reiter[i].done, persistiert, rendert neu.
+        var doneBtn = document.createElement('button');
+        doneBtn.type = 'button';
+        doneBtn.id = 'dtl_done_' + i;
+        doneBtn.className = 'drill-done-btn' + (isDone ? ' active' : '');
+        doneBtn.textContent = isDone ? 'Fertig zurücknehmen' : 'Feld fertig';
+        doneBtn.setAttribute('aria-pressed', isDone ? 'true' : 'false');
+        doneBtn.title = isDone
+          ? 'Markierung aufheben — Werte bleiben erhalten'
+          : 'Feld als fertig markieren';
+        doneBtn.onclick = (function(tabIdx, btnRef) {
+          return function() {
+            var tab = AppGlobals.state.reiter[tabIdx];
+            if (!tab) return;
+            tab.done = tab.done === true ? false : true;
+            AppGlobals.saveState();
+            // Vollständiger Re-Render: Liste, Summary, Results und Dashboard,
+            // weil Locking + Status-Anzeige + Verteilungs-Plan berührt sind.
+            AppGlobals.drillCalcAll();
+          };
+        })(i, doneBtn);
+        row.appendChild(doneBtn);
         container.appendChild(row);
       });
     }

--- a/public/js/state.js
+++ b/public/js/state.js
@@ -20,7 +20,8 @@ var state = {
     istHektar:  0,
     koerner:    0,
     duenger:    0,
-    entries:    []
+    entries:    [],
+    done:       false
   }],
   activeReiter:   0,
   activeView:     null,
@@ -114,7 +115,8 @@ var ALLOWED_TOP_KEYS = [
 ];
 var ALLOWED_TAB_KEYS = [
   'name', 'hektar', 'istHektar', 'koerner', 'duenger',
-  'entries', 'fahrgassenEnabled', 'fahrgassenBreite'
+  'entries', 'fahrgassenEnabled', 'fahrgassenBreite',
+  'done'
 ];
 var ALLOWED_ENTRY_KEYS = [
   'time', 'einheit', 'duenger', 'hektar', 'istHektar',
@@ -194,7 +196,7 @@ function sanitizeMachineLogEntry(raw) {
 
 function sanitizeTab(raw) {
   if (!isPlainObject(raw)) {
-    return { name: 'Tab', hektar: 0, istHektar: 0, koerner: 0, duenger: 0, entries: [] };
+    return { name: 'Tab', hektar: 0, istHektar: 0, koerner: 0, duenger: 0, entries: [], done: false };
   }
   var tab = {
     name:      sanitizeString(raw.name, 'Tab', 64),
@@ -202,7 +204,12 @@ function sanitizeTab(raw) {
     istHektar: sanitizeNumber(raw.istHektar, 0),
     koerner:   sanitizeNumber(raw.koerner, 0),
     duenger:   sanitizeNumber(raw.duenger, 0),
-    entries:   []
+    entries:   [],
+    // Issue #377: manuelles "Feld fertig"-Flag pro Tab.
+    // `used >= SOLL` ist nur ein Hinweis (render-drill.js "✓ fertig");
+    // der Landwirt markiert hier explizit, dass das Feld tatsächlich
+    // fertiggefahren wurde und `used` damit nicht mehr im Tank liegt.
+    done:      sanitizeBoolean(raw.done, false)
   };
   // Per-Tab-Overrides (optional, mit globalen Defaults)
   if (raw.fahrgassenEnabled !== undefined) {
@@ -247,7 +254,7 @@ function loadState() {
     var lv = originalLv;
     // Migration 0→1: Einzelne Felder → Tab-Array
     if (!data.reiter && (data.hektar !== undefined || data.koerner !== undefined)) {
-      data = { reiter: [{ name: 'Tab 1', hektar: data.hektar || 0, istHektar: data.istHektar || 0, koerner: data.koerner || 0, duenger: data.duenger || 0, entries: data.entries || [] }], activeReiter: 0, activeView: null, fahrgassenEnabled: false, fahrgassenBreite: 0, einheitGroesseEnabled: false, koernerProEinheit: 50000, machineLog: data.machineLog || [], drillPriorities: {}, iosInstallHintShown: false, _lv: 1 };
+      data = { reiter: [{ name: 'Tab 1', hektar: data.hektar || 0, istHektar: data.istHektar || 0, koerner: data.koerner || 0, duenger: data.duenger || 0, entries: data.entries || [], done: false }], activeReiter: 0, activeView: null, fahrgassenEnabled: false, fahrgassenBreite: 0, einheitGroesseEnabled: false, koernerProEinheit: 50000, machineLog: data.machineLog || [], drillPriorities: {}, iosInstallHintShown: false, _lv: 1 };
       lv = 1;
     }
     // Migration 1→2: Globale entries → per-Tab entries
@@ -285,6 +292,11 @@ function loadState() {
       // drillPriorities Default
       if (!data.drillPriorities) data.drillPriorities = {};
     }
+    // Migration 4→5 (Issue #377): manuelles "Feld fertig"-Flag pro Tab.
+    // sanitizeTab() vergibt `done: false` als Default, daher sind keine
+    // Daten-Änderungen am reiter-Array nötig — die Persistenz-Schwelle
+    // wird weiter unten auf `_lv = 5` gehoben.
+    if (lv < 5) lv = 5;
     // Validate und übernehmen — Schema-strict ab _lv=4
     if (!Array.isArray(data.reiter) || data.reiter.length === 0) return false;
     var sanitizedReiter = [];
@@ -327,13 +339,13 @@ function loadState() {
         var k = ALLOWED_TOP_KEYS[ki];
         if (data[k] !== undefined) cleaned[k] = data[k];
     }
-    cleaned._lv = 4;
+    cleaned._lv = 5;
     data = cleaned;
     state = data;
-    // Migration-Persistenz: Wenn die Daten nicht bereits _lv=4 waren,
+    // Migration-Persistenz: Wenn die Daten nicht bereits _lv=5 waren,
     // schreibe den migrierten Snapshot einmalig zurück, damit nachfolgende
     // Page-Loads die Migration überspringen können.
-    if (originalLv < 4) {
+    if (originalLv < 5) {
       try {
         localStorage.setItem('agrar_rechner', JSON.stringify(state));
       } catch(e) {

--- a/public/js/ui-handlers.js
+++ b/public/js/ui-handlers.js
@@ -58,7 +58,7 @@
       syncStateFromInputs();
       var maxIdx = 0;
       AppGlobals.state.reiter.forEach(function(r, i) { var m = parseInt(r.name.replace(/\D+/g, '')); if (!isNaN(m) && m > maxIdx) maxIdx = m; });
-      AppGlobals.state.reiter.push({ name: 'Tab ' + (maxIdx + 1), hektar: 0, istHektar: 0, koerner: 0, duenger: 0, entries: [], fahrgassenEnabled: AppGlobals.state.fahrgassenEnabled, fahrgassenBreite: AppGlobals.state.fahrgassenBreite });
+      AppGlobals.state.reiter.push({ name: 'Tab ' + (maxIdx + 1), hektar: 0, istHektar: 0, koerner: 0, duenger: 0, entries: [], done: false, fahrgassenEnabled: AppGlobals.state.fahrgassenEnabled, fahrgassenBreite: AppGlobals.state.fahrgassenBreite });
       AppGlobals.state.activeReiter = AppGlobals.state.reiter.length - 1;
       AppGlobals.appEmit('TAB_ADDED', { tabIdx: AppGlobals.state.activeReiter });
       document.getElementById('hektar').focus();
@@ -600,8 +600,28 @@
       AppGlobals.renderDrillTabList();
       // Plan in die frischen Inputs schreiben
       _applyDrillPlan(plan);
+      // Issue #377: globale Drill-Inputs (drill_einheit / drill_duenger /
+      // drill_hektar) deaktivieren, wenn der aktive Tab als done markiert
+      // ist. Die Felder würden sonst Einträge auf einen abgeschlossenen
+      // Tab schreiben (drillMachineAdd → state.reiter[activeReiter]).
+      _syncActiveTabLock();
       AppGlobals.renderDrillSummary();
       AppGlobals.renderResults();
+    }
+
+    function _syncActiveTabLock() {
+      // Issue #377: sperrt die globalen "Maschine eingefüllt"-Eingabefelder,
+      // wenn der aktuell aktive Reiter `done === true` ist. Die
+      // Per-Tab-Felder (dtl_e_<i>, dtl_d_<i>) werden bereits in
+      // renderDrillTabList() pro-Tab disabled gerendert — dieser Sync
+      // deckt den globalen Eingabeblock ab.
+      var activeTab = AppGlobals.state.reiter[AppGlobals.state.activeReiter];
+      var isActiveDone = !!(activeTab && activeTab.done === true);
+      var ids = ['drill_einheit', 'drill_duenger', 'drill_hektar'];
+      for (var i = 0; i < ids.length; i++) {
+        var el = document.getElementById(ids[i]);
+        if (el) el.disabled = isActiveDone;
+      }
     }
 
     function drillCalcDebounced() {

--- a/public/js/ui-handlers.js
+++ b/public/js/ui-handlers.js
@@ -92,6 +92,11 @@
       // ist kein eigener Reiter sondern ein View-Toggle).
       AppGlobals.state.activeView = null;
       AppGlobals.appEmit('TAB_CHANGED', { tabIdx: idx });
+      // Issue #377 (PR #379 Follow-up): TAB_CHANGED triggert im render-tabs-Subscriber
+      // KEIN drillCalcAll — also würde der globale Lock auf drill_einheit / drill_duenger /
+      // drill_hektar am vorherigen activeReiter verkleben. Direkt hier syncen ist
+      // minimal-invasiv (kein Event-Coupling, kein Re-Render, vgl. Review-Variante A).
+      AppGlobals._syncActiveTabLock();
     }
 
     function switchToProtokoll() {
@@ -994,6 +999,7 @@ Object.assign(window.AppGlobals, {
   drillRemove: drillRemove,
   _calcDrillDistribution: _calcDrillDistribution,
   _applyDrillPlan: _applyDrillPlan,
+  _syncActiveTabLock: _syncActiveTabLock,
   drillCalcAll: drillCalcAll,
   drillCalcDebounced: drillCalcDebounced,
   drillMachineAdd: drillMachineAdd,

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // ⚠️ CACHE_VERSION muss bei jedem Release manuell gebumpet werden!
 // Bei Vergessen bekommen Nutzer die alte Version aus dem Cache.
 // alternativa: Build-Script das Hash/Zeitstempel injiziert.
-const CACHE_VERSION = 'agrar-rechner-v37';
+const CACHE_VERSION = 'agrar-rechner-v38';
 const STATIC_ASSETS = [
     '/',
     '/index.html',

--- a/tests/07-state-persistence.test.js
+++ b/tests/07-state-persistence.test.js
@@ -152,8 +152,8 @@ describe('State persistence', () => {
       expect(w.state.reiter[0].entries[0].einheit).toBe(1);
     });
 
-    it('persists migrated snapshot so _lv advances to 4 after first load', () => {
-      // Alt-State ohne _lv → Migration 0→4 sollte durchlaufen
+    it('persists migrated snapshot so _lv advances to 5 after first load', () => {
+      // Alt-State ohne _lv → Migration 0→5 sollte durchlaufen
       // und das Ergebnis einmalig zurück in localStorage geschrieben werden.
       store['agrar_rechner'] = JSON.stringify({
         reiter: [{ name: 'Tab 1', hektar: 10, koerner: 90000, duenger: 150, entries: [] }],
@@ -162,9 +162,11 @@ describe('State persistence', () => {
         fahrgassenBreite: 0,
       });
       w.loadState();
-      // Nach Migration: gespeicherter Snapshot hat _lv=4
+      // Nach Migration: gespeicherter Snapshot hat _lv=5
       var persisted = JSON.parse(store['agrar_rechner']);
-      expect(persisted._lv).toBe(4);
+      expect(persisted._lv).toBe(5);
+      // Issue #377: `done: false` wird via sanitizeTab auf bestehende Tabs gesetzt
+      expect(persisted.reiter[0].done).toBe(false);
     });
 
     it('does not re-run migration on second load (idempotent at storage level)', () => {
@@ -176,13 +178,13 @@ describe('State persistence', () => {
       });
       w.loadState();
       var afterFirst = JSON.parse(store['agrar_rechner']);
-      // Zweiter Load: _lv ist schon 4, also kein Re-Migration-Touch.
+      // Zweiter Load: _lv ist schon 5, also kein Re-Migration-Touch.
       // Wenn loadState erneut schreiben würde, wäre das ein No-Op für die
       // Felder; der Test sichert ab, dass _lv erhalten bleibt und keine
       // Re-Schreibung passiert (idempotent = kein Drift).
       w.loadState();
       var afterSecond = JSON.parse(store['agrar_rechner']);
-      expect(afterSecond._lv).toBe(4);
+      expect(afterSecond._lv).toBe(5);
       expect(afterSecond.reiter[0].hektar).toBe(10);
     });
   });

--- a/tests/58-tab-done-flag.test.js
+++ b/tests/58-tab-done-flag.test.js
@@ -219,10 +219,23 @@ describe('Issue #377: manuelle Fertig-Markierung pro Tab', () => {
             w.state.activeReiter = 0;
             w.AppGlobals.drillCalcAll();
             expect(doc.getElementById('drill_einheit').disabled).toBe(false);
-            // Auf done-Tab wechseln
-            w.state.activeReiter = 1;
-            w.AppGlobals.drillCalcAll();
+            // Bug #377/PR #379: Auf done-Tab wechseln über den realistischen Pfad
+            // (User klickt Tab-Pill → switchReiter → appEmit('TAB_CHANGED')).
+            // Vor dem Fix re-synct der render-tabs TAB_CHANGED-Subscriber KEINEN
+            // drillCalcAll, also blieb der Lock auf drill_einheit am vorherigen
+            // activeReiter "verklebt" bis der User irgendetwas anderes tut.
+            // switchReiter(1) muss den Lock ohne zwischenzeitliches drillCalcAll
+            // sofort korrekt setzen.
+            w.switchReiter(1);
             expect(doc.getElementById('drill_einheit').disabled).toBe(true);
+            expect(doc.getElementById('drill_duenger').disabled).toBe(true);
+            expect(doc.getElementById('drill_hektar').disabled).toBe(true);
+            // Zurück auf Tab 0 (nicht done) → Inputs wieder enabled, ebenfalls
+            // ohne zwischenzeitliches drillCalcAll.
+            w.switchReiter(0);
+            expect(doc.getElementById('drill_einheit').disabled).toBe(false);
+            expect(doc.getElementById('drill_duenger').disabled).toBe(false);
+            expect(doc.getElementById('drill_hektar').disabled).toBe(false);
         });
     });
 });

--- a/tests/58-tab-done-flag.test.js
+++ b/tests/58-tab-done-flag.test.js
@@ -1,0 +1,228 @@
+/**
+ * Issue #377: Manuelle Fertig-Markierung pro Tab — done-Flag + UI + Locking
+ *
+ * Coverage:
+ *   1. State: done-Flag existiert im Default-State
+ *   2. State-Migration: alter State ohne `done` → `done: false` für alle Tabs
+ *   3. State: `done: true` überlebt einen Reload (saveState/loadState round-trip)
+ *   4. UI: Toggle-Button "Feld fertig" rendert pro Tab, Klick setzt `done = true`
+ *   5. UI: nach Toggle rendert Button "Fertig zurücknehmen" + Klasse `active`
+ *   6. UI: Klick auf "Fertig zurücknehmen" setzt `done = false` (Undo)
+ *   7. Locking: bei `done = true` sind `dtl_e_<i>` und `dtl_d_<i>` disabled
+ *   8. Locking: bei `done = false` sind die Inputs wieder enabled
+ *   9. Locking: bei aktivem done-Tab sind die globalen drill_einheit / drill_duenger /
+ *      drill_hektar Felder disabled
+ *  10. Locking: Tab-Wechsel (activeReiter) auf nicht-done-Tab entsperrt die globalen Felder
+ *  11. Schema-Whitelist: `done` ist in ALLOWED_TAB_KEYS (würde sonst beim Save
+ *      gestrippt werden, ist aber Top-Level auf reiter[])
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createDom } from './helpers.js';
+
+describe('Issue #377: manuelle Fertig-Markierung pro Tab', () => {
+    let w, doc, store;
+
+    beforeEach(() => {
+        const result = createDom();
+        w = result.window;
+        doc = w.document;
+        store = result.store;
+    });
+
+    describe('State: done-Flag existiert', () => {
+        it('Default-State (frisch) hat done: false auf reiter[0]', () => {
+            // Kein localStorage → frischer State
+            expect(w.state.reiter[0].done).toBe(false);
+        });
+
+        it('done ist in ALLOWED_TAB_KEYS (Schema-Whitelist)', () => {
+            expect(w.AppGlobals.ALLOWED_TAB_KEYS).toContain('done');
+        });
+    });
+
+    describe('State-Migration', () => {
+        it('alter State ohne `done`-Feld bekommt done: false auf allen Tabs', () => {
+            // Migration 4 → 5: kein `done`-Feld im gespeicherten State
+            store['agrar_rechner'] = JSON.stringify({
+                _lv: 4,
+                reiter: [
+                    { name: 'Tab 1', hektar: 10, koerner: 90000, duenger: 150, entries: [] },
+                    { name: 'Tab 2', hektar: 5, koerner: 95000, duenger: 100, entries: [] }
+                ],
+                activeReiter: 0,
+                fahrgassenEnabled: false,
+                fahrgassenBreite: 0,
+                einheitGroesseEnabled: false,
+                koernerProEinheit: 50000,
+                machineLog: [],
+                drillPriorities: {},
+                iosInstallHintShown: false
+            });
+            w.loadState();
+            expect(w.state.reiter.length).toBe(2);
+            expect(w.state.reiter[0].done).toBe(false);
+            expect(w.state.reiter[1].done).toBe(false);
+        });
+
+        it('alter State mit done=true auf einem Tab bleibt nach Migration erhalten', () => {
+            store['agrar_rechner'] = JSON.stringify({
+                _lv: 4,
+                reiter: [
+                    { name: 'Tab 1', hektar: 10, koerner: 90000, duenger: 150, entries: [], done: true },
+                    { name: 'Tab 2', hektar: 5, koerner: 95000, duenger: 100, entries: [] }
+                ],
+                activeReiter: 0,
+                fahrgassenEnabled: false,
+                fahrgassenBreite: 0,
+                einheitGroesseEnabled: false,
+                koernerProEinheit: 50000,
+                machineLog: [],
+                drillPriorities: {},
+                iosInstallHintShown: false
+            });
+            w.loadState();
+            expect(w.state.reiter[0].done).toBe(true);
+            expect(w.state.reiter[1].done).toBe(false);
+        });
+
+        it('done wird nach saveState/loadState round-trip erhalten', () => {
+            w.state.reiter[0].done = true;
+            w.state.reiter.push({ name: 'Tab 2', hektar: 5, koerner: 90000, duenger: 100, entries: [], done: false });
+            w.saveState();
+            // Frisches Window simulieren (anderer Reiter-Reload)
+            w.state.reiter[0].done = false; // lokal überschreiben
+            w.loadState();
+            expect(w.state.reiter[0].done).toBe(true);
+            expect(w.state.reiter[1].done).toBe(false);
+        });
+    });
+
+    describe('UI: Toggle-Button pro Tab', () => {
+        function setupDrillView() {
+            w.state.reiter[0] = { name: 'Acker Nord', hektar: 10, koerner: 90000, duenger: 150, entries: [], done: false };
+            // Drill-View anzeigen (activeView='protokoll') und rendern
+            w.state.activeView = 'protokoll';
+            w.AppGlobals.renderDrillTabList();
+        }
+
+        it('rendert einen done-Button pro Tab', () => {
+            setupDrillView();
+            var btn = doc.getElementById('dtl_done_0');
+            expect(btn).toBeTruthy();
+            expect(btn.textContent).toBe('Feld fertig');
+            expect(btn.classList.contains('active')).toBe(false);
+            expect(btn.getAttribute('aria-pressed')).toBe('false');
+        });
+
+        it('Klick auf "Feld fertig" setzt done=true und rendert als "Fertig zurücknehmen"', () => {
+            setupDrillView();
+            var btn = doc.getElementById('dtl_done_0');
+            btn.click();
+            expect(w.state.reiter[0].done).toBe(true);
+            // Re-render: neuer Button hat neuen Text
+            var btn2 = doc.getElementById('dtl_done_0');
+            expect(btn2.textContent).toBe('Fertig zurücknehmen');
+            expect(btn2.classList.contains('active')).toBe(true);
+            expect(btn2.getAttribute('aria-pressed')).toBe('true');
+        });
+
+        it('Undo: zweiter Klick setzt done=false und Werte bleiben erhalten', () => {
+            setupDrillView();
+            // Erstmal done=true setzen
+            w.state.reiter[0].done = true;
+            w.AppGlobals.renderDrillTabList();
+            // Eine Entry hinzufügen, used-Wert soll erhalten bleiben
+            w.state.reiter[0].entries.push({
+                time: 1, einheit: 5, duenger: 75, hektar: 10, istHektar: 0,
+                koerner: 90000, duengerRate: 150, mlIdx: -1
+            });
+            // Undo
+            doc.getElementById('dtl_done_0').click();
+            expect(w.state.reiter[0].done).toBe(false);
+            // Entries bleiben unangetastet
+            expect(w.state.reiter[0].entries.length).toBe(1);
+            expect(w.state.reiter[0].entries[0].einheit).toBe(5);
+        });
+
+        it('persistiert done nach saveState', () => {
+            setupDrillView();
+            doc.getElementById('dtl_done_0').click();
+            var persisted = JSON.parse(store['agrar_rechner']);
+            expect(persisted.reiter[0].done).toBe(true);
+        });
+    });
+
+    describe('Locking: Per-Tab-Inputs (dtl_e_<i> / dtl_d_<i>)', () => {
+        function setupDrillView() {
+            w.state.reiter[0] = { name: 'Acker', hektar: 10, koerner: 90000, duenger: 150, entries: [], done: false };
+            w.state.activeView = 'protokoll';
+            w.AppGlobals.renderDrillTabList();
+        }
+
+        it('bei done=true sind dtl_e_0 und dtl_d_0 disabled', () => {
+            setupDrillView();
+            w.state.reiter[0].done = true;
+            w.AppGlobals.renderDrillTabList();
+            expect(doc.getElementById('dtl_e_0').disabled).toBe(true);
+            expect(doc.getElementById('dtl_d_0').disabled).toBe(true);
+        });
+
+        it('bei done=false sind dtl_e_0 und dtl_d_0 enabled', () => {
+            setupDrillView();
+            // Default: done=false
+            expect(doc.getElementById('dtl_e_0').disabled).toBe(false);
+            expect(doc.getElementById('dtl_d_0').disabled).toBe(false);
+        });
+
+        it('Undo: nach done=true → false sind die Inputs wieder enabled', () => {
+            setupDrillView();
+            w.state.reiter[0].done = true;
+            w.AppGlobals.renderDrillTabList();
+            expect(doc.getElementById('dtl_e_0').disabled).toBe(true);
+            // Undo
+            w.state.reiter[0].done = false;
+            w.AppGlobals.renderDrillTabList();
+            expect(doc.getElementById('dtl_e_0').disabled).toBe(false);
+        });
+    });
+
+    describe('Locking: globale Drill-Inputs (drill_einheit / drill_duenger / drill_hektar)', () => {
+        function setupDrillView() {
+            w.state.reiter[0] = { name: 'Acker', hektar: 10, koerner: 90000, duenger: 150, entries: [], done: false };
+            w.state.activeReiter = 0;
+            w.state.activeView = 'protokoll';
+            w.AppGlobals.renderDrillTabList();
+            w.AppGlobals.drillCalcAll();
+        }
+
+        it('aktiver Tab done=true → globale Inputs disabled', () => {
+            setupDrillView();
+            w.state.reiter[0].done = true;
+            w.AppGlobals.drillCalcAll();
+            expect(doc.getElementById('drill_einheit').disabled).toBe(true);
+            expect(doc.getElementById('drill_duenger').disabled).toBe(true);
+            expect(doc.getElementById('drill_hektar').disabled).toBe(true);
+        });
+
+        it('aktiver Tab done=false → globale Inputs enabled', () => {
+            setupDrillView();
+            // Default
+            expect(doc.getElementById('drill_einheit').disabled).toBe(false);
+            expect(doc.getElementById('drill_duenger').disabled).toBe(false);
+            expect(doc.getElementById('drill_hektar').disabled).toBe(false);
+        });
+
+        it('Tab-Wechsel: aktiver Tab nicht-done, anderer Tab done → globale Inputs enabled', () => {
+            setupDrillView();
+            w.state.reiter.push({ name: 'Tab 2', hektar: 5, koerner: 90000, duenger: 100, entries: [], done: true });
+            w.state.reiter[0].done = false;
+            w.state.activeReiter = 0;
+            w.AppGlobals.drillCalcAll();
+            expect(doc.getElementById('drill_einheit').disabled).toBe(false);
+            // Auf done-Tab wechseln
+            w.state.activeReiter = 1;
+            w.AppGlobals.drillCalcAll();
+            expect(doc.getElementById('drill_einheit').disabled).toBe(true);
+        });
+    });
+});


### PR DESCRIPTION
Closes #377

## Context

Issue #377. Das aktuelle Modell markiert ein Tab automatisch als "fertig"
sobald `used >= SOLL`. Das ist physikalisch falsch: eingefuelltes Material
(`used`) liegt noch im Tank, nicht in der Erde. Erst wenn der Landwirt das
Feld wirklich fertiggefahren hat, ist die Saat in der Erde.

Voraussetzung fuer #378 (Pool-Modell-Umstellung): ohne done-Flag kann das
neue Pool-Modell nicht berechnen, was noch im Tank liegt.

## Aenderungen

- **public/js/state.js**: neues `done: false` pro reiter (sanitizeTab + Whitelist
  ALLOWED_TAB_KEYS), Default in state-Literal, _lv 4 → 5 (Migration vergibt
  done:false auf alten Tabs via sanitizeTab, idempotent).
- **public/js/render-drill.js**: Toggle-Button "Feld fertig" / "Fertig
  zuruecknehmen" pro Reiter (`dtl_done_<i>`), Locking der `dtl_e_<i>`/
  `dtl_d_<i>` Inputs via `disabled` bei done=true. Bestehender "✓ fertig"-
  Hinweis (used>=SOLL) bleibt visuell, ist aber explizit KEIN Trigger fuer done.
- **public/js/ui-handlers.js**: `_syncActiveTabLock()` in drillCalcAll()
  sperrt die globalen `drill_einheit` / `drill_duenger` / `drill_hektar`
  Felder wenn der aktive Tab done=true ist (drillMachineAdd wuerde sonst
  Eintraege auf einen abgeschlossenen Tab schreiben).
- **public/css/styles.css**: `.drill-done-btn` (Toggle-Look), `.drill-tab-row.done`
  (gruenliches Highlight), `:disabled`-Style fuer Inputs.
- **public/sw.js**: CACHE_VERSION v37 → v38.
- **tests/58-tab-done-flag.test.js**: 15 Tests (Default-State, Migration,
  round-trip, Button-Rendering, Undo, Per-Tab-Locking, Global-Locking,
  Tab-Wechsel).
- **tests/07-state-persistence.test.js**: _lv 4 → 5 Erwartungen aktualisiert
  (plus done-Default-Test).

## UX-Klaerungen (Session 2026-07-03, bestaetigt)

- **Undo: JA** — `done` ist zuruecksetzbar, `used`-Werte bleiben erhalten.
- **Auto-Highlight: NEIN** — `done` rein manuell.

## Test-Status

- Branch:  909 passed / 0 failed
- dev (baseline):  894 passed / 0 failed
- Delta: +15 passed, -0 failed