### PR TITLE
chore(#389): bump CACHE_VERSION v43 -> v44

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // ⚠️ CACHE_VERSION muss bei jedem Release manuell gebumpet werden!
 // Bei Vergessen bekommen Nutzer die alte Version aus dem Cache.
 // alternativa: Build-Script das Hash/Zeitstempel injiziert.
-const CACHE_VERSION = 'agrar-rechner-v43';
+const CACHE_VERSION = 'agrar-rechner-v44';
 const STATIC_ASSETS = [
     '/',
     '/index.html',


### PR DESCRIPTION
Auto bump after merge of #389 (redesign reset modal + netting UI). Invalidates service worker cache so users get the new assets.