### PR TITLE
feat(#236): redesign reset modal + netting UI

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1280,3 +1280,113 @@ font-size: 0.75rem;
         scroll-behavior: auto !important;
       }
     }
+
+    /* ===== Reset confirmation modal (Issue #236) =====
+       shown as a centered modal via the .open class, same as the dashboard
+       sheet pattern. See public/js/ui-handlers.js for openResetModal(). */
+
+    /* Small footer link-style buttons (used by "Daten zurücksetzen") */
+    .link-btn {
+      background: none;
+      border: none;
+      color: var(--color-text-hint);
+      font-size: 0.82rem;
+      font-weight: 600;
+      padding: 10px 14px;
+      border-radius: 10px;
+      transition: background 0.15s ease, color 0.15s ease;
+    }
+    .link-btn:hover {
+      background: var(--color-bg-hover);
+      color: var(--color-text-label-strong);
+    }
+    .footer-actions {
+      display: flex;
+      justify-content: center;
+      margin-top: -8px;
+      margin-bottom: 8px;
+    }
+    .link-btn-danger:hover {
+      color: var(--color-danger);
+      background: rgba(213, 57, 47, 0.08);
+    }
+
+    /* Focus ring for keyboard navigation (Accessibility) */
+    .btn:focus-visible, .btn-add:focus-visible, .btn-danger:focus-visible,
+    .toggle-btn:focus-visible, .tab-btn:focus-visible, .link-btn:focus-visible,
+    input:focus-visible, .drill-prio-btn:focus-visible, .drill-done-btn:focus-visible,
+    .tab-close:focus-visible, .theme-toggle:focus-visible, .dashboard-close:focus-visible {
+      outline: 2.5px solid var(--color-primary);
+      outline-offset: 2px;
+    }
+
+    /* Reset modal: hidden by default, shown via .open class */
+    .reset-overlay {
+      display: none;
+      position: fixed;
+      inset: 0;
+      background: rgba(10, 16, 6, 0.45);
+      z-index: 200;
+      animation: fadeIn 0.18s ease;
+    }
+    .reset-overlay.open {
+      display: block;
+    }
+    .reset-modal {
+      display: none;
+      position: fixed;
+      left: 50%;
+      top: 50%;
+      transform: translate(-50%, -50%);
+      width: min(92vw, 400px);
+      background: var(--color-card-bg);
+      border-radius: 18px;
+      padding: 24px 22px;
+      z-index: 201;
+      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.35);
+    }
+    .reset-modal.open {
+      display: block;
+      animation: popIn 0.22s ease;
+    }
+    @keyframes popIn {
+      from { opacity: 0; transform: translate(-50%, -50%) scale(0.94); }
+      to   { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+    }
+    @keyframes fadeIn {
+      from { opacity: 0; }
+      to   { opacity: 1; }
+    }
+    .reset-modal-header h2 {
+      font-size: 1.15rem;
+      font-weight: 800;
+      color: var(--color-primary-dark);
+      margin-bottom: 10px;
+    }
+    .reset-modal-desc {
+      font-size: 0.92rem;
+      color: var(--color-text-label);
+      line-height: 1.5;
+      margin-bottom: 20px;
+    }
+    .reset-modal-actions {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+    /* btn-secondary: secondary action style for "Aktuellen Tab zurücksetzen" */
+    .btn-secondary {
+      background: var(--color-primary-active);
+    }
+    .btn-secondary:active {
+      filter: brightness(0.92);
+      transform: scale(0.98);
+    }
+    .btn-cancel {
+      background: var(--color-bg-soft);
+      color: var(--color-text-strong);
+    }
+    .btn-cancel:active {
+      filter: brightness(0.96);
+      transform: scale(0.98);
+    }

--- a/public/index.html
+++ b/public/index.html
@@ -127,11 +127,11 @@
       <div id="r_drill_section" style="display:none">
         <div class="drill-separator"></div>
         <div class="result-row">
-          <span class="label">🔧 Eingefüllt</span>
+          <span class="label">Einheiten eingefüllt</span>
           <span class="value small" id="r_drill_e_used">—</span>
         </div>
         <div class="result-row" id="r_drill_e_rem_row">
-          <span class="label">Verbleibend</span>
+          <span class="label">Einheiten verbleibend</span>
           <span class="value small" id="r_drill_e_rem">—</span>
         </div>
         <div class="result-row" id="r_drill_d_used_row" style="display:none">
@@ -260,6 +260,9 @@
   <script src="js/render-dashboard.js"></script>
   <script src="js/main.js"></script>
   <div class="version-footer" id="version_footer"></div>
+  <div class="footer-actions">
+    <button class="link-btn link-btn-danger" onclick="openResetModal()">🗑️ Daten zurücksetzen</button>
+  </div>
   <!-- Dashboard overlay + sheet -->
   <div class="dashboard-overlay" id="dashboard_overlay" onclick="closeDashboard()"></div>
   <div class="dashboard-sheet" id="dashboard_sheet" role="dialog" aria-modal="true" aria-label="Dashboard — Alle Tabs Übersicht">
@@ -268,6 +271,21 @@
       <button class="dashboard-close" onclick="closeDashboard()" aria-label="Schließen">✕</button>
     </div>
     <div class="dashboard-content" id="dashboard_content"></div>
+  </div>
+  <!-- Reset Confirmation Modal (Issue #236) -->
+  <div class="reset-overlay" id="reset_overlay" onclick="_onOverlayClick(event)"></div>
+  <div class="reset-modal" id="reset_modal" role="dialog" aria-modal="true" aria-labelledby="reset_modal_title" aria-describedby="reset_modal_desc">
+    <div class="reset-modal-header">
+      <h2 id="reset_modal_title">Zurücksetzen</h2>
+    </div>
+    <p class="reset-modal-desc" id="reset_modal_desc">
+      Was möchtest du zurücksetzen? Diese Aktion lässt sich nicht rückgängig machen.
+    </p>
+    <div class="reset-modal-actions">
+      <button class="btn btn-secondary" id="reset_modal_tab" onclick="_onResetTab()">Aktuellen Tab zurücksetzen</button>
+      <button class="btn btn-danger" id="reset_modal_confirm_all" onclick="_onResetAll()">Alle Daten löschen</button>
+      <button class="btn btn-cancel" id="reset_modal_cancel" onclick="_onCancel()">Abbrechen</button>
+    </div>
   </div>
 </body>
 </html>

--- a/public/js/render-results.js
+++ b/public/js/render-results.js
@@ -145,6 +145,74 @@
           }
         }
       }
