### PR TITLE
fix(carryover): Mehrbedarf nicht mehr doppelt zählen — netted in remaining abziehen

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,9 +573,16 @@ fahrgassenFaktor = (fahrgassenBreite - 1) / fahrgassenBreite
 ### Verbleibende Menge
 
 ```
-verbliebene_Einheiten = max(0, Einheiten_IST - usedEinheit - carryover)
-verbliebener_Dünger   = max(0, Dünger_IST  - usedDuenger  - carryover)
+verbliebene_Einheiten = max(0, Einheiten_IST - usedEinheit + entzogen - netted)
+verbliebener_Dünger   = max(0, Dünger_IST  - usedDuenger  + entzogen - netted)
 ```
+
+`entzogen` = Anteil, den ANDERE Tabs (Mehrbedarf-Lücken) diesem Tab entzogen
+haben (Spender). `netted` = Anteil des eigenen Mehrbedarfs, der bereits durch
+den Cross-Tab-Pool gedeckt ist (Empfänger). Beide Terme zusammen halten die
+Materialerhaltung: `Σ remaining = Σ basis − Σ used`, da `Σ entzogen = Σ netted`.
+Ohne `− netted` würde der gedeckte Mehrbedarf doppelt gezählt (im Empfänger-
+remaining UND im Spender-remaining via `+ entzogen`).
 
 ### Prognose (Maschinen-Log)
 

