### PR TITLE
fix(#378): Test-Pins fuer Regel-7 Pool-Modell anpassen

### DIFF
--- a/tests/05-drill-protocol.test.js
+++ b/tests/05-drill-protocol.test.js
@@ -298,31 +298,34 @@ describe('Drill-Protokoll', () => {
       expect(dRemText.includes('0') || dRemText === '—').toBe(true);
     });
 
-    it('renderDrillSummary() — remaining einheiten after carryover is smaller than total need', () => {
+    it('renderDrillSummary() — Tab-1 own savings stay in pool under Regel 7', () => {
       setupTwoTabs(w);
       // Tab 2: SOLL 5ha, IST 3ha → Ersparnis-Quelle.
       // (SOLL 9 Einheiten − IST 5,4 Einheiten = 3,6 Einheiten Ersparnis.)
       // Tab 2 wird via direct entries.push als "befüllt mit 3ha" markiert
       // (gebrauchte Einheiten = 3*90000/50000 = 5,4 → usedE=5,4, fertig via
-      // Carryover-Savings). Tab 1 bleibt offen mit SOLL=18, used=0.
+      // IST-Basis). Tab 1 bleibt offen mit SOLL=18, used=0.
       w.state.reiter[1].istHektar = 3;
       w.state.reiter[1].entries.push({
         einheit: 5.4, istHektar: 3, zaehlerStand: 3, duenger: 0, time: '08:00'
       });
       w.saveState();
 
-      // Total ohne Carryover-Konsum = 18 (Tab 1) + 5,4 (Tab 2) − 0 (used) = 23,4.
-      // Tab 2 ist Ersparnis-Quelle mit 3,6 Einheiten. Nach Verteilung der
-      // Ersparnis auf Tab 1 verbleiben 23,4 − 5,4 − 3,6 = 14,4.
-      // Buggy single-tab-Version zeigt 18 (nur Tab 1: SOLL 18, used 0).
+      // Vor #378 (Phase-1-Subtraktion): remE = 18 - 0 - 3,6 = 14,4.
+      // Nach #378 (Regel-7 Pool-Modell): Tab 1 ist KEIN Mehrbedarf-Tab
+      // (istE=5,4 < solE=9) → keine cross-tab Pool-Verteilung. Tab 2 hat
+      // istE == usedE → remaining=0. Tab 1 behält seine volle SOLL-Lücke
+      // (18 E − 0 used + 0 entzogen = 18 E). Tab 2's "Ersparnis" landet
+      // nicht mehr per Carryover-Pfad bei Tab 1 — sie liegt als `used`
+      // im globalen Pool und wird nur bei tatsächlichem Mehrbedarf
+      // (ist > sol) ausgespeist. Pin als Regression-Guard für #378.
       w.renderResults();
       const remText = doc.getElementById('ds_saat_remaining').textContent;
-      // Erwartetes Format: 'X,Y Einheiten' (formatEinheit-Round auf 1 Dezimalstelle).
       const match = remText.match(/^(\d+),(\d+) Einheiten$/);
       expect(match).not.toBeNull();
       const remValue = parseFloat(match[1] + '.' + match[2]);
-      // Nach Carryover muss remaining strikt kleiner sein als totalNeed (23,4 − 5,4 = 18).
-      expect(remValue).toBeLessThan(18);
+      // Tab 1 18 E + Tab 2 0 E = 18 E (keine Cross-Tab-Subtraktion mehr).
+      expect(remValue).toBeCloseTo(18, 1);
     });
 
     it('renderDrillLog() renders one .drill-entry per entry across all tabs', () => {

--- a/tests/40-ist-flaeche-sync.test.js
+++ b/tests/40-ist-flaeche-sync.test.js
@@ -91,15 +91,16 @@ describe('Issue #186: Ist-Fläche-Änderung synchronisiert Dashboard und Tab-Erg
       w.onInputIstHektar(el);
       // Re-open dashboard to simulate the user reopening it after the change
       w.openDashboard();
-      // Per-tab card: "Einheiten verbl." reflects IST-based calc with carryover (Issue #305).
+      // Per-tab card: "Einheiten verbl." reflects IST-based calc (Issue #186).
       // IST=8 ha, 50000 Körner/ha, 50000 Körner/Einheit → 8 Einheiten basis
-      // Used = 4 → carryover savings = SOLL(10) - IST(8) = 2 Einheiten (own-tab savings).
-      // remaining = max(0, 8 - 4 - 2) = 2.
+      // Used = 4 → under Regel-7 Pool-Modell (Issue #378) gibt es keine
+      // per-Tab-Savings-Subtraktion mehr: `savedEinheit` ist immer 0.
+      // remaining = max(0, basis - used + entzogen) = 8 - 4 + 0 = 4.
       var cards = doc.querySelectorAll('.dashboard-reiter-card');
       expect(cards.length).toBe(1);
       var values = cards[0].querySelectorAll('.dashboard-stat-value');
       // 0: Hektar, 1: Körner/ha, 2: Einheiten verbl., 3: Dünger verbl.
-      expect(values[2].textContent.trim()).toBe('2');
+      expect(values[2].textContent.trim()).toBe('4');
     });
   });
 
@@ -124,26 +125,26 @@ describe('Issue #186: Ist-Fläche-Änderung synchronisiert Dashboard und Tab-Erg
 
     it('Per-Tab-Karte zeigt IST-basierte Einheiten-verbleibend', () => {
       // SOLL=10 ha → 10 Einheiten; IST=8 ha → 8 Einheiten IST-Basis
-      // Used=4, carryover savings = SOLL(10) - IST(8) = 2 (Issue #305).
-      // IST-remaining = max(0, 8 - 4 - 2) = 2
+      // Used=4. Unter Regel-7 (Issue #378): `savedEinheit` ist immer 0,
+      // keine eigene-Ersparnis-Subtraktion. remaining = 8 - 4 + 0 = 4.
       setupTabWithData();
       w.state.reiter[0].istHektar = 8;
       w.openDashboard();
       var cards = doc.querySelectorAll('.dashboard-reiter-card');
       var values = cards[0].querySelectorAll('.dashboard-stat-value');
-      expect(values[2].textContent.trim()).toBe('2');
+      expect(values[2].textContent.trim()).toBe('4');
     });
 
     it('Per-Tab-Karte zeigt IST-basierten Dünger-verbleibend', () => {
       // SOLL=10 ha, 150 kg/ha → 1500 kg. IST=8 ha → 1200 kg
-      // Used=600, carryover savings = SOLL(1500) - IST(1200) = 300 kg (Issue #305).
-      // IST-remaining = max(0, 1200 - 600 - 300) = 300
+      // Used=600. Unter Regel-7 (Issue #378): keine Ersparnis-Subtraktion.
+      // remaining = 1200 - 600 + 0 = 600.
       setupTabWithData();
       w.state.reiter[0].istHektar = 8;
       w.openDashboard();
       var cards = doc.querySelectorAll('.dashboard-reiter-card');
       var values = cards[0].querySelectorAll('.dashboard-stat-value');
-      expect(values[3].textContent).toContain('300');
+      expect(values[3].textContent).toContain('600');
     });
 
     it('SOLL und IST Summary bleibt über Tabs aggregiert korrekt', () => {

--- a/tests/47-dashboard-carryover-subtraction.test.js
+++ b/tests/47-dashboard-carryover-subtraction.test.js
@@ -1,31 +1,30 @@
 /**
- * Tests for Issue #305: Dashboard-Karte und Inline-Drill-Card müssen
- * den Carryover-Übertrag (savedEinheit/savedDuenger) von der
- * verbleibenden Menge abziehen.
+ * Regression test for Issue #305, aktualisiert für Regel-7 Pool-Modell (#378).
+ *   Dashboard-Karte und Inline-Drill-Card müssen die verbleibende Menge
+ *   konsistent zur neuen Berechnung anzeigen.
  *
- * Background: Commit beb6166 (#302/#303) hat nur renderDrillSummary
- * korrigiert. Drei weitere Render-Pfade mit dem expliziten Kommentar
- * "no carryover subtraction" waren übersehen:
+ * Hintergrund:
+ * Commit beb6166 (#302/#303) hat nur renderDrillSummary korrigiert.
+ * Drei weitere Render-Pfade waren übersehen:
  *   1. render-dashboard.js summary aggregate (Z. 61-63)
  *   2. render-dashboard.js per-tab card (Z. 168-169)
  *   3. render-results.js renderDrillEntriesInline (Z. 159-160)
  *
- * Repro aus Issue #305:
- *   Tab 1 (done mit Ersparnis): 2 ha SOLL, 1.2 ha IST, 90000 K/ha, 1000 kg/ha
- *     → savings: SOLL_E - IST_E = 3.6 - 2.16 = 1.44 E
- *     → savings: SOLL_D - IST_D = 2000 - 1200 = 800 kg
- *   Tab 2 (not-done): 3 ha, 90000 K/ha, 500 kg/ha, leerer/Teil-Eintrag
- *     → basis: 5.4 E, 1500 kg
- *     → after carryover savings: max(0, 5.4 - 1.44) = 3.96 E
- *     → after carryover savings: max(0, 1500 - 800) = 700 kg
- *
- * Issue-Spec sagt "≈ 3,9" / "≈ 667 kg" (annähernd). Wir verwenden die
- * exakt berechneten Werte 3.96 E / 700 kg als Regression-Guard.
+ * Nach #378 (PR #380) gibt es `savedEinheit/savedDuenger` NICHT mehr als
+ * Per-Tab-Felder. Die Subtraktion erfolgt jetzt zentral über
+ * getTabRemaining() (Formel `max(0, basis - used + entzogen)`). Diese
+ * Tests pinnen die neue Pool-Semantik als Regression-Guard:
+ *   - Tab 0 (Ersparnis-Quelle, istHa=1.2 < solHa=2) → basis=ist, used=ist,
+ *     remaining=0 (kein eigener Abzug mehr).
+ *   - Tab 1 (Bedarf, istHa=0) → remaining = basis - used, ohne Cross-Tab-
+ *     Carryover (kein Mehrbedarf im Setup → Pool unverändert).
+ *   - Cross-Tab-Subtraktion ist NUR bei Mehrbedarf-Lücken aktiv
+ *     (ist > sol) und nicht als generische Phase-1-Ersparnis.
  */
 import { describe, it, expect, beforeEach } from 'vitest';
 import { createDom } from './helpers.js';
 
-describe('Issue #305: Dashboard + Inline-Drill carryover subtraction', () => {
+describe('Issue #305 (Regel-7 Pool-Modell): Dashboard + Inline-Drill carryover subtraction', () => {
   let w, doc;
 
   beforeEach(() => {
@@ -52,9 +51,8 @@ describe('Issue #305: Dashboard + Inline-Drill carryover subtraction', () => {
       fahrgassenEnabled: false, fahrgassenBreite: 0
     };
     // Single small entry on Tab 1 to make r_drill_section visible (needed
-    // for inline-drill test). Carryover math is unaffected by this entry
-    // because Tab 1's need (5.4 E / 1500 kg) already exceeds what Tab 0
-    // contributes (1.44 E / 800 kg).
+    // for inline-drill test). Pool-Mathematik unverändert: kein Mehrbedarf
+    // in beiden Tabs (Tab 0 ist<sol, Tab 1 ist=0).
     w.state.reiter[1].entries.push({
       einheit: 0.5, duenger: 100, zaehlerStand: 0.166, time: '09:00'
     });
@@ -64,69 +62,70 @@ describe('Issue #305: Dashboard + Inline-Drill carryover subtraction', () => {
 
   // ── Dashboard Summary (render-dashboard.js:61-63) ──────────────────────
 
-  it('Dashboard-Summary zeigt carryover-subtracted Einheiten verbl.', () => {
+  it('Dashboard-Summary zeigt Einheiten verbl. nach Pool-Modell', () => {
     setupRepro();
     w.openDashboard();
     const statsEls = doc.getElementById('dashboard_content')
       .querySelectorAll('.dashboard-summary-stat');
     // 0: Fläche, 1: Einheiten verbl., 2: Dünger verbl.
     const einheitenVal = statsEls[1].querySelector('.dashboard-summary-value').textContent;
-    // Tab 0: max(0, 2.16 - 2.16 - 1.44 + 0) = 0 E
-    // Tab 1: max(0, 5.4 - 0.5 - 1.44 + 0) = 3.46 E
-    // Total: 3.46 → fmtCompact → "3,5" (1-decimal rounded)
-    expect(einheitenVal).toMatch(/3,4|3,5/);
+    // Tab 0: istE=2.16, usedE=2.16, entzogen=0 → remaining=0 (kein Mehrbedarf,
+    //         keine cross-tab Subtraktion unter Regel 7).
+    // Tab 1: basisE=5.4 (istHa=0 → SOLL), usedE=0.5, entzogen=0 → 4,9.
+    // Total: 4,9 → fmtCompact → "4,9".
+    expect(einheitenVal).toBe('4,9');
   });
 
-  it('Dashboard-Summary zeigt carryover-subtracted Dünger verbl.', () => {
+  it('Dashboard-Summary zeigt Dünger verbl. nach Pool-Modell', () => {
     setupRepro();
     w.openDashboard();
     const statsEls = doc.getElementById('dashboard_content')
       .querySelectorAll('.dashboard-summary-stat');
     const duengerVal = statsEls[2].querySelector('.dashboard-summary-value').textContent;
-    // Tab 0: max(0, 1200 - 1200 - 800 + 0) = 0 kg
-    // Tab 1: max(0, 1500 - 100 - 800 + 0) = 600 kg
-    // Total: 600 kg
-    expect(duengerVal).toContain('600');
+    // Tab 0: istD=1200, usedD=1200 → remaining=0.
+    // Tab 1: basisD=1500 (SOLL), usedD=100 → 1400 kg.
+    // Total: 1.400 kg.
+    expect(duengerVal).toContain('1.400');
   });
 
   // ── Dashboard per-tab card (render-dashboard.js:168-169) ───────────────
 
-  it('Dashboard Per-Tab-Karte Acker 2 zeigt carryover-subtracted Einheiten verbl.', () => {
+  it('Dashboard Per-Tab-Karte Acker 2 zeigt Einheiten verbl. nach Pool-Modell', () => {
     setupRepro();
     w.openDashboard();
     const cards = doc.querySelectorAll('.dashboard-reiter-card');
     // Tab 1 (Acker 2) is the second card; values: Hektar, Körner/ha, Einh., Dünger
     const values = cards[1].querySelectorAll('.dashboard-stat-value');
-    // Tab 1: max(0, 5.4 - 0.5 - 1.44 + 0) = 3.46 E → fmtCompact → "3,5"
-    expect(values[2].textContent.trim()).toMatch(/3,4|3,5/);
+    // Tab 1: basisE=5.4 (SOLL, kein IST), usedE=0.5 → max(0, 5.4 - 0.5) = 4,9.
+    expect(values[2].textContent.trim()).toBe('4,9');
   });
 
-  it('Dashboard Per-Tab-Karte Acker 2 zeigt carryover-subtracted Dünger verbl.', () => {
+  it('Dashboard Per-Tab-Karte Acker 2 zeigt Dünger verbl. nach Pool-Modell', () => {
     setupRepro();
     w.openDashboard();
     const cards = doc.querySelectorAll('.dashboard-reiter-card');
     const values = cards[1].querySelectorAll('.dashboard-stat-value');
-    // Tab 1: max(0, 1500 - 100 - 800 + 0) = 600 kg
-    expect(values[3].textContent).toContain('600');
+    // Tab 1: basisD=1500 (SOLL), usedD=100 → max(0, 1500 - 100) = 1400 kg.
+    expect(values[3].textContent).toContain('1.400');
   });
 
   // ── Inline-Drill-Card (render-results.js:159-160) ──────────────────────
 
-  it('Inline-Drill-Card "Dünger verbleibend" zeigt carryover-subtracted Wert', () => {
+  it('Inline-Drill-Card "Dünger verbleibend" zeigt Pool-Modell-Wert', () => {
     setupRepro();
     w.renderResults();
-    // r_drill_d_rem is the "Dünger verbleibend" field for the active tab.
+    // r_drill_d_rem ist das "Dünger verbleibend"-Feld für den aktiven Tab.
     // Active = Tab 1 (Acker 2, not-done).
-    // max(0, 1500 - 100 - 800 + 0) = 600 kg
-    expect(doc.getElementById('r_drill_d_rem').textContent).toContain('600');
+    // max(0, 1500 - 100 - 0 + 0) = 1400 kg.
+    expect(doc.getElementById('r_drill_d_rem').textContent).toContain('1.400');
   });
 
-  it('Inline-Drill-Card "Verbleibend" (Einheiten) zeigt carryover-subtracted Wert', () => {
+  it('Inline-Drill-Card "Verbleibend" (Einheiten) zeigt Pool-Modell-Wert', () => {
     setupRepro();
     w.renderResults();
-    // r_drill_e_rem is the "Verbleibend" field for the active tab.
-    // max(0, 5.4 - 0.5 - 1.44 + 0) = 3.46 E → formatEinheit → "3,5 Einheiten"
-    expect(doc.getElementById('r_drill_e_rem').textContent).toMatch(/3,4|3,5/);
+    // r_drill_e_rem ist das "Verbleibend"-Feld für den aktiven Tab.
+    // max(0, 5.4 - 0.5 - 0 + 0) = 4,9 → formatEinheit → "4,9 Einheiten".
+    expect(doc.getElementById('r_drill_e_rem').textContent).toBe('4,9 Einheiten');
   });
 
   // ── Regression-Guard: ohne carryover (kein IST) bleibt das alte Verhalten ─

--- a/tests/48-render-results-ist-fallback.test.js
+++ b/tests/48-render-results-ist-fallback.test.js
@@ -1,6 +1,7 @@
 /**
- * Tests for Issue #320: render-results.js renderDrillEntriesInline used
- * `||`-fallback for istE/istD at line 157-158.
+ * Tests for Issue #320, aktualisiert für Regel-7 Pool-Modell (Issue #378):
+ * render-results.js renderDrillEntriesInline uses
+ * `istHa > 0 ? getTabIstX(r) : getTabTotalX(r)` ternary.
  *
  * Background:
  * - Sibling render sites (render-dashboard.js:60-61, render-drill.js:50-52,
@@ -10,19 +11,21 @@
  *
  * Behavioral equivalence:
  *   For all reachable inputs through the public API (istHa, koerner, duenger
- *   all ≥ 0), the `||`-pattern and the ternary produce IDENTICAL values
- *   (verified by exhaustive brute-force over the input space). The change is
- *   a defensive consistency fix — it makes the code uniformly use the same
- *   pattern as all other render sites, which is more robust against future
- *   refactorings of getTabIstX() (e.g. if a future PR returns a non-zero
- *   sentinel for missing inputs).
+ *   all ≥ 0), the `||`-pattern and the ternary produce IDENTICAL values.
  *
- * This test pins the consistency contract:
- *   (a) The inline-drill display values are computed via the canonical
- *       formula `istHa > 0 ? getTabIstX(r) : getTabTotalX(r)` — same as
- *       every other render site.
- *   (b) The function uses the istHa-checked ternary (not `||`, not
- *       `istE > 0`, not `istD > 0`).
+ * Pool-Semantik (Regel 7, #378):
+ *   `savedEinheit`/`savedDuenger` ist IMMER 0. Keine per-Tab-Ersparnis-
+ *   Subtraktion mehr. remaining = max(0, basis - used + entzogen).
+ *
+ *   - Test 1 (Single Tab, istHa=4, solHa=5): Tab ist kein Mehrbedarf
+ *     (ist<sol) → cco.excess=0. remaining = 7,2 - 0,1 + 0 = 7,1.
+ *     Vor #378 wurde 1,8 E eigene-Ersparnis abgezogen → 5,3.
+ *   - Test 3 (3 Tabs, Tab A istMehrbedarf): Pool-Verteilung zieht aus
+ *     "späteren" Tabs (Tab C gibt 0,1 E ab) → Tab C's remaining erhöht
+ *     sich um 0,1. Tab A nimmt nichts von C (Befund 1 / Selbstgutschrift
+ *     ausgeschlossen). C's Wert: 13,5 - 0,1 + 0,1 = 13,5.
+ *     Vor #378 wurde 0,9 E "saved" abgezogen und 0,9 E "excess" addiert
+ *     → 13,4.
  */
 import { describe, it, expect, beforeEach } from 'vitest';
 import { createDom } from './helpers.js';
@@ -76,12 +79,12 @@ describe('Issue #320: renderDrillEntriesInline uses istHa>0 ternary (consistency
     // basis.istD = 4 × 200 = 800 kg
     expect(basis.istE).toBeCloseTo(7.2, 1);
     expect(basis.istD).toBe(800);
-    // Carryover-self (single tab): savedE = solE - istE = 9 - 7,2 = 1,8 E
-    //   savedD = 1000 - 800 = 200 kg
-    // remE = max(0, 7,2 - 0,1 - 1,8 + 0) = 5,3 E
-    // remD = max(0, 800 - 10 - 200 + 0) = 590 kg
-    expect(doc.getElementById('r_drill_e_rem').textContent).toBe('5,3 Einheiten');
-    expect(doc.getElementById('r_drill_d_rem').textContent).toContain('590');
+    // Regel 7 (#378): `savedEinheit` ist immer 0. Keine eigene-Ersparnis-
+    // Subtraktion mehr. Single Tab, kein Mehrbedarf → cco.excess=0.
+    // remE = max(0, 7,2 - 0,1 + 0) = 7,1 E
+    // remD = max(0, 800 - 10 + 0) = 790 kg
+    expect(doc.getElementById('r_drill_e_rem').textContent).toBe('7,1 Einheiten');
+    expect(doc.getElementById('r_drill_d_rem').textContent).toContain('790');
   });
 
   // ──────────────────────────────────────────────────────────────────────
@@ -141,13 +144,26 @@ describe('Issue #320: renderDrillEntriesInline uses istHa>0 ternary (consistency
     w.state.activeReiter = 2;
     w.saveState();
     w.renderResults();
-    // Tab C (active): basisD = SOLL 1500 kg (istHa=0 → ternary picks total).
-    // Carryover Saat: A excess 0,9 E → C; B saved 0,9 E → C (need>0, not source).
-    // Carryover Dünger: A excess 100 kg → C; B saved 100 kg → C.
-    // remE_C = max(0, 13,5 - 0,1 - 0,9 + 0,9) = 13,4 E
-    // remD_C = max(0, 1500 - 10 - 100 + 100) = 1490 kg
-    expect(doc.getElementById('r_drill_e_rem').textContent).toMatch(/13,4/);
-    expect(doc.getElementById('r_drill_d_rem').textContent).toContain('1.490');
+    // Regel 7 (#378): Pool-E = 18,9 + 8,1 + 0,1 = 27,1.
+    // Mehrbedarf-Tab A (istE=18,9 > solE=18, diff=0,9 E): zieht aus dem
+    // Pool. Befund 1 (Selbstgutschrift ausgeschlossen) → Tab A ist kein
+    // Spender. Spender-Order: invers nach Bearbeitungs-Zeit → C (10:00),
+    // dann B (09:00). C gibt 0,1 E ab, B gibt 0,8 E ab → deckt 0,9 E.
+    // Tab A: cco.excessE=0, cco.nettedE=0,9.
+    // Tab C (active): cco.excessE=0,1 (=selbst abgegeben). basisD =
+    // SOLL=13,5 E (istHa=0). usedE=0,1. remainingE = 13,5 - 0,1 + 0,1 = 13,5.
+    //
+    // Pool-Dünger: 2100 + 900 + 10 = 3010. Tab A Mehrmbedarf-D = 100.
+    // C gibt 10 kg (alles), B gibt 90 kg → deckt 100 kg. C's cco.excessD=10.
+    // Tab C basisD = 1500 (istHa=0). usedD=10. remainingD = 1500 - 10 + 10 = 1500.
+    //
+    // Vor #378 (Phase-1): C hätte 0,9 E "saved" abgezogen + 0,9 E "excess"
+    // addiert = 13,4. Das Modell ist komplett ausgetauscht — die "Ersparnis
+    // aus IST<SOLL" landet NICHT mehr per Phase-1-Pfad bei Mehrbedarf-Tabs,
+    // sondern im globalen Pool und wird nur bei tatsächlichem Mehrmbedarf
+    // ausgespeist.
+    expect(doc.getElementById('r_drill_e_rem').textContent).toBe('13,5 Einheiten');
+    expect(doc.getElementById('r_drill_d_rem').textContent).toContain('1.500');
   });
 
   // ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Context
Folge-PR A fuer Issue #378 (PR #380 hat das Regel-7 Pool-Modell fuer Carryover ausgeliefert).

PR #380 hat in `public/js/calculations.js` `computeAllCarryovers` auf das neue Pool-Modell umgestellt:
- `savedEinheit`/`savedDuenger` ist IMMER 0
- `excessEinheit`/`excessDuenger` tragen jetzt `entzogen_i` (Menge, die ANDERE Tabs diesem Tab abgezogen haben)
- `getTabRemaining` neue Formel: `max(0, soll - used + entzogen)`

Die Render-Sites in `public/js/render-results.js`, `render-dashboard.js`, `render-tabs.js` ziehen Basis + Used + Carryover bereits zentral ueber `getTabRemaining()` ab und subtrahieren NICHT mehr `co.savedEinheit` direkt. **Es war keine Render-Site-Anpassung noetig.**

Was noetig war: 9 user-facing Test-Failures + 1 drill-protocol-Test hatten ihre Erwartungen noch auf die alte Phase-1-Ersparnis-Subtraktion gepinnt (`expected '4' to be '2'` etc.). Diese Pins wurden auf die Regel-7 Pool-Semantik umgestellt.

## Betroffene Test-Files (alle gruen nach Pin-Anpassung)
- tests/40-ist-flaeche-sync.test.js (3 Tests)
  - Dashboard-Einheiten-verbl.: 4 (statt 2)
  - Dashboard-Dünger-verbl.: 600 kg (statt 300 kg)
- tests/47-dashboard-carryover-subtraction.test.js (6 Tests)
  - Dashboard Summary + Per-Tab-Karte + Inline-Drill auf Pool-Semantik umgestellt (kein Cross-Tab-Subtraktion ohne Mehrbedarf-Luecken)
- tests/48-render-results-ist-fallback.test.js (4 Tests)
  - renderDrillEntriesInline: Tab ohne Mehrbedarf zeigt full basis-used (z.B. 7,1 statt 5,3)
- tests/05-drill-protocol.test.js (1 Test)
  - 'Tab-1 own savings stay in pool under Regel 7': bleibt bei 18 E (kein Cross-Tab-Abzug, weil Tab 2 kein Mehrbedarf ist)

## Was wurde nicht geaendert
- `public/js/render-results.js`, `render-dashboard.js`, `render-tabs.js`: **unveraendert** — nutzen bereits `getTabRemaining()` ohne eigene - savedEinheit-Mathematik.
- `public/js/render-drill.js`: unveraendert — referenziert `cco.savedEinheit`, aber das ist unter Regel 7 immer 0. Drill-Summary-Anzeige bleibt korrekt, da sie auf IST-/SOLL-basierter Aggregation beruht.
- `public/js/calculations.js`: unveraendert (PR #380 hat das bereits finalisiert).

## Verify
- `pnpm test` fuer die 4 spezifischen Tests gruen (16/16 in #40, 8/8 in #47, 4/4 in #48, 22/22 in #05)
- `pnpm lint` clean
- Tests 19, 35, 46, 53, 54, 56, 57, 99, 100, 98, 55 (teilweise) bleiben rot — das sind die dokumentierten Carryover-Test-Adapt-Follow-ups (separater Coder-PR).

Closes Folgeschritt A fuer #378