+
+      // Issue (User-Feedback 2026-07-11): Cross-Tab-Netting (Senken-Modell)
+      // war bisher unsichtbar — ein Tab mit Mehrbedarf zeigte "verbleibend: 0",
+      // aber nirgends stand, DASS und WOHIN dieser Mehrbedarf wandert. Und die
+      // Senke (der Tab, der den Mehrbedarf/die Ersparnis anderer Tabs
+      // übernimmt) bekam plötzlich einen höheren/niedrigeren "verbleibend"-Wert
+      // ohne Erklärung. Diese beiden Hinweise machen die Verrechnung
+      // nachvollziehbar, ohne die Rechenlogik selbst zu ändern.
+      var netHint = document.getElementById('r_net_hint');
+      if (!netHint) {
+        netHint = document.createElement('div');
+        netHint.id = 'r_net_hint';
+        netHint.style.cssText = 'font-size:0.85rem;padding:4px 0;';
+        if (carryoverHint && carryoverHint.parentNode) {
+          carryoverHint.parentNode.insertBefore(netHint, carryoverHint.nextSibling);
+        }
+      }
+      if (netHint) {
+        while (netHint.firstChild) netHint.removeChild(netHint.firstChild);
+        netHint.style.display = 'none';
+        var allCarry = AppGlobals.computeAllCarryovers();
+        var sinkIdx = -1;
+        for (var ci = 0; ci < allCarry.length; ci++) {
+          if (allCarry[ci].isSink) { sinkIdx = ci; break; }
+        }
+        var activeIdxForNet = AppGlobals.state.activeReiter || 0;
+        var coForNet = allCarry[activeIdxForNet] || AppGlobals.getCarryover(activeIdxForNet);
+        var hasOwnOverage = (r.istHektar > 0 && r.hektar > 0)
+          && (AppGlobals.getTabIstEinheiten(r) - AppGlobals.getTabTotalEinheiten(r) > 0.05
+              || (r.istHektar - r.hektar) * (r.duenger || 0) > 0.05);
+        if (!coForNet.isSink && hasOwnOverage && sinkIdx !== -1 && sinkIdx !== activeIdxForNet) {
+          // Dieser Tab hat selbst Mehrbedarf, ist aber nicht die Senke —
+          // sein Mehrbedarf wird unsichtbar auf einen anderen Tab (die
+          // Senke) verrechnet. Zeige, welcher das ist.
+          var sinkTab = AppGlobals.state.reiter[sinkIdx];
+          var sinkName = (sinkTab && sinkTab.name) || ('Tab ' + (sinkIdx + 1));
+          var noteDiv = document.createElement('div');
+          noteDiv.className = 'r-carryover-row r-carryover-carryover';
+          noteDiv.textContent = '↳ wird über den Tab-Ausgleich von „' + sinkName + '\u201c gedeckt';
+          netHint.appendChild(noteDiv);
+          netHint.style.display = 'block';
+        } else if (coForNet.isSink && (Math.abs(coForNet.sinkAdjustedE) > 0.05 || Math.abs(coForNet.sinkAdjustedD) > 0.05)) {
+          // Dieser Tab IST die Senke: er übernimmt Mehrbedarf/Ersparnis aus
+          // anderen Tabs in sein eigenes "verbleibend". Zeige wie viel.
+          var label2 = document.createElement('div');
+          label2.className = 'r-carryover-section-label';
+          label2.textContent = 'Ausgleich mit anderen Tabs';
+          netHint.appendChild(label2);
+          var addParts = [], subParts = [];
+          if (coForNet.sinkAdjustedE > 0.05) addParts.push(AppGlobals.fmt(coForNet.sinkAdjustedE) + ' Einheiten Saatgut');
+          else if (coForNet.sinkAdjustedE < -0.05) subParts.push(AppGlobals.fmt(-coForNet.sinkAdjustedE) + ' Einheiten Saatgut');
+          if (coForNet.sinkAdjustedD > 0.05) addParts.push(Math.round(coForNet.sinkAdjustedD).toLocaleString('de-DE') + ' kg Dünger');
+          else if (coForNet.sinkAdjustedD < -0.05) subParts.push(Math.round(-coForNet.sinkAdjustedD).toLocaleString('de-DE') + ' kg Dünger');
+          if (addParts.length) {
+            var addDiv = document.createElement('div');
+            addDiv.className = 'r-carryover-row r-carryover-excess';
+            addDiv.textContent = '+ Mehrbedarf von anderen Tabs übernommen: ' + addParts.join(', ');
+            netHint.appendChild(addDiv);
+          }
+          if (subParts.length) {
+            var subDiv = document.createElement('div');
+            subDiv.className = 'r-carryover-row r-carryover-savings';
+            subDiv.textContent = '− Ersparnis von anderen Tabs übernommen: ' + subParts.join(', ');
+            netHint.appendChild(subDiv);
+          }
+          netHint.style.display = 'block';
+        }
+      }
     }
 
     // --- Render: Results (Hauptergebnis) ---
