### PR TITLE
feat(#236): redesign reset modal as card-based options with danger hierarchy

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1338,12 +1338,13 @@ font-size: 0.75rem;
       left: 50%;
       top: 50%;
       transform: translate(-50%, -50%);
-      width: min(92vw, 400px);
+      width: min(92vw, 420px);
       background: var(--color-card-bg);
-      border-radius: 18px;
-      padding: 24px 22px;
+      border-radius: 20px;
+      padding: 26px 22px 18px;
       z-index: 201;
-      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.35);
+      box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4);
+      text-align: center;
     }
     .reset-modal.open {
       display: block;
@@ -1357,24 +1358,137 @@ font-size: 0.75rem;
       from { opacity: 0; }
       to   { opacity: 1; }
     }
-    .reset-modal-header h2 {
-      font-size: 1.15rem;
+    .reset-modal-x {
+      position: absolute;
+      top: 12px;
+      right: 12px;
+      width: 32px;
+      height: 32px;
+      border: none;
+      border-radius: 50%;
+      background: var(--color-bg-soft);
+      color: var(--color-text-muted);
+      font-size: 0.95rem;
+      cursor: pointer;
+      transition: background 0.15s, color 0.15s;
+    }
+    .reset-modal-x:active {
+      background: var(--color-bg-hover);
+      transform: scale(0.92);
+    }
+    .reset-modal-icon {
+      font-size: 2.4rem;
+      line-height: 1;
+      margin-bottom: 8px;
+    }
+    .reset-modal > h2 {
+      font-size: 1.2rem;
       font-weight: 800;
       color: var(--color-primary-dark);
-      margin-bottom: 10px;
+      margin-bottom: 8px;
     }
     .reset-modal-desc {
-      font-size: 0.92rem;
+      font-size: 0.9rem;
       color: var(--color-text-label);
       line-height: 1.5;
-      margin-bottom: 20px;
+      margin: 0 auto 20px;
+      max-width: 320px;
     }
-    .reset-modal-actions {
+    .reset-options {
       display: flex;
       flex-direction: column;
       gap: 10px;
+      margin-bottom: 14px;
     }
-    /* btn-secondary: secondary action style for "Aktuellen Tab zurücksetzen" */
+    /* --- Option cards: clickable rows with icon + title + description --- */
+    .reset-option {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      width: 100%;
+      padding: 14px 14px;
+      border: 2px solid var(--color-border);
+      border-radius: 14px;
+      background: var(--color-bg-soft);
+      text-align: left;
+      cursor: pointer;
+      transition: background 0.16s, border-color 0.16s, transform 0.1s;
+    }
+    .reset-option:active {
+      transform: scale(0.985);
+    }
+    .reset-option-icon {
+      font-size: 1.5rem;
+      line-height: 1;
+      flex-shrink: 0;
+      width: 40px;
+      height: 40px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 10px;
+      background: var(--color-card-bg);
+    }
+    .reset-option-body {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+      min-width: 0;
+    }
+    .reset-option-title {
+      font-size: 1rem;
+      font-weight: 700;
+      color: var(--color-text);
+    }
+    .reset-option-desc {
+      font-size: 0.82rem;
+      color: var(--color-text-muted);
+      line-height: 1.35;
+    }
+    /* Tab reset: neutral / harmless — primary accent on interaction */
+    .reset-option-tab:hover {
+      background: var(--color-bg-hover);
+      border-color: var(--color-primary);
+    }
+    .reset-option-tab .reset-option-icon {
+      background: var(--color-success-soft);
+    }
+    /* All data: destructive — neutral bg, red border + title + red fill on hover */
+    .reset-option-all {
+      background: var(--color-bg-soft);
+      border-color: var(--color-danger-soft);
+    }
+    .reset-option-all:hover {
+      background: var(--color-danger-soft);
+      border-color: var(--color-danger);
+    }
+    .reset-option-all:hover .reset-option-title,
+    .reset-option-all:hover .reset-option-desc {
+      color: var(--color-card-text);
+    }
+    .reset-option-all .reset-option-icon {
+      background: var(--color-danger-soft);
+    }
+    .reset-option-all .reset-option-title {
+      color: var(--color-text-danger);
+    }
+    .reset-modal-cancel {
+      width: 100%;
+      padding: 12px;
+      border: none;
+      border-radius: 10px;
+      background: transparent;
+      color: var(--color-text-muted);
+      font-size: 0.95rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background 0.15s, color 0.15s;
+    }
+    .reset-modal-cancel:active {
+      background: var(--color-bg-soft);
+      color: var(--color-text);
+    }
+    /* btn-secondary / btn-cancel legacy classes retained for back-compat */
     .btn-secondary {
       background: var(--color-primary-active);
     }

--- a/public/index.html
+++ b/public/index.html
@@ -272,20 +272,32 @@
     </div>
     <div class="dashboard-content" id="dashboard_content"></div>
   </div>
-  <!-- Reset Confirmation Modal (Issue #236) -->
+  <!-- Reset Confirmation Modal (Issue #236, redesign v3) -->
   <div class="reset-overlay" id="reset_overlay" onclick="_onOverlayClick(event)"></div>
   <div class="reset-modal" id="reset_modal" role="dialog" aria-modal="true" aria-labelledby="reset_modal_title" aria-describedby="reset_modal_desc">
-    <div class="reset-modal-header">
-      <h2 id="reset_modal_title">Zurücksetzen</h2>
-    </div>
+    <button class="reset-modal-x" id="reset_modal_cancel" onclick="_onCancel()" aria-label="Schließen">✕</button>
+    <div class="reset-modal-icon" aria-hidden="true">⚠️</div>
+    <h2 id="reset_modal_title">Daten zurücksetzen</h2>
     <p class="reset-modal-desc" id="reset_modal_desc">
-      Was möchtest du zurücksetzen? Diese Aktion lässt sich nicht rückgängig machen.
+      Wähle, was zurückgesetzt werden soll. Diese Aktion kann nicht rückgängig gemacht werden.
     </p>
-    <div class="reset-modal-actions">
-      <button class="btn btn-secondary" id="reset_modal_tab" onclick="_onResetTab()">Aktuellen Tab zurücksetzen</button>
-      <button class="btn btn-danger" id="reset_modal_confirm_all" onclick="_onResetAll()">Alle Daten löschen</button>
-      <button class="btn btn-cancel" id="reset_modal_cancel" onclick="_onCancel()">Abbrechen</button>
+    <div class="reset-options">
+      <button class="reset-option reset-option-tab" id="reset_modal_tab" onclick="_onResetTab()">
+        <span class="reset-option-icon" aria-hidden="true">🗂️</span>
+        <span class="reset-option-body">
+          <span class="reset-option-title">Aktuellen Tab</span>
+          <span class="reset-option-desc" id="reset_modal_tab_ctx">Leert Felder &amp; Protokoll dieses Tabs</span>
+        </span>
+      </button>
+      <button class="reset-option reset-option-all" id="reset_modal_confirm_all" onclick="_onResetAll()">
+        <span class="reset-option-icon" aria-hidden="true">🗑️</span>
+        <span class="reset-option-body">
+          <span class="reset-option-title">Alle Daten löschen</span>
+          <span class="reset-option-desc" id="reset_modal_all_ctx">Entfernt alle Tabs &amp; Einstellungen</span>
+        </span>
+      </button>
     </div>
+    <button class="reset-modal-cancel" onclick="_onCancel()">Abbrechen</button>
   </div>
 </body>
 </html>

--- a/public/js/ui-handlers.js
+++ b/public/js/ui-handlers.js
@@ -316,10 +316,38 @@
       AppGlobals.saveState();
     }
 
-    // --- Reset-Modal (Issue #236) ---
+    // --- Reset-Modal (Issue #236, redesign v3) ---
     // Öffnet/schließt das Bestätigungs-Dialogfenster für Reset-Aktionen.
     // Zeigt/versteckt Overlay + Modal über die 'open'-Klasse (siehe styles.css).
+    // Beim Öffnen werden Kontext-Infos (Tab-Name, Anzahl Tabs/Einträge) befüllt,
+    // damit der Nutzer sieht, was genau gelöscht wird.
+    function _countAllEntries() {
+      var n = 0;
+      var reiter = AppGlobals.state.reiter || [];
+      for (var i = 0; i < reiter.length; i++) {
+        var e = reiter[i].entries;
+        if (e) n += e.length;
+      }
+      return n;
+    }
+
+    function _populateResetContext() {
+      var tabCtx = document.getElementById('reset_modal_tab_ctx');
+      if (tabCtx) {
+        var active = AppGlobals.getActiveReiter();
+        var name = active && active.name ? active.name : 'Aktueller Tab';
+        tabCtx.textContent = 'Leert Felder & Protokoll von „' + name + '“';
+      }
+      var allCtx = document.getElementById('reset_modal_all_ctx');
+      if (allCtx) {
+        var tabs = (AppGlobals.state.reiter || []).length;
+        var entries = _countAllEntries();
+        allCtx.textContent = tabs + ' Tab' + (tabs === 1 ? '' : 's') + ' · ' + entries + ' ' + (entries === 1 ? 'Eintrag' : 'Einträge');
+      }
+    }
+
     function openResetModal() {
+      _populateResetContext();
       var overlay = document.getElementById('reset_overlay');
       var modal = document.getElementById('reset_modal');
       if (overlay) overlay.classList.add('open');

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // ⚠️ CACHE_VERSION muss bei jedem Release manuell gebumpet werden!
 // Bei Vergessen bekommen Nutzer die alte Version aus dem Cache.
 // alternativa: Build-Script das Hash/Zeitstempel injiziert.
-const CACHE_VERSION = 'agrar-rechner-v44';
+const CACHE_VERSION = 'agrar-rechner-v45';
 const STATIC_ASSETS = [
     '/',
     '/index.html',


### PR DESCRIPTION
feat(#236): redesign reset modal as card-based options with danger hierarchy

- Replace 3 stacked buttons with two clickable option cards (Tab/Alles)
- Clear danger escalation: tab reset neutral, all-data with red border/title/hover
- Context-aware descriptions: active tab name + total tabs/entries count
- Close X button top-right + header warning icon
- CACHE_VERSION v44 → v45 to invalidate SW cache after UI change

---
**Files changed:**
```
 public/css/styles.css    | 136 +++++++++++++++++++++++++++++++++++++++++++----
 public/index.html        |  30 +++++++----
 public/js/ui-handlers.js |  30 ++++++++++-
 public/sw.js             |   2 +-
 4 files changed, 176 insertions(+), 22 deletions(-)
```

Closes #236
