### PR TITLE
chore: CACHE_VERSION v47 → v48 — invalidate SW cache

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // ⚠️ CACHE_VERSION muss bei jedem Release manuell gebumpet werden!
 // Bei Vergessen bekommen Nutzer die alte Version aus dem Cache.
 // alternativa: Build-Script das Hash/Zeitstempel injiziert.
-const CACHE_VERSION = 'agrar-rechner-v47';
+const CACHE_VERSION = 'agrar-rechner-v48';
 const STATIC_ASSETS = [
     '/',
     '/index.html',


### PR DESCRIPTION
Cache-Version-Bump nach v1.2.0 Redesign-v2 Release. Invalidiert den Service-Worker-Cache, damit User das aktuelle UI ziehen.