@@ -224,11 +292,14 @@
       var dUsedEl = document.getElementById('r_drill_d_used');
       if (dUsedEl) dUsedEl.textContent = usedD > 0 ? usedD.toLocaleString('de-DE') + ' kg' : '—';
       var dRemEl = document.getElementById('r_drill_d_rem');
-      if (dRemEl) dRemEl.textContent = remD > 0 ? remD.toLocaleString('de-DE') + ' kg' : '—';
+      // Issue: "Dünger verbleibend" muss auch bei 0 kg sichtbar sein, sobald
+      // überhaupt Dünger eingefüllt wurde — sonst verschwindet die Zeile
+      // genau dann, wenn der Tank aufgebraucht ist (irreführend).
+      if (dRemEl) dRemEl.textContent = usedD > 0 ? Math.round(remD).toLocaleString('de-DE') + ' kg' : '—';
       var dUsedRow = document.getElementById('r_drill_d_used_row');
       if (dUsedRow) dUsedRow.style.display = usedD > 0 ? '' : 'none';
       var dRemRow = document.getElementById('r_drill_d_rem_row');
-      if (dRemRow) dRemRow.style.display = remD > 0 ? '' : 'none';
+      if (dRemRow) dRemRow.style.display = usedD > 0 ? '' : 'none';
       // Iterate in chronological order — matches renderDrillLog and the
       // original f7f7e8d behaviour (see 09-blind-spots "drill entry has #number span").
       r.entries.forEach(function(entry, actualIdx) {

--- a/public/js/ui-handlers.js
+++ b/public/js/ui-handlers.js
@@ -6,6 +6,45 @@
 // Keine render*-Aufrufe direkt in diesen Funktionen (außer wo sofort nötig).
 // ============================================================================
 
+    // Zentrale DOM-ID-Registry (Issue #281). IDs aus resetAll() und
+    // resetActiveTab() werden hier gebündelt, damit die Reset-Funktionen
+    // nicht mit verstreuten String-Literals arbeiten. Helper `_resetInput`
+    // und `_resetSummary` arbeiten auf dieser Konstante.
+    var DOM_IDS = {
+      hektar: 'hektar',
+      istHektar: 'ist_hektar',
+      koerner: 'koerner',
+      duenger: 'duenger',
+      errHektar: 'err_hektar',
+      errKoerner: 'err_koerner',
+      results: 'results',
+      drillSection: 'drill_section',
+      drillOverflowWarn: 'drill_overflow_warn',
+      fahrgassenToggle: 'fahrgassen_toggle',
+      fahrgassenSettings: 'fahrgassen_settings',
+      fahrgassenBreite: 'fahrgassen_breite',
+      fahrgassenSaved: 'fahrgassen_saved',
+      einheitGroesseToggle: 'einheit_groesse_toggle',
+      einheitGroesseSettings: 'einheit_groesse_settings',
+      einheitGroesseSaved: 'einheit_groesse_saved',
+      koernerProEinheit: 'koerner_pro_einheit',
+      drillSummary: [
+        'ds_saat_total', 'ds_saat_used', 'ds_saat_remaining',
+        'ds_duenger_total', 'ds_duenger_used', 'ds_duenger_remaining',
+        'ds_total_summary'
+      ]
+    };
+
+    // Helper: Input-Feld leeren + dataset.prev/cleaned zurücksetzen.
+    // Wird von resetAll() und resetActiveTab() gemeinsam genutzt.
+    function _resetInput(id) {
+      var el = document.getElementById(id);
+      if (!el) return;
+      el.value = '';
+      el.dataset.prev = '';
+      el.dataset.cleaned = '';
+    }
+
     // --- Tab-Verwaltung ---
 
     function addReiter() {
@@ -175,6 +214,138 @@
         document.getElementById('koerner_pro_einheit').style.borderColor = '#c00';
       }
       AppGlobals.appEmit('SETTINGS_CHANGED', { setting: 'koernerProEinheit' });
+    }
+
+    // --- Reset ---
+
+    function resetActiveTab() {
+      var active = AppGlobals.state.activeReiter;
+      AppGlobals.state.reiter[active] = {
+        name: AppGlobals.state.reiter[active].name,
+        hektar: 0, istHektar: 0, koerner: 0, duenger: 0,
+        entries: [],
+        fahrgassenEnabled: AppGlobals.state.fahrgassenEnabled,
+        fahrgassenBreite: AppGlobals.state.fahrgassenBreite
+      };
+      AppGlobals.state.drillPriorities = {};
+      // Clear drill summary values (Issue #281: IDs aus DOM_IDS)
+      for (var si = 0; si < DOM_IDS.drillSummary.length; si++) {
+        var sEl = document.getElementById(DOM_IDS.drillSummary[si]);
+        if (sEl) sEl.textContent = '';
+      }
+      // Hide drill_section after reset
+      var ds = document.getElementById(DOM_IDS.drillSection);
+      if (ds) ds.style.display = 'none';
+      var eh = document.getElementById(DOM_IDS.errHektar);
+      if (eh) eh.textContent = '';
+      var ek = document.getElementById(DOM_IDS.errKoerner);
+      if (ek) ek.textContent = '';
+      var he = document.getElementById(DOM_IDS.hektar);
+      if (he) he.style.borderColor = '';
+      var ke = document.getElementById(DOM_IDS.koerner);
+      if (ke) ke.style.borderColor = '';
+      var re = document.getElementById(DOM_IDS.results);
+      if (re) re.style.display = 'none';
+      // Clear inputs via _resetInput helper
+      _resetInput(DOM_IDS.hektar);
+      _resetInput(DOM_IDS.istHektar);
+      _resetInput(DOM_IDS.koerner);
+      _resetInput(DOM_IDS.duenger);
+      AppGlobals.appEmit('TAB_RESET', { tabIdx: active });
+    }
+
+    function resetAll() {
+      AppGlobals.state = {
+        reiter: [{ name: 'Tab 1', hektar: 0, istHektar: 0, koerner: 0, duenger: 0, entries: [] }],
+        activeReiter: 0,
+        fahrgassenEnabled: false,
+        fahrgassenBreite: 0,
+        einheitGroesseEnabled: false,
+        koernerProEinheit: 50000,
+        machineLog: []
+      };
+      // Input- und Fehlerfelder zurücksetzen
+      _resetInput(DOM_IDS.hektar);
+      _resetInput(DOM_IDS.istHektar);
+      _resetInput(DOM_IDS.koerner);
+      _resetInput(DOM_IDS.duenger);
+      var errH = document.getElementById(DOM_IDS.errHektar);
+      if (errH) errH.textContent = '';
+      var errK = document.getElementById(DOM_IDS.errKoerner);
+      if (errK) errK.textContent = '';
+      var he2 = document.getElementById(DOM_IDS.hektar);
+      if (he2) he2.style.borderColor = '';
+      var ke2 = document.getElementById(DOM_IDS.koerner);
+      if (ke2) ke2.style.borderColor = '';
+      var res = document.getElementById(DOM_IDS.results);
+      if (res) res.style.display = 'none';
+      var ds = document.getElementById(DOM_IDS.drillSection);
+      if (ds) ds.style.display = 'none';
+      // Fahrgassen-Toggle deaktivieren
+      var fgBtn = document.getElementById(DOM_IDS.fahrgassenToggle);
+      if (fgBtn) {
+        fgBtn.classList.remove('active');
+        fgBtn.setAttribute('aria-pressed', 'false');
+      }
+      var fgSet = document.getElementById(DOM_IDS.fahrgassenSettings);
+      if (fgSet) fgSet.classList.remove('open');
+      var fgBr = document.getElementById(DOM_IDS.fahrgassenBreite);
+      if (fgBr) fgBr.value = '';
+      var fgSv = document.getElementById(DOM_IDS.fahrgassenSaved);
+      if (fgSv) fgSv.textContent = '';
+      // Einheit-Groesse-Toggle deaktivieren
+      var egBtn = document.getElementById(DOM_IDS.einheitGroesseToggle);
+      if (egBtn) {
+        egBtn.classList.remove('active');
+        egBtn.setAttribute('aria-pressed', 'false');
+      }
+      var egSet = document.getElementById(DOM_IDS.einheitGroesseSettings);
+      if (egSet) egSet.classList.remove('open');
+      var kp = document.getElementById(DOM_IDS.koernerProEinheit);
+      if (kp) kp.value = '';
+      var egSv = document.getElementById(DOM_IDS.einheitGroesseSaved);
+      if (egSv) egSv.textContent = '';
+      AppGlobals.state.drillPriorities = {};
+      AppGlobals.renderTabs();
+      AppGlobals.saveState();
+    }
+
+    // --- Reset-Modal (Issue #236) ---
+    // Öffnet/schließt das Bestätigungs-Dialogfenster für Reset-Aktionen.
+    // Zeigt/versteckt Overlay + Modal über die 'open'-Klasse (siehe styles.css).
+    function openResetModal() {
+      var overlay = document.getElementById('reset_overlay');
+      var modal = document.getElementById('reset_modal');
+      if (overlay) overlay.classList.add('open');
+      if (modal) modal.classList.add('open');
+    }
+
+    function closeResetModal() {
+      var overlay = document.getElementById('reset_overlay');
+      var modal = document.getElementById('reset_modal');
+      if (overlay) overlay.classList.remove('open');
+      if (modal) modal.classList.remove('open');
+    }
+
+    function _onOverlayClick(event) {
+      // Nur schließen wenn direkt auf das Overlay geklickt wurde (nicht auf ein Kind-Element).
+      if (event && event.target && event.target.id === 'reset_overlay') {
+        closeResetModal();
+      }
+    }
+
+    function _onResetTab() {
+      resetActiveTab();
+      closeResetModal();
+    }
+
+    function _onResetAll() {
+      resetAll();
+      closeResetModal();
+    }
+
+    function _onCancel() {
+      closeResetModal();
     }
 
     // --- Drill Protocol ---
@@ -717,6 +888,8 @@
 
 // Register exposed globals on AppGlobals (ADR-001 Schritt 3, Issue #278).
 Object.assign(window.AppGlobals, {
+  DOM_IDS: DOM_IDS,
+  _resetInput: _resetInput,
   addReiter: addReiter,
   removeReiter: removeReiter,
   switchReiter: switchReiter,
@@ -726,6 +899,14 @@ Object.assign(window.AppGlobals, {
   fahrgassenUpdate: fahrgassenUpdate,
   einheitGroesseToggle: einheitGroesseToggle,
   einheitGroesseUpdate: einheitGroesseUpdate,
+  resetActiveTab: resetActiveTab,
+  resetAll: resetAll,
+  openResetModal: openResetModal,
+  closeResetModal: closeResetModal,
+  _onOverlayClick: _onOverlayClick,
+  _onResetTab: _onResetTab,
+  _onResetAll: _onResetAll,
+  _onCancel: _onCancel,
   _parseDrillInputs: _parseDrillInputs,
   _resolvePerTabDistribution: _resolvePerTabDistribution,
   _buildDrillEntry: _buildDrillEntry,

--- a/public/js/ui-handlers.js
+++ b/public/js/ui-handlers.js
@@ -255,14 +255,19 @@
     }
 
     function resetAll() {
+      // Preserve UI-prefs that "Daten zurücksetzen" should NOT wipe.
+      var keepIosHint = AppGlobals.state.iosInstallHintShown;
       AppGlobals.state = {
-        reiter: [{ name: 'Tab 1', hektar: 0, istHektar: 0, koerner: 0, duenger: 0, entries: [] }],
+        reiter: [{ name: 'Tab 1', hektar: 0, istHektar: 0, koerner: 0, duenger: 0, entries: [], done: false, fahrgassenEnabled: false, fahrgassenBreite: 0 }],
         activeReiter: 0,
+        activeView: null,
         fahrgassenEnabled: false,
         fahrgassenBreite: 0,
         einheitGroesseEnabled: false,
         koernerProEinheit: 50000,
-        machineLog: []
+        machineLog: [],
+        drillPriorities: {},
+        iosInstallHintShown: keepIosHint
       };
       // Input- und Fehlerfelder zurücksetzen
       _resetInput(DOM_IDS.hektar);

--- a/public/js/ui-handlers.js
+++ b/public/js/ui-handlers.js
@@ -224,6 +224,7 @@
         name: AppGlobals.state.reiter[active].name,
         hektar: 0, istHektar: 0, koerner: 0, duenger: 0,
         entries: [],
+        done: false,
         fahrgassenEnabled: AppGlobals.state.fahrgassenEnabled,
         fahrgassenBreite: AppGlobals.state.fahrgassenBreite
       };

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // ⚠️ CACHE_VERSION muss bei jedem Release manuell gebumpet werden!
 // Bei Vergessen bekommen Nutzer die alte Version aus dem Cache.
 // alternativa: Build-Script das Hash/Zeitstempel injiziert.
-const CACHE_VERSION = 'agrar-rechner-v42';
+const CACHE_VERSION = 'agrar-rechner-v43';
 const STATIC_ASSETS = [
     '/',
     '/index.html',

--- a/tests/08-reset-init-sync.test.js
+++ b/tests/08-reset-init-sync.test.js
@@ -249,3 +249,56 @@ describe('syncStateFromInputs / syncInputsFromState', () => {
     expect(w.getActiveReiter()).toBe(w.state.reiter[0]);
   });
 });
+
+
+describe('resetActiveTab()', () => {
+  let w, doc;
+
+  beforeEach(() => {
+    const { window } = createDom();
+    w = window;
+    doc = w.document;
+    // Two tabs, both with data + a drill entry on tab 0 (active)
+    w.addReiter();                          // tab 1
+    w.switchReiter(0);                      // active = tab 0
+    doc.getElementById('hektar').value = '10';
+    doc.getElementById('koerner').value = '90000';
+    doc.getElementById('duenger').value = '150';
+    w.syncStateFromInputs();
+    doc.getElementById('drill_einheit').value = '2';
+    doc.getElementById('drill_duenger').value = '200';
+    w.drillAdd();
+    // Put data on tab 1 too
+    w.switchReiter(1);
+    doc.getElementById('hektar').value = '5';
+    doc.getElementById('koerner').value = '80000';
+    w.syncStateFromInputs();
+    w.switchReiter(0);                      // back to tab 0
+  });
+
+  it('clears the active tab inputs', () => {
+    w.resetActiveTab();
+    expect(doc.getElementById('hektar').value).toBe('');
+    expect(doc.getElementById('koerner').value).toBe('');
+  });
+
+  it('clears the active tab state (entries + fields)', () => {
+    expect(w.state.reiter[0].entries.length).toBe(1);
+    w.resetActiveTab();
+    expect(w.state.reiter[0].entries).toEqual([]);
+    expect(w.state.reiter[0].hektar).toBe(0);
+    expect(w.state.reiter[0].koerner).toBe(0);
+  });
+
+  it('leaves other tabs untouched', () => {
+    w.resetActiveTab();
+    expect(w.state.reiter[1].hektar).toBe(5);
+    expect(w.state.reiter[1].koerner).toBe(80000);
+    expect(w.state.reiter.length).toBe(2);
+  });
+
+  it('hides results section', () => {
+    w.resetActiveTab();
+    expect(doc.getElementById('results').style.display).toBe('none');
+  });
+});

--- a/tests/08-reset-init-sync.test.js
+++ b/tests/08-reset-init-sync.test.js
@@ -288,6 +288,7 @@ describe('resetActiveTab()', () => {
     expect(w.state.reiter[0].entries).toEqual([]);
     expect(w.state.reiter[0].hektar).toBe(0);
     expect(w.state.reiter[0].koerner).toBe(0);
+    expect(w.state.reiter[0].done).toBe(false);
   });
 
   it('leaves other tabs untouched', () => {

--- a/tests/08-reset-init-sync.test.js
+++ b/tests/08-reset-init-sync.test.js
@@ -1,0 +1,251 @@
+/**
+ * Tests for resetAll() and initUI()
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createDom } from './helpers.js';
+
+describe('resetAll()', () => {
+  let w, doc;
+
+  beforeEach(() => {
+    const { window } = createDom();
+    w = window;
+    doc = w.document;
+
+    // Setup: read DOM values into state, then render.
+    // (Replaces legacy w.berechne() removed by PR #388; the reactive
+    // pipeline (syncStateFromInputs + renderResults) replaces it.)
+    doc.getElementById('hektar').value = '10';
+    doc.getElementById('koerner').value = '90000';
+    doc.getElementById('duenger').value = '150';
+    w.syncStateFromInputs();
+    w.renderResults();
+
+    doc.getElementById('drill_einheit').value = '2';
+    doc.getElementById('drill_duenger').value = '200';
+    w.drillAdd();
+
+    // Add fahrgassen
+    w.fahrgassenToggle();
+    doc.getElementById('fahrgassen_breite').value = '24';
+    w.fahrgassenUpdate();
+  });
+
+  it('resets all input fields', () => {
+    w.resetAll();
+    expect(doc.getElementById('hektar').value).toBe('');
+    expect(doc.getElementById('koerner').value).toBe('');
+    expect(doc.getElementById('duenger').value).toBe('');
+  });
+
+  it('clears error messages', () => {
+    doc.getElementById('err_hektar').textContent = 'Some error';
+    w.resetAll();
+    expect(doc.getElementById('err_hektar').textContent).toBe('');
+    expect(doc.getElementById('err_koerner').textContent).toBe('');
+  });
+
+  it('clears border colors', () => {
+    doc.getElementById('hektar').style.borderColor = '#d32f2f';
+    w.resetAll();
+    expect(doc.getElementById('hektar').style.borderColor).toBe('');
+    expect(doc.getElementById('koerner').style.borderColor).toBe('');
+  });
+
+  it('hides results section', () => {
+    w.resetAll();
+    expect(doc.getElementById('results').style.display).toBe('none');
+  });
+
+  it('hides drill section', () => {
+    w.resetAll();
+    expect(doc.getElementById('drill_section').style.display).toBe('none');
+  });
+
+  it('resets fahrgassen toggle', () => {
+    w.resetAll();
+    expect(w.state.fahrgassenEnabled).toBe(false);
+    expect(doc.getElementById('fahrgassen_toggle').classList.contains('active')).toBe(false);
+    expect(doc.getElementById('fahrgassen_settings').classList.contains('open')).toBe(false);
+  });
+
+  it('clears fahrgassen breite input', () => {
+    w.resetAll();
+    expect(doc.getElementById('fahrgassen_breite').value).toBe('');
+    expect(doc.getElementById('fahrgassen_saved').textContent).toBe('');
+  });
+
+  it('resets state to default', () => {
+    w.resetAll();
+    expect(w.state.reiter.length).toBe(1);
+    expect(w.state.activeReiter).toBe(0);
+    expect(w.state.fahrgassenEnabled).toBe(false);
+    expect(w.state.fahrgassenBreite).toBe(0);
+    expect(w.state.reiter[0].hektar).toBe(0);
+    expect(w.state.reiter[0].koerner).toBe(0);
+    expect(w.state.reiter[0].duenger).toBe(0);
+    expect(w.state.reiter[0].entries).toEqual([]);
+  });
+
+  it('clears drill entries', () => {
+    expect(w.getActiveReiter().entries.length).toBe(1);
+    w.resetAll();
+    expect(w.getActiveReiter().entries.length).toBe(0);
+  });
+
+  it('removes extra tabs', () => {
+    w.addReiter();
+    w.addReiter();
+    expect(w.state.reiter.length).toBe(3);
+    w.resetAll();
+    expect(w.state.reiter.length).toBe(1);
+  });
+});
+
+describe('initUI()', () => {
+  let w, doc, store;
+
+  beforeEach(() => {
+    const result = createDom();
+    w = result.window;
+    doc = w.document;
+    store = result.store;
+  });
+
+  it('loads state from localStorage', () => {
+    store['agrar_rechner'] = JSON.stringify({
+      reiter: [{ name: 'Test', hektar: 15, koerner: 80000, duenger: 200, entries: [] }],
+      activeReiter: 0,
+      fahrgassenEnabled: false,
+      fahrgassenBreite: 0,
+    });
+    w.initUI();
+    expect(doc.getElementById('hektar').value).toBe('15');
+    expect(doc.getElementById('koerner').value).toBe('80000');
+  });
+
+  it('shows results when state has valid data', () => {
+    store['agrar_rechner'] = JSON.stringify({
+      reiter: [{ name: 'Reiter 1', hektar: 10, koerner: 90000, duenger: 150, entries: [] }],
+      activeReiter: 0,
+      fahrgassenEnabled: false,
+      fahrgassenBreite: 0,
+    });
+    w.initUI();
+    expect(doc.getElementById('results').style.display).toBe('block');
+  });
+
+  it('hides results when state has no valid data', () => {
+    store['agrar_rechner'] = JSON.stringify({
+      reiter: [{ name: 'Reiter 1', hektar: 0, koerner: 0, duenger: 0, entries: [] }],
+      activeReiter: 0,
+      fahrgassenEnabled: false,
+      fahrgassenBreite: 0,
+    });
+    w.initUI();
+    expect(doc.getElementById('results').style.display).toBe('none');
+  });
+
+  it('restores fahrgassen state', () => {
+    store['agrar_rechner'] = JSON.stringify({
+      reiter: [{ name: 'Reiter 1', hektar: 10, koerner: 90000, duenger: 150, entries: [] }],
+      activeReiter: 0,
+      fahrgassenEnabled: true,
+      fahrgassenBreite: 24,
+    });
+    w.initUI();
+    expect(doc.getElementById('fahrgassen_toggle').classList.contains('active')).toBe(true);
+    expect(doc.getElementById('fahrgassen_settings').classList.contains('open')).toBe(true);
+    expect(doc.getElementById('fahrgassen_breite').value).toBe('24');
+  });
+
+  it('renders tabs from saved state', () => {
+    store['agrar_rechner'] = JSON.stringify({
+      reiter: [
+        { name: 'Feld A', hektar: 10, koerner: 90000, duenger: 150, entries: [] },
+        { name: 'Feld B', hektar: 5, koerner: 80000, duenger: 100, entries: [] },
+      ],
+      activeReiter: 1,
+      fahrgassenEnabled: false,
+      fahrgassenBreite: 0,
+    });
+    w.initUI();
+    // Tab buttons should appear (2 tabs)
+    const btns = doc.querySelectorAll('.field-tab');
+    expect(btns.length).toBe(2);
+    // Active should be tab 1
+    expect(w.state.activeReiter).toBe(1);
+    // Inputs should show tab 1 data
+    expect(doc.getElementById('hektar').value).toBe('5');
+  });
+
+  it('works with empty localStorage', () => {
+    // No saved state
+    w.initUI();
+    expect(doc.getElementById('hektar').value).toBe('');
+    expect(w.state.reiter.length).toBe(1);
+  });
+});
+
+describe('syncStateFromInputs / syncInputsFromState', () => {
+  let w, doc;
+
+  beforeEach(() => {
+    const { window } = createDom();
+    w = window;
+    doc = w.document;
+  });
+
+  it('syncStateFromInputs reads DOM values into state', () => {
+    doc.getElementById('hektar').value = '12,5';
+    doc.getElementById('koerner').value = '80000';
+    doc.getElementById('duenger').value = '200';
+    w.syncStateFromInputs();
+
+    const r = w.getActiveReiter();
+    expect(r.hektar).toBeCloseTo(12.5);
+    expect(r.koerner).toBe(80000);
+    expect(r.duenger).toBe(200);
+  });
+
+  it('syncStateFromInputs handles empty inputs as 0', () => {
+    doc.getElementById('hektar').value = '';
+    doc.getElementById('koerner').value = '';
+    doc.getElementById('duenger').value = '';
+    w.syncStateFromInputs();
+
+    const r = w.getActiveReiter();
+    expect(r.hektar).toBe(0);
+    expect(r.koerner).toBe(0);
+    expect(r.duenger).toBe(0);
+  });
+
+  it('syncInputsFromState writes state values into DOM', () => {
+    w.state.reiter[0].hektar = 15;
+    w.state.reiter[0].koerner = 85000;
+    w.state.reiter[0].duenger = 175;
+    w.syncInputsFromState();
+
+    expect(doc.getElementById('hektar').value).toBe('15');
+    expect(doc.getElementById('koerner').value).toBe('85000');
+    expect(doc.getElementById('duenger').value).toBe('175');
+  });
+
+  it('syncInputsFromState shows empty for zero values', () => {
+    w.state.reiter[0].hektar = 0;
+    w.state.reiter[0].koerner = 0;
+    w.state.reiter[0].duenger = 0;
+    w.syncInputsFromState();
+
+    expect(doc.getElementById('hektar').value).toBe('');
+    expect(doc.getElementById('koerner').value).toBe('');
+    expect(doc.getElementById('duenger').value).toBe('');
+  });
+
+  it('getActiveReiter returns correct tab', () => {
+    w.addReiter();
+    expect(w.getActiveReiter()).toBe(w.state.reiter[1]);
+    w.switchReiter(0);
+    expect(w.getActiveReiter()).toBe(w.state.reiter[0]);
+  });
+});

--- a/tests/10-regression-session-fixes.test.js
+++ b/tests/10-regression-session-fixes.test.js
@@ -4,7 +4,7 @@
  * These tests verify the exact scenarios that caused each bug,
  * ensuring they cannot re-occur.
  *
- * Fix 1 (5e823cb): entries undefined on reiter → TypeError in berechne()
+ * Fix 1 (5e823cb): entries undefined on reiter → TypeError in the calculation pipeline
  * Fix 2 (741a31b): missing tab-add button → appendChild(null) in renderTabs()
  * Fix 3 (75447f1): renderTabs recycled detached node → NotFoundError
  * Fix 4 (919a999): syncInputsFromState wrote 9.2 instead of 9,2 → parseDE read 92
@@ -25,7 +25,7 @@ describe('Regression: entries undefined on reiter', () => {
     store = result.store;
   });
 
-  it('berechne() works when reiter has no entries field (loaded from old localStorage)', () => {
+  it('calculation works when reiter has no entries field (loaded from old localStorage)', () => {
     // Simulate old localStorage where reiter objects had no entries field
     store['agrar_rechner'] = JSON.stringify({
       reiter: [
@@ -58,7 +58,7 @@ describe('Regression: entries undefined on reiter', () => {
     expect(Array.isArray(r.entries)).toBe(true);
   });
 
-  it('berechne() works with multiple reiters where one has no entries', () => {
+  it('calculation works with multiple reiters where one has no entries', () => {
     store['agrar_rechner'] = JSON.stringify({
       reiter: [
         { name: 'Feld A', hektar: 5, koerner: 80000, duenger: 100, entries: [{ einheit: 1, hektar: 2, duenger: 50, time: '10:00' }] },
@@ -190,7 +190,7 @@ describe('Regression: syncInputsFromState uses DE format', () => {
     expect(doc.getElementById('koerner').value).toBe('90000');
   });
 
-  it('full cycle: berechne → switchReiter → berechne preserves correct decimal', () => {
+  it('full cycle: calculate → switchReiter → calculate preserves correct decimal', () => {
     // Calculate with 9,2 ha
     doc.getElementById('hektar').value = '9,2';
     doc.getElementById('koerner').value = '90000';
@@ -217,7 +217,7 @@ describe('Regression: syncInputsFromState uses DE format', () => {
     expect(doc.getElementById('r_korner').textContent).toBe('828.000');
   });
 
-  it('full cycle: berechne → initUI reload → berechne preserves correct decimal', () => {
+  it('full cycle: calculate → initUI reload → calculate preserves correct decimal', () => {
     // Calculate with 12,5 ha
     doc.getElementById('hektar').value = '12,5';
     doc.getElementById('koerner').value = '80000';


### PR DESCRIPTION
# feat(#236): redesign reset modal + netting UI

## Summary

Selective merge of the redesigned branch into `dev`, preserving PR #388's dead-code cleanup while re-installing the reset modal feature (the JS wiring `openResetModal` + the four `_on*` handlers was the missing piece that caused #388 to mark the modal as "dead code") along with design/UI improvements.

4 commits on top of dev (`b066e72`), totalling **+703 / −10 across 7 files**. All 792 tests pass on 47 files.

| Area | Change |
|---|---|
| Reset feature | `openResetModal` / `resetActiveTab` / `resetAll` + modal HTML + modal CSS re-added, fully wired |
| Footer | "🗑️ Daten zurücksetzen" link button below the version footer |
| Design | Labels "Einheiten eingefüllt / Einheiten verbleibend"; focus-visible outlines |
| Netting UX | Cross-tab netting hints make the Senken-Modell visible to the user |
| Bugfix | "Dünger verbleibend" stays visible at 0 kg once fertilizer was filled |
| Test coverage | `tests/08-reset-init-sync.test.js` re-added, 25 tests (resetAll + resetActiveTab + initUI + syncStateFromInputs / syncInputsFromState) |
| Cache | `sw.js` v42 → v43 |

## Why merge this? Supersedes the silent part of #388

PR #388 (commit `123f773`) removed the reset modal + `resetActiveTab` / `resetAll` with the justification:

> The reset-modal HTML in index.html had no JS that ever opened it — its four onclick handlers were never defined, so any click would throw ReferenceError.

This PR closes that gap. `openResetModal()` and the four handlers (`_onOverlayClick`, `_onResetTab`, `_onResetAll`, `_onCancel`) are defined in `ui-handlers.js` and triggered by the new "🗑️ Daten zurücksetzen" footer button. Both reset functions are reachable from real UI and covered by tests.

## Schema consistency between the two reset functions

Both `resetAll()` and `resetActiveTab()` now produce identical, schema-complete reiter objects:

```js
{
  name, hektar: 0, istHektar: 0, koerner: 0, duenger: 0,
  entries: [], done: false,
  fahrgassenEnabled, fahrgassenBreite
}
```

`resetAll()` also preserves `iosInstallHintShown` so "Daten zurücksetzen" does not un-dismiss the iOS install banner.

## Explicitly preserved (not restored from the redesigned branch)

Per agreement, **PR #388 stays fully in place**:

- `berechne()` remains removed (reactive `onInput*` bindings keep working)
- `_askConfirm()` remains removed
- Carryover pool model `_computeNetCarryoverPools` (Issue #378) — not taken
- `ALLOWED_ENTRY_KEYS` / `ALLOWED_MACHINE_LOG_KEYS` schema validation — not taken
- `drillMachineAdd()` — not taken (its implementation in the upload looked fragile)
- Tests `03-berechne`, `28-berechne-confirm`, `27-dashboard-carryover`, `97-debug-371` — not taken

These can be picked up later as separate follow-up PRs if desired.

## Commits (4)

```
a3e693e  fix(#236): add done:false to resetActiveTab reiter schema (consistency)
83f1055  chore(#236): update stale berechne() references in tests/10 descriptions
4a83bef  fix(#236): complete resetAll state schema + resetActiveTab tests
0dceca4  feat(#236): redesign reset modal + netting UI
```

## Verification

- [x] `pnpm install` clean
- [x] `pnpm lint` passes
- [x] `pnpm test` passes — **47/47 files, 792/792 tests** (~61s)
- [x] `tests/08-reset-init-sync.test.js` alone: **25/25** pass
- [x] `tests/10-regression-session-fixes.test.js`: **17/17** pass (after the stale-`berechne()` cleanup)
- [ ] Manual smoke (recommended before merge): open the deployed `dev` preview, add a tab + drill entries, open the reset modal via "🗑️ Daten zurücksetzen", verify both reset actions work, verify the cross-tab netting hint appears on tabs with own overage.

## Files

```
M  public/css/styles.css                                 +110
M  public/index.html                                       +22   −1
M  public/js/render-results.js                             +75   −1
M  public/js/ui-handlers.js                                +187
M  public/sw.js                                             +1   −1
A  tests/08-reset-init-sync.test.js                       +305   (new)
M  tests/10-regression-session-fixes.test.js                +5   −5
```

## Test plan / checklist for the reviewer

- [ ] Diff vs. dev makes sense (everything in scope, nothing extra)
- [ ] No stray `berechne()` / `_askConfirm()` references in src or tests
- [ ] `index.html` modal markup + `ui-handlers.js` handler names match 1:1
- [ ] `styles.css` covers every selector referenced by the modal / footer
- [ ] `sw.js` v43 is intentional (new release)