--- a/public/js/calculations.js
+++ b/public/js/calculations.js
@@ -359,12 +359,19 @@ function getCarryover(tabIndex) {
 // sowie Basis + Used, damit Render-Sites die Anzeige konsistent speisen.
 //
 // REGEL 7 (Issue #378) — NEUE FORMEL:
-//   remaining_i = max(0, soll_i − used_i + entzogen_i)
-// wobei `entzogen_i` = die Menge, die ANDERE Tabs (Mehrbedarf-Lücken,
-// rueckwaerts verteilt) diesem Tab abgezogen haben. Die Felder `saved*` und
-// `netted*` existieren weiterhin fuer Backward-Compat mit Render-Sites —
-// die "Quelle" ist jetzt aber der globale Pool (Σ used der done=false Tabs),
-// nicht mehr eine Per-Tab-Ersparnis.
+//   remaining_i = max(0, soll_i − used_i + entzogen_i − netted_i)
+// `entzogen_i` = Menge, die ANDERE Tabs (Mehrbedarf-Lücken, rückwärts
+//   verteilt) DIESEM Tab abgezogen haben (Spender-Tabs, excess*).
+// `netted_i`   = Menge, mit der der Mehrbedarf DIESES Tabs bereits durch
+//   den Cross-Tab-Pool gedeckt wurde (Empfänger-Tabs, netted*).
+//
+// WICHTIG (Doppelzählungs-Fix): entzogen und netted sind zwei Seiten derselben
+// Buchung (Σ entzogen === Σ netted === gedeckter Mehrbedarf). Beide müssen in
+// die Formel eingehen, sonst wird der gedeckte Mehrbedarf zweimal gezählt —
+// einmal in der offenen Lücke des Empfänger-Tabs (remaining nicht um netted
+// reduziert) UND einmal im aufgeblähten remaining des Spender-Tabs (+entzogen).
+// Mit beiden Termen gilt Materialerhaltung:
+//   Σ remaining_i = Σ basis_i − Σ used_i   (da Σ netted − Σ entzogen = 0).
 //
 // Null-safe (fehlende Felder = 0). IST-Flaeche hat Vorrang vor SOLL.
 function getTabRemaining(r, tabIdx) {
@@ -378,13 +385,17 @@ function getTabRemaining(r, tabIdx) {
   // Regel 7: entzogen = was ANDERE Tabs (nicht dieser) von ihm genommen haben
   var entzogenE = co.excessEinheit;
   var entzogenD = co.excessDuenger;
+  // netted = Anteil des eigenen Mehrbedarfs, der bereits durch den Pool
+  // gedeckt ist (muss abgezogen werden, sonst Doppelzählung mit entzogen).
+  var nettedE = co.nettedEinheit;
+  var nettedD = co.nettedDuenger;
   return {
     basisE:     solE,
     basisD:     solD,
     usedE:      usedE,
     usedD:      usedD,
-    remainingE: Math.max(0, solE - usedE + entzogenE),
-    remainingD: Math.max(0, solD - usedD + entzogenD)
+    remainingE: Math.max(0, solE - usedE + entzogenE - nettedE),
+    remainingD: Math.max(0, solD - usedD + entzogenD - nettedD)
   };
 }
 
@@ -395,6 +406,11 @@ function getTabRemaining(r, tabIdx) {
 // REGEL 7 (Issue #378): Fertig = remaining = 0 ODER done=true.
 // Carryover wird nur beruecksichtigt, wenn tabIndex mitgegeben wird
 // (Backward-Compat). Nil-safe (fehlende Felder = 0).
+//
+// Formel (konsistent mit getTabRemaining):
+//   remaining = max(0, soll − used + entzogen − netted)
+// netted wird abgezogen, damit ein Mehrbedarf-Tab, dessen Lücke voll durch
+// den Pool gedeckt ist und dessen Plan-Bedarf erfüllt ist, als fertig gilt.
 function isTabDone(r, tabIndex) {
   if (!r || !r.entries) return true; // Keine Entries = fertig (kein Bedarf)
   if (r.done) return true; // Manuell abgeschlossen (Issue #377)
@@ -406,14 +422,14 @@ function isTabDone(r, tabIndex) {
   var istE = getTabIstEinheiten(r);
   var totalE = istE > 0 ? istE : getTabTotalEinheiten(r);
   var usedE = getTabUsedEinheiten(r);
-  // remaining = soll - used + entzogen (Regel 7)
-  var remainingE = Math.max(0, totalE - usedE + carryover.excessEinheit);
+  // remaining = soll - used + entzogen - netted (Regel 7, Doppelzählungs-Fix)
+  var remainingE = Math.max(0, totalE - usedE + carryover.excessEinheit - carryover.nettedEinheit);
   if (remainingE > 0.05) return false;
 
   var istD = getTabIstDuenger(r);
   var totalD = istD > 0 ? istD : getTabTotalDuenger(r);
   var usedD = getTabUsedDuenger(r);
-  var remainingD = Math.max(0, totalD - usedD + carryover.excessDuenger);
+  var remainingD = Math.max(0, totalD - usedD + carryover.excessDuenger - carryover.nettedDuenger);
   return remainingD <= 0.05;
 }
 

--- a/tests/101-carryover-conservation.test.js
+++ b/tests/101-carryover-conservation.test.js
@@ -1,0 +1,130 @@
+/**
+ * Carryover-Aggregat-Erhaltung — Doppelzählungs-Wächter (Fix "− netted").
+ *
+ * Regel-7-Fix-Formel: remaining_i = max(0, basis_i − used_i + entzogen_i − netted_i).
+ * Da in computeAllCarryovers jede Einheit, die einem Spender entzogen wird
+ * (entzogen), exakt einen Empfänger-Mehrbedarf deckt (netted) — also
+ * Σ entzogen === Σ netted — hebt sich das in der Aggregatsumme auf:
+ *
+ *   Σ remaining_i = Σ(basis_i − used_i)   (ohne Clamping durch überfüllte Tabs)
+ *
+ * Vor dem Fix fehlte "− netted" → die gedeckte Mehrbedarfsmenge tauchte BEIDE
+ * Male auf: einmal im Empfänger-remaining (Lücke nicht abgezogen) UND einmal
+ * im Spender-remaining (via +entzogen). Das Aggregat war um Σ netted zu hoch.
+ * Genau das vom User bemängelte "Mehrbedarf wird zweimal angezeigt".
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createDom } from './helpers.js';
+import { generateScenarios } from './helpers/invariant-generator.js';
+
+const TOL = 0.5;
+
+describe('Carryover-Aggregat-Erhaltung (Doppelzählungs-Wächter, Fix − netted)', () => {
+    let w;
+    beforeEach(() => { w = createDom().window; });
+
+    function apply(scenario) {
+        w.state.koernerProEinheit = scenario.koernerProEinheit;
+        w.state.reiter = scenario.reiter;
+        if (w.invalidateCarryoverCache) w.invalidateCarryoverCache();
+    }
+
+    function sums(rems) {
+        const sumRem = { E: 0, D: 0 };
+        const phys = { E: 0, D: 0 };
+        for (const r of rems) {
+            sumRem.E += r.remainingE; sumRem.D += r.remainingD;
+            phys.E += (r.basisE - r.usedE); phys.D += (r.basisD - r.usedD);
+        }
+        return { sumRem, phys };
+    }
+
+    it('Clean-Szenarien (kein Clamping): Σ remaining === Σ(basis − used) — kein Phantom-Bedarf', () => {
+        const scenarios = generateScenarios(0xC0FFEE, 400);
+        let checkedSaat = 0, checkedDuenger = 0;
+        for (let s = 0; s < scenarios.length; s++) {
+            apply(scenarios[s]);
+            const rems = scenarios[s].reiter.map((r, i) => w.getTabRemaining(r, i));
+            const cos = scenarios[s].reiter.map((_, i) => w.getCarryover(i));
+            const nettedE = cos.reduce((a, c) => a + c.nettedEinheit, 0);
+            const nettedD = cos.reduce((a, c) => a + c.nettedDuenger, 0);
+            const { sumRem, phys } = sums(rems);
+
+            // "Clean" = kein Tab wird gecclampet, d.h. der UNGECLAMPTE Wert
+            //   raw = basis − used + excess − netted ≥ 0 für jeden Tab.
+            //   (used ≤ basis reicht NICHT: ein Empfänger mit used > sol wird trotz
+            //    used ≤ ist gecclampet.) Nur dann ist max(0, raw) = raw und die
+            //    Aggregatsumme hält exakt.
+            const cleanSaat = rems.every((r, i) =>
+                (r.basisE - r.usedE + cos[i].excessEinheit - cos[i].nettedEinheit) >= -TOL);
+            const cleanDuenger = rems.every((r, i) =>
+                (r.basisD - r.usedD + cos[i].excessDuenger - cos[i].nettedDuenger) >= -TOL);
+
+            if (cleanSaat) {
+                checkedSaat++;
+                // Fix: Σ remaining === Σ(basis − used). Bug: + Σ netted (zu hoch).
+                if (Math.abs(sumRem.E - phys.E) > TOL) {
+                    throw new Error(
+                        `Aggregat Saat nicht erhalten (clean) Szenario[${s}]: ` +
+                        `Σrem=${sumRem.E.toFixed(3)} ≠ phys=${phys.E.toFixed(3)} ` +
+                        `(Σnetted=${nettedE.toFixed(3)})\n` +
+                        JSON.stringify(scenarios[s].reiter.map((r, i) => ({
+                            i, hektar: r.hektar, istHektar: r.istHektar, koerner: r.koerner,
+                            duenger: r.duenger, entries: r.entries, co: cos[i]
+                        })), null, 2)
+                    );
+                }
+            }
+            if (cleanDuenger) {
+                checkedDuenger++;
+                if (Math.abs(sumRem.D - phys.D) > TOL) {
+                    throw new Error(
+                        `Aggregat Dünger nicht erhalten (clean) Szenario[${s}]: ` +
+                        `Σrem=${sumRem.D.toFixed(3)} ≠ phys=${phys.D.toFixed(3)} ` +
+                        `(Σnetted=${nettedD.toFixed(3)})`
+                    );
+                }
+            }
+        }
+        // Sanity: mindestens ein Clean-Szenario geprüft.
+        expect(checkedSaat + checkedDuenger).toBeGreaterThan(0);
+    });
+
+    it('Alle Szenarien: Σ remaining ≥ Σ(basis − used) (Clamping durch Überfüllung darf nur addieren)', () => {
+        const scenarios = generateScenarios(0xC0FFEE, 400);
+        for (let s = 0; s < scenarios.length; s++) {
+            apply(scenarios[s]);
+            const rems = scenarios[s].reiter.map((r, i) => w.getTabRemaining(r, i));
+            const { sumRem, phys } = sums(rems);
+            // max(0, …) lässt die Summe nur WACHSEN, nie schrumpfen → nie unter phys.
+            expect(sumRem.E).toBeGreaterThanOrEqual(phys.E - TOL);
+            expect(sumRem.D).toBeGreaterThanOrEqual(phys.D - TOL);
+        }
+    });
+
+    it('3-Tab-User-Szenario: Σ remaining = 7 E / 600 kg (= Σ basis − Σ used, vor Fix 8 / 700)', () => {
+        // Issue #347-Setup (T2 = Mehrbedarf 1 E / 100 kg, gedeckt durch T3).
+        w.state.koernerProEinheit = 50000;
+        w.state.reiter = [
+            { name: 'T1', hektar: 10, istHektar: 9, koerner: 100000, duenger: 200,
+              entries: [{ einheit: 18, duenger: 1800, time: '08:00' }] },
+            { name: 'T2', hektar: 7.5, istHektar: 8, koerner: 100000, duenger: 200,
+              entries: [{ einheit: 11, duenger: 1500, time: '09:00' }] },
+            { name: 'T3', hektar: 5, istHektar: 5, koerner: 100000, duenger: 200,
+              entries: [{ einheit: 8, duenger: 500, time: '10:00' }] },
+        ];
+        w.invalidateCarryoverCache();
+        const rems = w.state.reiter.map((r, i) => w.getTabRemaining(r, i));
+        const { sumRem, phys } = sums(rems);
+        // Fix: T1=0, T2=4, T3=3 → 7 E; Dünger 0 + 0 + 600 → 600 kg.
+        expect(sumRem.E).toBeCloseTo(7, 1);
+        expect(sumRem.D).toBeCloseTo(600, 0);
+        // Aggregat entspricht exakt dem physischen Gesamtbedarf.
+        expect(sumRem.E).toBeCloseTo(phys.E, 1);
+        expect(sumRem.D).toBeCloseTo(phys.D, 0);
+        // Der Mehrbedarf (1 E / 100 kg) taucht nur EINMAL auf (in T3 als
+        // entzogen), nicht zusätzlich in T2 → kein Doppelzählen.
+        expect(rems[1].remainingE).toBeCloseTo(4, 1); // T2: 16-11-1(netted) = 4
+        expect(rems[1].remainingD).toBeCloseTo(0, 0); // T2 Dünger: 1600-1500-100 = 0
+    });
+});

--- a/tests/35-carryover-isTabDone-fix.test.js
+++ b/tests/35-carryover-isTabDone-fix.test.js
@@ -112,8 +112,9 @@ describe('Issue #138: computeAllCarryovers skips carryover-dependent tabs', () =
     // savedEinheit ist unter Regel 7 immer 0.
     expect(co0.savedEinheit).toBe(0);
     expect(co1.savedEinheit).toBe(0);
-    // isTabDone: Tab 0 ist Mehrbedarf-Quelle mit used=5 < sollE=8 → remE=3 > 0.
-    expect(w.isTabDone(w.state.reiter[0], 0)).toBe(false);
+    // isTabDone: Tab 0 ist Mehrbedarf-Quelle, used=5 < istE=8, ABER die Lücke
+    // ist voll per Pool (netted=3) gedeckt → remainingE = max(0, 8-5+0-3) = 0 → done.
+    expect(w.isTabDone(w.state.reiter[0], 0)).toBe(true);
     // Tab 1: used=5/500, aber entzogen=3/300 (Pool-Spender) → remE = 5-5+3 = 3 > 0.
     // Tab 1 ist NICHT done, weil er 3 E / 300 kg an Tab 0 abgegeben hat.
     expect(w.isTabDone(w.state.reiter[1], 1)).toBe(false);

--- a/tests/53-mehrbedarf-tab-verbleibend.test.js
+++ b/tests/53-mehrbedarf-tab-verbleibend.test.js
@@ -93,16 +93,11 @@ describe('Mehrbedarf-Tab verbleibend = 0 wenn durch Netting abgedeckt (Regel 7)'
 
   it('Tab 1 isTabDone === true (Mehrbedarf gedeckt + used < soll)', () => {
     setup3Tabs();
-    // Tab 1: sollE=16, usedE=15, entzogen=0 → remE=1, aber nettedE=1 → effektiv 0.
-    // getTabRemaining: remainingE = max(0, 16-15+0) = 1 → NICHT done by raw remaining!
-    // ABER der "Mehrbedarf gedeckt"-Pfad: wenn usedE >= istE - nettedE, dann done.
-    // Vereinfacht: Tab 1 hat usedE=15, istE=16, Lücke=1, netted=1 → Lücke gefüllt
-    // → der Tab ist konzeptuell fertig (alle Bedarfe abgedeckt).
-    // isTabDone in PR #380 nutzt `remaining = max(0, soll - used + entzogen)`
-    // und returnt false, wenn remaining > 0.05. Hier: remainingE=1 → false.
-    // → Der Test pinnt jetzt explizit das neue Verhalten.
-    expect(w.isTabDone(w.state.reiter[1], 1)).toBe(false);
-    // Stattdessen: getCarryover dokumentiert die Deckung.
+    // Tab 1: istE=16, usedE=15, nettedE=1 → remainingE = max(0, 16-15+0-1) = 0.
+    // Doppelzählungs-Fix (− netted): die per Pool gedeckte Lücke reduziert das
+    // remaining → der Tab ist konzeptuell fertig (alle Bedarfe abgedeckt).
+    expect(w.isTabDone(w.state.reiter[1], 1)).toBe(true);
+    // getCarryover dokumentiert die Deckung.
     expect(w.getCarryover(1).nettedEinheit).toBeCloseTo(1, 1);
   });
 
@@ -143,24 +138,25 @@ describe('Mehrbedarf-Tab verbleibend = 0 wenn durch Netting abgedeckt (Regel 7)'
     expect(el.textContent).toMatch(/braucht|fertig/);
   });
 
-  it('(b) Dashboard Per-Tab-Karte Acker 2 zeigt 1 / 100 (verbleibend, nicht 0!)', () => {
+  it('(b) Dashboard Per-Tab-Karte Acker 2 zeigt 0 / 0 kg (Mehrbedarf per Netting gedeckt)', () => {
     setup3Tabs();
     w.openDashboard();
     const cards = doc.querySelectorAll('.dashboard-reiter-card');
     // Tab 1 ist die zweite Karte. Werte: [Hektar, Körner/ha, Einh. verbl., Dünger verbl.]
     const values = cards[1].querySelectorAll('.dashboard-stat-value');
-    // getTabRemaining: remE = max(0, 16-15+0) = 1; remD = max(0, 1600-1500+0) = 100.
-    expect(values[2].textContent.trim()).toBe('1');
-    expect(values[3].textContent.trim()).toContain('100');
+    // Doppelzählungs-Fix: Tab 1 remaining = 16-15+0-1(netted) = 0 E / 1600-1500-100 = 0 kg.
+    // Die per Pool gedeckte Lücke taucht NICHT als offener Bedarf auf.
+    expect(values[2].textContent.trim()).toBe('0');
+    expect(values[3].textContent.trim()).toContain('0');
   });
 
-  it('(c) Inline-Drill (activeReiter = Tab 1) zeigt 1,0 Einheiten / 100 kg', () => {
+  it('(c) Inline-Drill (activeReiter = Tab 1) zeigt 0,0 Einheiten / — Dünger', () => {
     setup3Tabs();
     w.state.activeReiter = 1;
     w.renderResults();
-    expect(doc.getElementById('r_drill_e_rem').textContent).toContain('1');
+    expect(doc.getElementById('r_drill_e_rem').textContent).toBe('0,0 Einheiten');
     const remDRow = doc.getElementById('r_drill_d_rem');
-    expect(remDRow.textContent).toContain('100');
+    expect(remDRow.textContent).toBe('—');
   });
 
   // ── Edge: 2 Mehrbedarf-Tabs, beide durch Pool gedeckt ──────────────────

--- a/tests/54-sequentielle-netting.test.js
+++ b/tests/54-sequentielle-netting.test.js
@@ -74,19 +74,16 @@ describe('Sequenzielle Carryover-Netting (Issue #368, Regel 7)', () => {
     expect(sum).toBe(2);
   });
 
-  // isTabDone: Tab 1: sollE=16 (IST), usedE=14, entzogenE=0 (Quelle) → remE=2.
-  //            ABER nach Netting ist die Lücke gefüllt — der Tab hat alle
-  //            Bedarfe abgedeckt. isTabDone nutzt aber `soll - used + entzogen`
-  //            ohne Netting-Subtraktion → remE=2 > 0.05 → NICHT done.
-  //            Tab 2: sollE=16, usedE=14, entzogenE=0 → remE=2 → NICHT done.
-  it('Mehrbedarf-Tabs bleiben nach Algorithmus isTabDone=false (verbleibend aus IST-used)', () => {
+  // isTabDone (mit Doppelzählungs-Fix − netted):
+  //   Tab 1: istE=16, usedE=14, nettedE=2 (volle Lücke gedeckt) → remE = 16-14-2 = 0 → done.
+  //   Tab 2: istE=16, usedE=14, nettedE=0 (Pool leer, Lücke offen) → remE = 2 → NICHT done.
+  it('Mehrbedarf-Tab: voll genettet → isTabDone=true; ungenettet → isTabDone=false', () => {
     setupPoolKleinerAlsExcess();
-    // Tab 1: istE=16, usedE=14, entzogenE=0 → remE=2 > 0.05 → NICHT done.
-    //         ABER getCarryover dokumentiert: nettedEinheit=2 (Lücke gefüllt).
-    expect(w.isTabDone(w.state.reiter[1], 1)).toBe(false);
-    // Tab 2: gleicher remE → NICHT done.
+    // Tab 1: Lücke 2E wird voll aus dem Pool gedeckt → done.
+    expect(w.isTabDone(w.state.reiter[1], 1)).toBe(true);
+    // Tab 2: Pool leer → Lücke bleibt offen → NICHT done.
     expect(w.isTabDone(w.state.reiter[2], 2)).toBe(false);
-    // Belegen via getCarryover: Tab 1 ist konzeptuell fertig (netted = full).
+    // Belegen via getCarryover: Tab 1 voll genettet, Tab 2 nicht.
     expect(w.getCarryover(1).nettedEinheit).toBe(2);
     expect(w.getCarryover(2).nettedEinheit).toBe(0);
   });
@@ -183,20 +180,19 @@ describe('Sequenzielle Carryover-Netting (Issue #368, Regel 7)', () => {
     expect(w.getCarryover(2).nettedEinheit).toBe(1);
   });
 
-  // ── Render-Site: getTabRemaining reflektiert Netting via entzogen=0 ─────
-  //   Tab 1: sollE=16 (IST), usedE=14, entzogenE=0 (Quelle) → remE = 2.
-  //          ABER nettedE=2 (Lücke gefüllt) → die Lücke aus getTabRemaining-
-  //          Sicht ist nicht sichtbar (Netting ist semantisch eine Deckung,
-  //          keine Reduktion des SOLL-Bedarfs).
-  it('getTabRemaining: Tab 1 remE=2 (Lücke nach IST-used), Tab 2 remE=2 (Mehrbedarf offen)', () => {
+  // ── Render-Site: getTabRemaining reflektiert Netting via − netted ────────
+  //   Doppelzählungs-Fix: remaining = max(0, istE − usedE + entzogen − netted).
+  //   Tab 1: 16-14+0-2 = 0 (Lücke per Pool voll gedeckt → nicht als Bedarf sichtbar).
+  //   Tab 2: 16-14+0-0 = 2 (Mehrbedarf-Lücke offen, kein Netting erfolgt).
+  it('getTabRemaining: Tab 1 remE=0 (voll genettet), Tab 2 remE=2 (Mehrbedarf offen)', () => {
     setupPoolKleinerAlsExcess();
     const rem1 = w.getTabRemaining(w.state.reiter[1], 1);
     const rem2 = w.getTabRemaining(w.state.reiter[2], 2);
-    // getTabRemaining: remE = max(0, istE - usedE + entzogenE).
-    // Tab 1: 16-14+0 = 2. Tab 2: 16-14+0 = 2.
-    expect(rem1.remainingE).toBe(2);
+    // getTabRemaining: remE = max(0, istE - usedE + entzogenE - nettedE).
+    // Tab 1: 16-14+0-2 = 0. Tab 2: 16-14+0-0 = 2.
+    expect(rem1.remainingE).toBe(0);
     expect(rem2.remainingE).toBe(2);
-    // ABER Tab 1 ist netted (Lücke gefüllt), Tab 2 nicht.
+    // Tab 1 ist netted (Lücke gefüllt), Tab 2 nicht.
     expect(w.getCarryover(1).nettedEinheit).toBe(2);
     expect(w.getCarryover(2).nettedEinheit).toBe(0);
   });

--- a/tests/55-carryover-invariants.test.js
+++ b/tests/55-carryover-invariants.test.js
@@ -104,12 +104,12 @@ describe('Carryover-Invarianten (5+1 User-Regeln, Regel-7-Modell #378)', () => {
     // matched exakt der dokumentierten Formel — Material darf weder entstehen
     // noch verschwinden."
     //
-    // Regel 7 (Issue #378): remaining = max(0, basisE − usedE + entzogenE)
-    //   wobei entzogenE = co.excessEinheit (Anteil, den ANDERE Tabs diesem
-    //   Tab entzogen haben). co.savedEinheit und co.nettedEinheit gehen NICHT
-    //   in remaining ein (Backward-Compat-Felder, die für Anzeige genutzt
-    //   werden, aber rechnerisch Nullsummen-Spiel zwischen
-    //   sol/used/excess/netted sind).
+    // Regel 7 (Issue #378) + Doppelzählungs-Fix: remaining = max(0, basis − used
+    //   + entzogen − netted). entzogen = was ANDERE Tabs diesem Tab abgezogen
+    //   haben (Spender, co.excess*); netted = Anteil des eigenen Mehrbedarfs, der
+    //   bereits durch den Pool gedeckt ist (Empfänger, co.netted*). Beide Terme
+    //   zusammen halten Materialerhaltung: Σ remaining = Σ basis − Σ used
+    //   (da Σ entzogen === Σ netted).
     //
     // Testet: für 200 Szenarien, jeden Tab, dass getTabRemaining exakt der
     // Formel folgt. Materialerhaltung im engeren Sinne (= kein Material
@@ -132,10 +132,10 @@ describe('Carryover-Invarianten (5+1 User-Regeln, Regel-7-Modell #378)', () => {
                     const istD = w.getTabIstDuenger(r);
                     const basisE = istE > 0 ? istE : w.getTabTotalEinheiten(r);
                     const basisD = istD > 0 ? istD : w.getTabTotalDuenger(r);
-                    // Regel 7 (Issue #378): remaining = max(0, basis − used + entzogen)
-                    // entzogen = was ANDERE diesem Tab abgezogen haben = co.excess*
-                    const expectedE = Math.max(0, basisE - usedE + co.excessEinheit);
-                    const expectedD = Math.max(0, basisD - usedD + co.excessDuenger);
+                    // Regel 7 + Doppelzählungs-Fix: remaining = max(0, basis − used
+                    // + entzogen − netted). entzogen = co.excess*, netted = co.netted*.
+                    const expectedE = Math.max(0, basisE - usedE + co.excessEinheit - co.nettedEinheit);
+                    const expectedD = Math.max(0, basisD - usedD + co.excessDuenger - co.nettedDuenger);
                     if (Math.abs(rem.remainingE - expectedE) > TOL) {
                         throw new Error(
                             `I1 Saat-Fehler in scenario[${s}] tab[${i}]: ` +

--- a/tests/98-planner-verify-371-real.test.js
+++ b/tests/98-planner-verify-371-real.test.js
@@ -57,15 +57,16 @@ describe('PLANNER VERIFY #378 — Regel-7 Pool-Modell', () => {
                 `excessD=${co.excessDuenger.toFixed(0)}`,
                 `remainingD=${rem.remainingD.toFixed(0)}`);
         }
-        // Tab1 (Mehrbedarf 1,6 E): Pool (Tab2+Tab3=18,4) deckt voll → netted=1,6
-        // used=24 < ist=25,6 → physische Lücke bleibt 1,6 (wird aus dem Pool gefüllt,
-        // bleibt aber in remaining sichtbar, weil sie nie in used landet).
+        // Tab1 (Mehrbedarf 1,6 E): Pool (Tab2+Tab3=18,4) deckt voll → netted=1,6.
+        // used=24 < ist=25,6 → physische Lücke 1,6 wird VOLL durch den Pool
+        // gedeckt (netted) → remaining = basis − used − netted = 0 (Doppelzählungs-
+        // Fix: die gedeckte Lücke bleibt NICHT in remaining stehen).
         const co1 = w.getCarryover(0);
         expect(co1.nettedEinheit).toBeCloseTo(1.6, 1);
         expect(co1.nettedDuenger).toBeCloseTo(200, 0);
         const rem1 = w.getTabRemaining(w.state.reiter[0], 0);
-        expect(rem1.remainingE).toBeCloseTo(1.6, 1);
-        expect(rem1.remainingD).toBeCloseTo(200, 0);
+        expect(rem1.remainingE).toBeCloseTo(0, 1);
+        expect(rem1.remainingD).toBeCloseTo(0, 0);
 
         // Tab2 (neutral voll): keine Entzogen, remaining 0
         const rem2 = w.getTabRemaining(w.state.reiter[1], 1);

--- a/tests/99-verify-bug-user-3tab-drill-summary.test.js
+++ b/tests/99-verify-bug-user-3tab-drill-summary.test.js
@@ -112,15 +112,16 @@ describe('Issue #347 Folge-Bug (Regel 7): Drill-Summary aggregiert Tab-Mehrbedar
     expect(inlineD.textContent).toBe('600 kg');
   });
 
-  it('T2 physische Mehrbedarf-Lücke (5 E / 100 kg) fliesst NICHT als Tab-Bedarf in andere Tabs', () => {
-    // Vor #378: T2 Mehrbedarf konnte Phase-1-Doppelzählung auslösen, weil
-    // es als Quelle UND Empfänger verbucht wurde. Unter Regel 7:
-    //   - T2 ist NUR Empfänger (nettedEinheit=1).
-    //   - T2's physische Lücke 5 E / 100 kg (used 11 vs ist 16) bleibt
-    //     in remaining(2) erhalten, NICHT als Tab-Bedarf in andere Tabs.
+  it('T2 Mehrbedarf-Lücke wird per Netting gedeckt (keine Doppelzählung in andere Tabs)', () => {
+    // Regel 7 + Doppelzählungs-Fix (− netted):
+    //   - T2 ist NUR Empfänger (nettedEinheit=1 / nettedDuenger=100).
+    //   - T2 remaining = basis − used − netted = 16-11-1 = 4 E / 1600-1500-100 = 0 kg.
+    //     Die 1-E-/100-kg-Lücke ist durch den Pool (T3) gedeckt und taucht in T2
+    //     NICHT mehr als offener Bedarf auf — sie wandert als entzogen genau EINMAL
+    //     zu T3 (Spender, der nachfüllen muss). Σ remaining = 0+4+3 = 7 E = Σ basis − Σ used.
     setup3TabsUserScenario();
     const rem2 = AG.getTabRemaining(AG.state.reiter[1], 1);
-    expect(rem2.remainingE).toBeCloseTo(5, 1);
-    expect(rem2.remainingD).toBeCloseTo(100, 0);
+    expect(rem2.remainingE).toBeCloseTo(4, 1);
+    expect(rem2.remainingD).toBeCloseTo(0, 0);
   });
 });

--- a/tests/99-verify-bug-user-3tab.test.js
+++ b/tests/99-verify-bug-user-3tab.test.js
@@ -92,10 +92,12 @@ describe('Issue #347 (Regel 7): Carryover vergibt Salden nicht mehr in Tabs ohne
 
   it('Per-Tab-Verbleibend nach Regel-7-Formel — Issue #347 Endresult umgerechnet', () => {
     setup3Tabs();
-    // expected berechnet mit getTabRemaining(r, i) (Regel-7-Formel):
-    //   T1: 18-18+0 = 0/0
-    //   T2: 16-11+0 = 5/100 (Mehrbedarf-Lücke, physisch offen)
-    //   T3: 10-8+1 = 3/600 (2 Rest + 1 entzogen)
+    // expected berechnet mit getTabRemaining(r, i) (Regel-7-Formel mit
+    // Doppelzählungs-Fix: remaining = max(0, basis − used + entzogen − netted)):
+    //   T1: 18-18+0-0 = 0/0
+    //   T2: 16-11+0-1 = 4/0 (Mehrbedarf-Lücke 1E/100kg voll genettet → 0 sichtbar;
+    //                         T2 braucht 4E für seine Rest-Plan-Fläche)
+    //   T3: 10-8+1-0 = 3/600 (Spender: 2 Rest + 1 entzogen)
     const r1 = AG.state.reiter[0];
     const r2 = AG.state.reiter[1];
     const r3 = AG.state.reiter[2];
@@ -106,8 +108,8 @@ describe('Issue #347 (Regel 7): Carryover vergibt Salden nicht mehr in Tabs ohne
     expect(rem1.remainingE).toBeCloseTo(0, 1);
     expect(rem1.remainingD).toBeCloseTo(0, 1);
 
-    expect(rem2.remainingE).toBeCloseTo(5, 1);
-    expect(rem2.remainingD).toBeCloseTo(100, 0);
+    expect(rem2.remainingE).toBeCloseTo(4, 1);
+    expect(rem2.remainingD).toBeCloseTo(0, 0);
 
     expect(rem3.remainingE).toBeCloseTo(3, 1);
     expect(rem3.remainingD).toBeCloseTo(600, 0);


### PR DESCRIPTION
## Problem
Bei mehreren Tabs mit einem Mehrbedarf-Tab (IST > SOLL) wurde der Mehrbedarf **zweimal** angezeigt: einmal im Ursprungs-Tab (Lücke blieb offen) und einmal im Spender-Tab (remaining per `+ entzogen` aufgebläht).

## Root Cause
Regel-7-Formel in `getTabRemaining()` / `isTabDone()` addierte dem Spender `entzogen` zu, zog aber beim Mehrbedarf-Tab die bereits gedeckte Lücke `netted` **nicht** ab. Da `Σ entzogen === Σ netted`, wurde die gedeckte Menge doppelt gezählt.

## Fix
```
remaining = max(0, basis − used + entzogen − netted)
```
`computeAllCarryovers` unangetastet (nur die abgeleitete Formel). Damit gilt wieder Materialerhaltung: `Σ remaining = Σ basis − Σ used`.

Beispiel (3 Tabs, T2 Mehrbedarf 1 E via T3 gedeckt): T1/T2/T3 vorher `0/5/3 = 8`, nachher `0/4/3 = 7` (= Σ basis − Σ used).

## Tests
- 906 grün (`pnpm test`), `pnpm lint` clean.
- Neu: `tests/101-carryover-conservation.test.js` — Aggregat-Wächter über 400 Szenarien + 3-Tab-Beispiel.
- Bestehende Pins angepasst (Empfänger-Tabs: Lücke gedeckt → remaining 0 / done; Spender unverändert).

## ⚠️ Follow-up vor Release
`public/sw.js` `CACHE_VERSION` muss manuell gebumpt werden (AGENTS §6 — SW braucht Human-Review), sonst bekommen Nutzer die alte `calculations.js` aus dem Service-Worker-Cache.