### PR TITLE
revert: dev zurück auf CACHE_VERSION v45 / APP_VERSION v1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,3 @@ node_modules/
 
 # test
 coverage/
-
-# pnpm transient artifacts (not part of the repo, regenerated on install)
-.pnpm-approve-builds
-pnpm-workspace.yaml
-pnpm-workspace.yaml.tmp

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -3,32 +3,28 @@
 
     /* ===== CSS Variables (light mode) ===== */
     :root {
-    --color-cream-bg: #efeae0;
-    --color-cream-card: #fbf8f0;
-    --color-cream-hover: #e6e0d2;
-    --color-bg: #efeae0;
-    --color-bg-card: #fbf8f0;
-    --color-bg-hover: #e6e0d2;
-    --color-bg-soft: #f3eee2;
-    --color-bg-success-soft: #d8e3c8;
-    --color-bg-soft-input: #d8e3c8;
-    --color-border: #d6c9a8;
+    --color-bg: #f0f4e8;
+    --color-bg-card: #fafef5;
+    --color-bg-hover: #d0e8b8;
+    --color-bg-soft: #f8faf4;
+    --color-bg-success-soft: #e8f5e9;
+    --color-border: #d0deb8;
     --color-border-dashed: #b8d4a0;
-    --color-border-disabled: #c9c2ae;
-    --color-border-faint: #ddd5bf;
-    --color-border-soft: #e0d8c4;
+    --color-border-disabled: #ccc;
+    --color-border-faint: #eee;
+    --color-border-soft: #e8f0de;
     --color-border-strong: #c8dcc0;
-    --color-card-bg: #fbf8f0;
+    --color-card-bg: white;
     --color-card-text: white;
-    --color-danger: #c0392b;
-    --color-danger-dark: #962d22;
-    --color-danger-soft: #c0392b;
-    --color-danger-bg-soft: #f5e3df;
+    --color-danger: #d32f2f;
+    --color-danger-dark: #b71c1c;
+    --color-danger-soft: #c62828;
+    --color-danger-bg-soft: #fdecec;
     --color-dashboard-done: #ffe066;
     --color-dashboard-open-active: #1e3410;
     --color-dashboard-remaining: #ffd700;
-    --color-divider: #d6cdb1;
-    --color-entry-diff-negative: #c0392b;
+    --color-divider: #c3dfa8;
+    --color-entry-diff-negative: #d32f2f;
     --color-entry-diff-positive: #4a7c23;
     --color-highlight-soft: #a5d6a7;
     --color-info: #1565c0;
@@ -37,26 +33,19 @@
     --color-primary: #4a7c23;
     --color-primary-active: #6b9e45;
     --color-primary-bright: #6aa336;
-    --color-primary-dark: #2d4a1a;
-    --color-primary-darker: #1f3a12;
-    --color-primary-hover: #2d4a1a;
+    --color-primary-dark: #2d5016;
+    --color-primary-hover: #3a6318;
     --color-primary-light: #8bc34a;
-    --color-result-bg: #f3eee2;
-    --color-success-soft: #d8e3c8;
-    --color-sage-input: #d8e3c8;
-    --color-sage-input-focus: #c5d4b0;
-    --color-sage-badge: #b9cca3;
-    --color-sage-progress-bg: #d8e3c8;
-    --color-accent-brown: #b8704a;
-    --color-subtitle-green: #5a7a3a;
+    --color-result-bg: #e8f4dc;
+    --color-success-soft: #e8f4dc;
     --color-text: #1a1a1a;
-    --color-text-danger: #c0392b;
+    --color-text-danger: #c62828;
     --color-text-hint: #616161;
     --color-text-hint-2: #5f6368;
     --color-text-label: #444;
-    --color-text-label-darker: #2a2a2a;
+    --color-text-label-darker: #333;
     --color-text-label-strong: #555;
-    --color-text-muted: #6b6b6b;
+    --color-text-muted: #666;
     --color-text-subtle: #757575;
     --color-text-success: #2e7d32;
     --color-text-success-strong: #3d6b1a;
@@ -64,14 +53,6 @@
     --color-warning-bg: #fff3cd;
     --color-warning-border: #ffc107;
     --color-warning-text: #856404;
-    --font-serif: 'Georgia', 'Times New Roman', 'Garamond', serif;
-    --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-    --shadow-card: 0 2px 8px rgba(0, 0, 0, 0.06);
-    --shadow-soft: 0 1px 3px rgba(0, 0, 0, 0.04);
-    --shadow-nav: 0 -2px 12px rgba(0, 0, 0, 0.06);
-    --radius-card: 18px;
-    --radius-pill: 999px;
-    --radius-button: 14px;
     }
 
     /* ===== CSS Variables (dark mode overrides) ===== */
@@ -85,9 +66,6 @@
     --color-bg-soft: #1e241a;
     --color-bg-soft-input: #1e241a;
     --color-bg-success-soft: #1a2e1a;
-    --color-cream-bg: #1a1f16;
-    --color-cream-card: #252b20;
-    --color-cream-hover: #333d28;
     --color-border: #3a4030;
     --color-border-soft: #3a4030;
     --color-card-bg: #252b20;
@@ -96,7 +74,7 @@
     --color-danger: #ef5350;
     --color-danger-bright: #ef5350;
     --color-danger-dark: #b71c1c;
-    --color-danger-soft: #ef5350;
+    --color-danger-soft: #c62828;
     --color-danger-bg-soft: #3a2424;
     --color-divider: #3a4030;
     --color-entry-diff-negative: #ef5350;
@@ -107,17 +85,11 @@
     --color-primary: #5a9a2a;
     --color-primary-active: #4a7c23;
     --color-primary-bright: #6aa336;
-    --color-primary-dark: #a5d6a7;
+    --color-primary-dark: #8bc34a;
     --color-primary-darker: #5a9a2a;
     --color-primary-hover: #3a6318;
     --color-result-bg: #2a3320;
     --color-summary-muted: #b0b8a8;
-    --color-sage-input: #1e2a18;
-    --color-sage-input-focus: #2a3a20;
-    --color-sage-badge: #2a3a20;
-    --color-sage-progress-bg: #2a3a20;
-    --color-accent-brown: #c97a52;
-    --color-subtitle-green: #8bc34a;
     --color-text: #e0e8d6;
     --color-text-danger: #ef5350;
     --color-text-hint: #9ca896;
@@ -133,10 +105,10 @@
     }
 
     body {
-      font-family: var(--font-sans);
-      background: var(--color-cream-bg);
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: var(--color-bg);
       min-height: 100dvh;
-      padding: max(20px, env(safe-area-inset-top)) 20px max(120px, calc(80px + env(safe-area-inset-bottom)));
+      padding: max(20px, env(safe-area-inset-top)) 20px max(20px, env(safe-area-inset-bottom));
       color: var(--color-text);
       overflow-x: hidden;
     }
@@ -144,154 +116,74 @@
       max-width: 420px;
       margin: 0 auto;
     }
-
-    /* ===== App Header ===== */
+    h1 {
+      text-align: center;
+      color: var(--color-primary-dark);
+      font-size: 1.8rem;
+      margin-bottom: 6px;
+    }
+    .subtitle {
+      text-align: center;
+      color: var(--color-text-muted);
+      font-size: 0.85rem;
+      margin-bottom: 24px;
+    }
     .header-row {
       display: flex;
       justify-content: space-between;
       align-items: flex-start;
       margin-bottom: 16px;
-      gap: 12px;
     }
     .header-titles {
       flex: 1;
-      min-width: 0;
-    }
-    .header-meta {
-      font-size: 0.78rem;
-      color: var(--color-subtitle-green);
-      font-weight: 600;
-      letter-spacing: 0.02em;
-      margin-bottom: 2px;
-      text-align: left;
     }
     .header-titles h1 {
+      margin-bottom: 2px;
+    }
+    .header-titles .subtitle {
       text-align: left;
-      color: var(--color-primary-dark);
-      font-family: var(--font-serif);
-      font-size: 1.85rem;
-      font-weight: 700;
       margin-bottom: 0;
-      line-height: 1.1;
     }
-    .header-actions {
-      display: flex;
-      gap: 8px;
-      align-items: flex-start;
-    }
-    .settings-btn {
-      width: 44px;
-      height: 44px;
-      border-radius: 50%;
-      background: var(--color-cream-card);
-      color: var(--color-primary-dark);
-      border: none;
-      font-size: 1.15rem;
-      cursor: pointer;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      box-shadow: var(--shadow-card);
-      flex-shrink: 0;
-    }
-    .settings-btn:active {
-      transform: scale(0.94);
-    }
-
-    /* ===== Cards (inputs + sections) ===== */
     .card {
-      background: var(--color-cream-card);
-      border-radius: var(--radius-card);
-      padding: 18px;
-      margin-bottom: 14px;
-      box-shadow: var(--shadow-card);
+      background: var(--color-card-bg);
+      border-radius: 16px;
+      padding: 20px;
+      margin-bottom: 16px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.08);
     }
     .card h2 {
       font-size: 1rem;
       color: var(--color-primary-dark);
-      margin-bottom: 14px;
-      padding-bottom: 0;
-      border-bottom: none;
-      font-weight: 600;
-      display: flex;
-      align-items: center;
-      gap: 10px;
-    }
-    .card h2 .section-badge {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      width: 28px;
-      height: 28px;
-      border-radius: 8px;
-      background: var(--color-primary-dark);
-      color: var(--color-card-text);
-      font-family: var(--font-sans);
-      font-weight: 700;
-      font-size: 0.95rem;
-    }
-    .card h2 .section-meta {
-      font-size: 0.85rem;
-      color: var(--color-text-muted);
-      font-weight: 500;
-      margin-left: auto;
+      margin-bottom: 16px;
+      padding-bottom: 8px;
+      border-bottom: 2px solid var(--color-border-soft);
     }
     .field {
-      margin-bottom: 14px;
-    }
-    .field:last-child {
-      margin-bottom: 0;
+      margin-bottom: 16px;
     }
     label {
       display: block;
-      font-size: 0.88rem;
-      font-weight: 500;
-      color: var(--color-text-label);
+      font-size: 0.9rem;
+      font-weight: 600;
+      color: var(--color-text-label-darker);
       margin-bottom: 6px;
     }
-    /* ===== Inputs (sage-green filled) ===== */
-    input[type="text"], input[type="number"], input:not([type]) {
+    input {
       width: 100%;
-      padding: 12px 14px;
-      font-size: 1.1rem;
-      border: none;
-      border-radius: var(--radius-button);
-      background: var(--color-sage-input);
+      padding: 14px 16px;
+      font-size: 1.2rem;
+      border: 2px solid var(--color-border);
+      border-radius: 10px;
+      background: var(--color-bg-card);
       color: var(--color-text);
       outline: none;
-      transition: background 0.15s;
-      font-family: var(--font-sans);
-      font-weight: 500;
+      transition: border-color 0.2s;
     }
     input:focus {
-      background: var(--color-sage-input-focus);
-      box-shadow: 0 0 0 2px var(--color-primary) inset;
+      border-color: var(--color-primary);
     }
     input::placeholder {
       color: var(--color-text-subtle);
-      font-weight: 400;
-    }
-    input[type="text"][disabled],
-    input[type="number"][disabled],
-    input:not([type])[disabled] {
-      opacity: 0.6;
-      cursor: not-allowed;
-    }
-    /* Unit suffix inside input wrapper */
-    .input-wrap {
-      position: relative;
-    }
-    .input-wrap input {
-      padding-right: 60px;
-    }
-    .input-unit {
-      position: absolute;
-      right: 14px;
-      top: 50%;
-      transform: translateY(-50%);
-      color: var(--color-text-muted);
-      font-size: 0.95rem;
-      pointer-events: none;
     }
     .error-msg {
       font-size: 0.8rem;
@@ -299,226 +191,69 @@
       margin-top: 4px;
       min-height: 18px;
     }
-    .unit, .hint-text {
+    .unit {
       font-size: 0.8rem;
       color: var(--color-text-hint);
-      margin-top: 6px;
+      margin-top: 4px;
     }
-    .hint-block {
-      font-size: 0.85rem;
-      color: var(--color-text-muted);
-      line-height: 1.45;
-      margin-top: 10px;
-    }
-    .btn, .btn-add, .btn-danger, .toggle-btn, .tab-btn, .bottom-nav-item {
+    .btn, .btn-add, .btn-danger, .toggle-btn, .tab-btn {
       touch-action: manipulation;
     }
-
-    /* ===== Primary Buttons ===== */
     .btn {
       width: 100%;
-      padding: 14px;
-      font-size: 1rem;
+      padding: 16px;
+      font-size: 1.1rem;
       font-weight: 700;
-      background: var(--color-primary-dark);
-      color: var(--color-card-text);
+      background: var(--color-primary);
+      color: var(--color-ios-banner-text);
       border: none;
-      border-radius: var(--radius-button);
+      border-radius: 12px;
       cursor: pointer;
-      transition: background 0.15s, transform 0.1s;
-      font-family: var(--font-sans);
+      transition: background 0.2s, transform 0.1s;
     }
     .btn:active {
-      background: var(--color-primary-darker);
+      background: var(--color-primary-hover);
       transform: scale(0.98);
-    }
-    .btn-secondary {
-      background: transparent;
-      color: var(--color-primary-dark);
-      border: 1.5px solid var(--color-primary-dark);
-    }
-    .btn-secondary:active {
-      background: var(--color-bg-hover);
-    }
-    .btn-block-big {
-      padding: 16px 18px;
-      font-size: 1.05rem;
-      border-radius: var(--radius-button);
-      width: 100%;
     }
     .btn-danger {
       background: var(--color-danger);
       width: auto;
       padding: 6px 12px;
       font-size: 0.8rem;
-      border-radius: 8px;
+      border-radius: 6px;
       margin-left: 8px;
     }
     .btn-danger:active {
       background: var(--color-danger-dark);
     }
-    .icon-btn {
-      width: 36px;
-      height: 36px;
-      border-radius: 50%;
-      border: 1px solid var(--color-border-soft);
-      background: var(--color-cream-card);
-      color: var(--color-text-muted);
-      cursor: pointer;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 1rem;
-    }
-    .icon-btn:active {
-      background: var(--color-bg-hover);
-    }
-    .icon-btn.success {
-      color: var(--color-primary);
-      border-color: var(--color-primary-light);
-    }
-
-    /* ===== Result card ===== */
     .result {
-      background: var(--color-cream-card);
-      border: none;
+      background: var(--color-result-bg);
+      border: 2px solid var(--color-primary);
     }
-    .result h2 .section-badge { background: var(--color-primary-dark); }
-
-    .result-layout {
-      display: grid;
-      grid-template-columns: auto 1fr;
-      gap: 18px;
-      align-items: center;
-      padding: 8px 0;
-    }
-    .result-ring-chart {
-      width: 110px;
-      height: 110px;
-      position: relative;
-      flex-shrink: 0;
-    }
-    .result-ring-chart svg {
-      width: 100%;
-      height: 100%;
-      transform: rotate(-90deg);
-    }
-    .result-ring-bg {
-      fill: none;
-      stroke: var(--color-sage-progress-bg);
-      stroke-width: 10;
-    }
-    .result-ring-fg {
-      fill: none;
-      stroke: var(--color-primary-dark);
-      stroke-width: 10;
-      stroke-linecap: round;
-      transition: stroke-dashoffset 0.3s ease-out;
-    }
-    .result-ring-center {
-      position: absolute;
-      inset: 0;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      pointer-events: none;
-    }
-    .result-ring-value {
-      font-family: var(--font-serif);
-      font-weight: 700;
-      font-size: 1.75rem;
-      color: var(--color-primary-dark);
-      line-height: 1;
-    }
-    .result-ring-sub {
-      font-size: 0.7rem;
-      color: var(--color-text-muted);
-      text-transform: uppercase;
-      letter-spacing: 0.06em;
-      margin-top: 4px;
-    }
-    .result-side {
-      min-width: 0;
-    }
-    .result-side-title {
-      font-family: var(--font-serif);
-      font-weight: 700;
-      font-size: 1.1rem;
-      color: var(--color-primary-dark);
-      margin-bottom: 4px;
-    }
-    .result-side-sub {
-      font-size: 0.85rem;
-      color: var(--color-text-muted);
-      line-height: 1.35;
-    }
-    .result-side-sub.hidden { display: none; }
-    .result-progress {
-      margin-top: 16px;
-      padding-top: 14px;
-      border-top: 1px solid var(--color-divider);
-    }
-    .result-progress-bar {
-      width: 100%;
-      height: 8px;
-      border-radius: 4px;
-      background: var(--color-sage-progress-bg);
-      overflow: hidden;
-      margin-bottom: 8px;
-    }
-    .result-progress-fill {
-      height: 100%;
-      background: var(--color-primary-dark);
-      border-radius: 4px;
-      transition: width 0.3s ease-out;
-    }
-    .result-progress-legend {
-      display: flex;
-      justify-content: space-between;
-      font-size: 0.85rem;
-    }
-    .result-progress-legend .legend-used {
-      color: var(--color-text-muted);
-    }
-    .result-progress-legend .legend-open {
-      color: var(--color-text);
-      font-weight: 600;
-    }
-    .drill-separator {
-      height: 1px;
-      background: var(--color-divider);
-      margin: 12px 0;
-    }
-
-    /* Hidden result details (carryover, drill section, etc.) — keep IDs intact */
-    .result-details {
-      padding-top: 14px;
-      border-top: 1px solid var(--color-divider);
-      margin-top: 14px;
+    .result h2 {
+      border-bottom-color: var(--color-divider);
     }
     .result-row {
       display: flex;
       justify-content: space-between;
       align-items: center;
-      padding: 8px 0;
+      padding: 12px 0;
       border-bottom: 1px solid var(--color-divider);
-      font-size: 0.92rem;
     }
     .result-row:last-child {
       border-bottom: none;
     }
     .result-row .label {
-      font-size: 0.9rem;
+      font-size: 0.95rem;
       color: var(--color-text-label);
     }
     .result-row .value {
-      font-size: 1.05rem;
+      font-size: 1.3rem;
       font-weight: 700;
       color: var(--color-primary-dark);
     }
     .result-row .value.small {
-      font-size: 0.95rem;
+      font-size: 1rem;
     }
     .result-row.remaining .value {
       color: var(--color-danger);
@@ -533,45 +268,18 @@
       margin-top: 8px;
     }
 
-    /* ===== Two-column stat cards (Körner gesamt / Dünger gesamt) ===== */
-    .stat-row {
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      gap: 12px;
-      margin-bottom: 14px;
+    .drill-separator {
+      height: 1px;
+      background: var(--color-divider);
+      margin: 8px 0;
     }
-    .stat-card {
-      background: var(--color-cream-card);
-      border-radius: var(--radius-card);
-      padding: 16px 18px;
-      box-shadow: var(--shadow-card);
-    }
-    .stat-card-label {
-      font-size: 0.82rem;
-      color: var(--color-text-muted);
-      margin-bottom: 6px;
-      font-weight: 500;
-    }
-    .stat-card-value {
-      font-family: var(--font-serif);
-      font-weight: 700;
-      font-size: 1.35rem;
-      color: var(--color-primary-dark);
-      line-height: 1.1;
-    }
-    .stat-card-na {
-      color: var(--color-text-subtle);
-      font-family: var(--font-sans);
-    }
-
-    /* ===== Drill inline entries — kept visual structure, retinted ===== */
     .drill-entry-inline {
       display: flex;
       justify-content: space-between;
       align-items: center;
-      padding: 8px 0;
+      padding: 6px 0;
       border-bottom: 1px solid var(--color-divider);
-      font-size: 0.9rem;
+      font-size: 0.85rem;
     }
     .drill-entry-inline:last-of-type {
       border-bottom: none;
@@ -583,202 +291,485 @@
       font-weight: 600;
       color: var(--color-primary-dark);
     }
-
-    /* ===== Tabs (pill style) ===== */
+    /* Tabs */
     .tab-bar {
       display: flex;
-      gap: 8px;
-      margin-bottom: 16px;
-      flex-wrap: nowrap;
-      align-items: center;
-      overflow-x: auto;
-      -webkit-overflow-scrolling: touch;
-      padding: 4px 0 8px;
-      scrollbar-width: none;
-    }
-    .tab-bar::-webkit-scrollbar { display: none; }
-    .tab-btn {
-      display: inline-flex;
-      align-items: center;
       gap: 6px;
-      background: var(--color-cream-card);
-      border: 1.5px solid transparent;
-      border-radius: var(--radius-pill);
-      padding: 0;
-      font-size: 0.85rem;
-      font-weight: 600;
-      color: var(--color-text);
-      cursor: pointer;
-      transition: background 0.15s, border-color 0.15s, color 0.15s, transform 0.1s;
-      max-width: 180px;
-      min-height: 40px;
-      position: relative;
-      flex-shrink: 0;
+      margin-bottom: 12px;
+      flex-wrap: wrap;
+      align-items: center;
     }
-    .tab-btn:active { transform: scale(0.97); }
+    .tab-btn {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      background: var(--color-border-soft);
+      border: 2px solid var(--color-divider);
+      border-radius: 8px;
+      padding: 0;
+      font-size: 0.8rem;
+      cursor: pointer;
+      transition: background 0.15s, border-color 0.15s;
+      max-width: 130px;
+      min-height: 48px;
+      /* Ensure tap area covers entire button */
+      position: relative;
+    }
     .tab-btn.field-tab.active {
-      background: var(--color-primary-dark);
-      border-color: var(--color-primary-dark);
-      color: var(--color-card-text);
+      background: var(--color-primary);
+      border: 3px solid var(--color-primary-dark);
+      box-shadow: 0 0 0 1px var(--color-primary) inset;
+      color: var(--color-ios-banner-text);
     }
     .tab-btn.field-tab:not(.active):hover {
-      background: var(--color-cream-hover);
-    }
-    .pill-tab-dot {
-      width: 8px;
-      height: 8px;
-      border-radius: 50%;
-      background: var(--color-accent-brown);
-      flex-shrink: 0;
-    }
-    .tab-btn.active .pill-tab-dot {
-      background: var(--color-card-text);
+      background: var(--color-bg-hover);
     }
     .tab-name {
       background: transparent;
       border: none;
-      font-size: 0.85rem;
+      font-size: 0.8rem;
       font-weight: 600;
       color: inherit;
-      width: auto;
-      max-width: 130px;
-      padding: 10px 12px 10px 4px;
+      width: 52px;
+      max-width: 52px;
+      padding: 14px 4px 14px 10px;
       outline: none;
       pointer-events: auto;
       cursor: pointer;
-      min-height: 40px;
+      min-height: 48px;
       display: inline-block;
-      flex: 1;
-      text-align: left;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
+      /* Prevent mobile copy/cut/paste menu on tap — edit only via double-click/tap */
+      user-select: none;
+      -webkit-user-select: none;
       -webkit-touch-callout: none;
     }
     .tab-name:focus {
       cursor: text;
-      background: rgba(255, 255, 255, 0.15);
-      -webkit-user-select: text;
+      background: rgba(255,255,255,0.15);
+      /* Allow text selection when editing */
       user-select: text;
+      -webkit-user-select: text;
     }
     .tab-btn:not(.active) .tab-name:focus {
-      background: var(--color-bg-soft);
+      background: var(--color-bg);
     }
+    .tab-btn.active .tab-name {
+      color: var(--color-ios-banner-text);
+    }
+    /* Remove the separate .tab-edit stift icon — tap input directly to edit */
     .tab-close {
       background: none;
       border: none;
       cursor: pointer;
       color: inherit;
-      opacity: 0.55;
+      opacity: 0.6;
       flex-shrink: 0;
-      width: 36px;
-      height: 36px;
-      min-width: 36px;
+      /* Ensure min 44x44px touch target */
+      width: 44px;
+      height: 44px;
+      min-width: 44px;
       display: flex;
       align-items: center;
       justify-content: center;
-      border-radius: 50%;
-      font-size: 0.9rem;
+      border-radius: 8px;
+      font-size: 1rem;
       transition: opacity 0.15s, background 0.15s;
-      margin-right: 4px;
+      margin: 2px;
     }
-    .tab-close:hover { opacity: 1; }
+    .tab-close:hover {
+      opacity: 1;
+    }
     .tab-close:active {
-      background: rgba(0, 0, 0, 0.1);
+      background: rgba(0,0,0,0.1);
       opacity: 1;
     }
     .tab-add {
-      background: var(--color-cream-card);
-      border: 1.5px dashed var(--color-primary-dark);
-      border-radius: var(--radius-pill);
-      padding: 0 14px;
-      font-size: 0.85rem;
+      background: var(--color-border-soft);
+      border: 2px dashed var(--color-border-dashed);
+      border-radius: 8px;
+      padding: 0 12px;
+      font-size: 0.8rem;
       font-weight: 600;
-      color: var(--color-primary-dark);
+      color: var(--color-primary);
       cursor: pointer;
       flex-shrink: 0;
-      min-height: 40px;
-      display: inline-flex;
+      min-height: 48px;
+      display: flex;
       align-items: center;
       justify-content: center;
     }
-    .tab-add:active { background: var(--color-cream-hover); }
-
-    /* ===== Bottom Navigation (sticky) ===== */
-    .bottom-nav {
-      position: fixed;
-      bottom: 0;
-      left: 0;
-      right: 0;
-      background: var(--color-cream-card);
-      display: flex;
-      justify-content: space-around;
-      align-items: center;
-      padding: 6px 8px calc(6px + env(safe-area-inset-bottom));
-      z-index: 80;
-      box-shadow: var(--shadow-nav);
-      border-top: 1px solid var(--color-border-soft);
+    .tab-add:active {
+      background: var(--color-bg-hover);
     }
-    .bottom-nav-item {
+    .tab-bar-left {
+      display: flex;
+      gap: 6px;
+      flex-wrap: wrap;
+      align-items: center;
       flex: 1;
+    }
+    .tab-separator {
+      width: 1px;
+      height: 24px;
+      background: var(--color-divider);
+      margin: 0 4px;
+      flex-shrink: 0;
+    }
+    .tab-btn.protokoll-tab {
+      background: var(--color-success-soft);
+      border: 2px solid var(--color-primary);
+      color: var(--color-primary-dark);
+      flex-shrink: 0;
+    }
+    .tab-btn.protokoll-tab.active {
+      background: var(--color-primary);
+      border-color: var(--color-primary);
+      color: var(--color-ios-banner-text);
+    }
+    .tab-btn.protokoll-tab:not(.active):hover {
+      background: var(--color-bg-hover);
+    }
+    .tab-bar > .tab-bar-left {
       display: flex;
-      flex-direction: column;
+      gap: 6px;
+      flex-wrap: wrap;
+      min-height: 36px;
       align-items: center;
-      justify-content: center;
-      gap: 2px;
-      padding: 8px 4px;
-      border: none;
-      background: transparent;
+    }
+
+    /* Drill log */
+    .drill-entry {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 10px 0;
+    }
+    #drill_machine_log {
+      margin-bottom: 12px;
+      padding-bottom: 8px;
+      border-bottom: 2px solid var(--color-border-strong);
+    }
+    .drill-entry-tab-header {
+      font-size: 13px;
+      font-weight: bold;
       color: var(--color-text-muted);
-      font-size: 0.72rem;
-      font-weight: 500;
-      cursor: pointer;
-      transition: color 0.15s, transform 0.1s;
-      border-radius: 10px;
+      padding: 8px 0 4px 0;
+      border-bottom: 1px solid var(--color-border-faint);
+      margin-bottom: 4px;
     }
-    .bottom-nav-item:active { transform: scale(0.95); }
-    .bottom-nav-icon {
-      font-size: 1.25rem;
-      line-height: 1;
-      filter: grayscale(40%);
-      transition: filter 0.15s;
+    .drill-entry {
+      border-bottom: 1px solid var(--color-border-soft);
+      font-size: 0.9rem;
     }
-    .bottom-nav-item.active {
+    .drill-entry:last-of-type {
+      border-bottom: none;
+    }
+    .drill-entry .entry-text {
+      color: var(--color-text-label);
+    }
+    .drill-entry .entry-text span {
+      font-weight: 600;
+      color: var(--color-primary-dark);
+    }
+    .drill-prognose {
+      font-size: 0.78rem;
+      color: var(--color-text-muted);
+      padding: 2px 0 6px 4px;
+    }
+    .drill-prognose span {
+      display: inline-block;
+      margin-right: 10px;
+    }
+    .drill-prognose .prog-label {
+      font-weight: 600;
+      color: var(--color-text-label-strong);
+    }
+    .drill-prognose .prog-val {
       color: var(--color-primary-dark);
       font-weight: 700;
     }
-    .bottom-nav-item.active .bottom-nav-icon {
-      filter: none;
+    .drill-empty {
+      text-align: center;
+      color: var(--color-text-hint);
+      font-size: 0.85rem;
+      padding: 12px 0;
+    }
+    .drill-summary {
+      background: var(--color-bg);
+      border-radius: 8px;
+      padding: 12px;
+      margin-bottom: 12px;
+    }
+    .drill-summary-row {
+      display: flex;
+      justify-content: space-between;
+      font-size: 0.9rem;
+      padding: 4px 0;
+    }
+    .drill-summary-row.remaining {
+      font-weight: 700;
+      color: var(--color-danger);
+      font-size: 1rem;
+      padding-top: 8px;
+      margin-top: 4px;
+      border-top: 1px solid var(--color-border);
+    }
+    .drill-summary-savings {
+      background: var(--color-bg-success-soft);
+      border-radius: 6px;
+      padding: 8px 10px;
+      margin-top: 8px;
+      font-size: 0.85rem;
+      color: var(--color-text-success);
+      font-weight: 600;
+    }
+    .drill-savings {
+      font-size: 0.85rem;
+      color: var(--color-text-success);
+      font-weight: 600;
+      padding: 2px 0;
+    }
+    .drill-savings .entry-text::before {
+      content: '↘ ';
+    }
+    .drill-carryover {
+      font-size: 0.85rem;
+      color: var(--color-info);
+      font-weight: 600;
+      padding: 2px 0;
+    }
+    .drill-carryover .entry-text::before {
+      content: '↗ ';
+    }
+    .drill-excess {
+font-size: 0.75rem;
+      color: var(--color-text-danger);
+      text-transform: uppercase;
+    }
+    .drill-excess .entry-text::before {
+      content: '↘ ';
+    }
+    .carryover-hint {
+      color: var(--color-info);
+    }
+    .excess-hint {
+      color: var(--color-danger-soft);
+    }
+    /* Issue #336: drei Carryover-Roh-Wert-Zeilen im Ergebnis-Tab.
+       Visuell getrennt von Verbleibend/Eingefüllt via border-top und
+       kleinerer Schrift. Farben folgen dem Maschinen-Protokoll-Pattern. */
+    .net-totals-line {
+      font-size: 0.9rem;
+      font-weight: 600;
+      padding: 2px 0;
+    }
+    .net-totals-savings {
+      color: var(--color-text-success);
+    }
+    .net-totals-excess {
+      color: var(--color-text-danger);
+    }
+    .r-carryover-row {
+      font-size: 0.85rem;
+      padding: 2px 0;
+      font-weight: 600;
+    }
+    .r-carryover-savings {
+      color: var(--color-text-success);
+    }
+    .r-carryover-carryover {
+      color: var(--color-info);
+    }
+    .r-carryover-excess {
+      color: var(--color-danger-soft);
+    }
+    .summary-muted {
+      font-size: 0.85rem;
+      font-weight: 600;
+      color: var(--color-text-label-strong);
+    }
+    .drill-summary-total {
+      margin-top: 10px;
+      padding-top: 10px;
+      border-top: 2px solid var(--color-primary);
+      font-size: 0.95rem;
+      font-weight: 700;
+      color: var(--color-primary-dark);
+      text-align: center;
+    }
+    .inline-row {
+      display: flex;
+      gap: 8px;
+    }
+    .inline-row .field {
+      flex: 1;
+      margin-bottom: 8px;
+    }
+    .drill-machine-row {
+      display: flex;
+      gap: 8px;
+    }
+    .drill-machine-row .field {
+      flex: 1;
+      margin-bottom: 8px;
+    }
+    .drill-tabs-section {
+      margin: 12px 0;
+      border: 1px solid var(--color-divider);
+      border-radius: 8px;
+      padding: 8px;
+      background: var(--color-bg-soft);
+    }
+    .drill-tabs-header {
+      font-size: 0.85rem;
+      color: var(--color-text-label-strong);
+      margin-bottom: 8px;
+      font-weight: 600;
+    }
+    .drill-tab-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 6px;
+      padding: 4px;
+      border-radius: 6px;
+    }
+    .drill-tab-row:hover {
+      background: rgba(0,0,0,0.03);
+    }
+    .drill-prio-btn {
+      width: 32px;
+      height: 32px;
+      border-radius: 50%;
+      border: 2px solid var(--color-divider);
+      background: var(--color-bg);
+      font-size: 0.85rem;
+      font-weight: 700;
+      color: var(--color-text-hint);
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+      transition: background 0.15s, border-color 0.15s, color 0.15s;
+      touch-action: manipulation;
+    }
+    .drill-prio-btn.active {
+      background: var(--color-primary);
+      border-color: var(--color-primary-dark);
+      color: var(--color-ios-banner-text);
+    }
+    .drill-prio-btn:active {
+      transform: scale(0.92);
+    }
+    .drill-tab-row .drill-tab-name-wrap {
+      flex: 1;
+      min-width: 0;
+    }
+    .drill-tab-row .drill-tab-name {
+      font-size: 0.9rem;
+      font-weight: 500;
+    }
+    .drill-tab-row .drill-tab-need {
+      font-size: 0.75rem;
+      color: var(--color-text-hint-2);
+      margin-top: 1px;
+    }
+    .drill-tab-row .drill-tab-need.done {
+      color: var(--color-text-success-strong);
+      font-weight: 600;
+    }
+    .drill-tab-row .drill-tab-values {
+      display: flex;
+      gap: 6px;
+      font-size: 0.85rem;
+      color: var(--color-text-muted);
+    }
+    .drill-tab-row .drill-tab-values input {
+      width: 90px;
+      max-width: 22vw;
+      min-width: 70px;
+      padding: 4px 6px;
+      border: 1px solid var(--color-border-disabled);
+      border-radius: 4px;
+      font-size: 0.85rem;
+      text-align: right;
+    }
+    .drill-tab-row .drill-tab-values input:focus {
+      border-color: var(--color-primary);
+      outline: none;
+    }
+    .drill-tab-row .drill-tab-values input:disabled {
+      background: var(--color-bg-disabled, #f3f3f3);
+      color: var(--color-text-hint);
+      cursor: not-allowed;
+      opacity: 0.65;
+    }
+    /* Issue #377: Toggle-Button "Feld fertig" pro Reiter. Default neutral
+       (grauer Rahmen), aktiv grün gefüllt. Klickbar auch auf Touch. */
+    .drill-done-btn {
+      flex-shrink: 0;
+      padding: 6px 10px;
+      font-size: 0.78rem;
+      font-weight: 600;
+      border-radius: 6px;
+      border: 1px solid var(--color-divider);
+      background: var(--color-bg);
+      color: var(--color-text-label-strong);
+      cursor: pointer;
+      transition: background 0.15s, border-color 0.15s, color 0.15s;
+      touch-action: manipulation;
+      white-space: nowrap;
+    }
+    .drill-done-btn:hover {
+      border-color: var(--color-primary);
+    }
+    .drill-done-btn.active {
+      background: var(--color-primary);
+      border-color: var(--color-primary-dark);
+      color: var(--color-ios-banner-text);
+    }
+    .drill-done-btn:active {
+      transform: scale(0.96);
+    }
+    .drill-tab-row.done {
+      background: rgba(76, 175, 80, 0.06);
+      border: 1px solid rgba(76, 175, 80, 0.25);
+    }
+    .btn-add {
+      width: 100%;
+      padding: 12px;
+      font-size: 0.95rem;
+      font-weight: 700;
+      background: var(--color-primary);
+      color: var(--color-ios-banner-text);
+      border: none;
+      border-radius: 10px;
+      cursor: pointer;
+      margin-top: 4px;
+    }
+    .btn-add:active {
+      background: var(--color-primary-hover);
     }
 
-    /* ===== Views (only one visible at a time) ===== */
-    #view_rechner, #view_protokoll, #view_uebersicht {
-      display: block;
-    }
-    #view_protokoll, #view_uebersicht {
-      display: none;
-    }
-
-    /* ===== Fahrgassen / Toggle rows ===== */
+    /* Fahrgassen */
     .fahrgassen-toggle {
       display: flex;
       align-items: center;
       justify-content: space-between;
-      padding: 10px 0;
+      padding: 12px 0;
       border-bottom: 1px solid var(--color-border-soft);
-      margin-top: 4px;
     }
     .fahrgassen-toggle:last-child {
       border-bottom: none;
     }
     .fahrgassen-toggle label {
       margin: 0;
-      font-size: 0.92rem;
+      font-size: 0.95rem;
     }
     .toggle-btn {
       width: 52px;
-      min-height: 28px;
-      height: 28px;
+      min-height: 44px;
       border-radius: 14px;
       background: var(--color-border-disabled);
       border: none;
@@ -786,7 +777,7 @@
       position: relative;
       transition: background 0.2s;
       flex-shrink: 0;
-      padding: 0;
+      padding: 8px 0;
     }
     .toggle-btn::after {
       content: '';
@@ -796,21 +787,20 @@
       width: 24px;
       height: 24px;
       border-radius: 12px;
-      background: white;
-      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+      background: var(--color-ios-banner-text);
       transition: left 0.2s;
     }
     .toggle-btn.active {
-      background: var(--color-primary-dark);
+      background: var(--color-primary);
     }
     .toggle-btn.active::after {
       left: 26px;
     }
     .fahrgassen-settings {
       margin-top: 12px;
-      padding: 14px;
-      background: var(--color-bg-soft);
-      border-radius: 12px;
+      padding: 12px;
+      background: var(--color-bg);
+      border-radius: 8px;
       display: none;
     }
     .fahrgassen-settings.open {
@@ -823,24 +813,26 @@
     }
     .fahrgassen-saved {
       font-size: 0.85rem;
-      color: var(--color-primary-dark);
+      color: var(--color-primary);
       font-weight: 600;
       margin-top: 8px;
       text-align: center;
     }
     .entry-diff.positive { color: var(--color-entry-diff-positive); font-weight: 600; }
     .entry-diff.negative { color: var(--color-entry-diff-negative); font-weight: 600; }
-
-    /* ===== Sticky layout ===== */
+    
+    
+    /* Sticky footer */
     .app-layout {
       display: flex;
       flex-direction: column;
-      min-height: calc(100dvh - max(20px, env(safe-area-inset-top)) - max(120px, calc(80px + env(safe-area-inset-bottom))));
+      min-height: calc(100dvh - max(20px, env(safe-area-inset-top)) - max(20px, env(safe-area-inset-bottom)));
     }
     .scrollable-content {
       flex: 1;
       overflow-y: auto;
       -webkit-overflow-scrolling: touch;
+      padding-bottom: max(80px, env(safe-area-inset-bottom));
     }
     .save-error-banner {
       background: var(--color-warning-bg);
@@ -873,418 +865,151 @@
       text-align: center;
       color: var(--color-text-hint);
       font-size: 0.75rem;
-      margin-top: 14px;
+      margin-top: 16px;
       padding-bottom: 8px;
     }
 
-    /* ===== Drill-Log (Protokoll view) ===== */
-    .drill-entry {
+    /* Dashboard */
+    .dashboard-overlay {
+      display: none;
+      position: fixed;
+      inset: 0;
+      background: rgba(0,0,0,0.4);
+      z-index: 150;
+    }
+    .dashboard-overlay.open {
+      display: block;
+    }
+    .dashboard-sheet {
+      display: none;
+      position: fixed;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      background: var(--color-card-bg);
+      border-radius: 20px 20px 0 0;
+      max-height: 80vh;
+      overflow-y: auto;
+      z-index: 151;
+      padding: 0 0 max(20px, env(safe-area-inset-bottom));
+    }
+    .dashboard-sheet.open {
+      display: block;
+    }
+    .dashboard-header {
       display: flex;
       justify-content: space-between;
       align-items: center;
-      padding: 8px 0;
+      padding: 20px 20px 16px;
+      border-bottom: 2px solid var(--color-border-soft);
+      position: sticky;
+      top: 0;
+      background: var(--color-card-bg);
+      border-radius: 20px 20px 0 0;
     }
-    #drill_machine_log {
-      margin-bottom: 12px;
-      padding-bottom: 8px;
-      border-bottom: 2px solid var(--color-border-strong);
-    }
-    .drill-entry-tab-header {
-      font-size: 0.78rem;
-      font-weight: 700;
-      text-transform: uppercase;
-      letter-spacing: 0.06em;
-      color: var(--color-text-muted);
-      padding: 12px 0 6px 0;
-      border-bottom: 1px solid var(--color-border-faint);
-      margin-bottom: 6px;
-    }
-    .drill-entry {
-      border-bottom: 1px solid var(--color-border-soft);
-      font-size: 0.92rem;
-    }
-    .drill-entry:last-of-type {
-      border-bottom: none;
-    }
-    .drill-entry .entry-text {
-      color: var(--color-text-label);
-    }
-    .drill-entry .entry-text span {
-      font-weight: 600;
-      color: var(--color-primary-dark);
-    }
-    .drill-prognose {
-      font-size: 0.78rem;
-      color: var(--color-text-muted);
-      padding: 2px 0 8px 4px;
-    }
-    .drill-prognose span {
-      display: inline-block;
-      margin-right: 10px;
-    }
-    .drill-prognose .prog-label {
-      font-weight: 600;
-      color: var(--color-text-label-strong);
-    }
-    .drill-prognose .prog-val {
-      color: var(--color-primary-dark);
-      font-weight: 700;
-    }
-    .drill-empty {
-      text-align: center;
-      color: var(--color-text-hint);
-      font-size: 0.9rem;
-      padding: 14px 0;
-    }
-    .drill-summary {
-      background: var(--color-bg-soft);
-      border-radius: 12px;
-      padding: 14px;
-      margin-bottom: 14px;
-    }
-    .drill-summary-row {
-      display: flex;
-      justify-content: space-between;
-      font-size: 0.9rem;
-      padding: 4px 0;
-    }
-    .drill-summary-row.remaining {
-      font-weight: 700;
-      color: var(--color-danger);
-      font-size: 1rem;
-      padding-top: 8px;
-      margin-top: 4px;
-      border-top: 1px solid var(--color-border);
-    }
-    .drill-summary-savings {
-      background: var(--color-bg-success-soft);
-      border-radius: 8px;
-      padding: 8px 10px;
-      margin-top: 8px;
-      font-size: 0.85rem;
-      color: var(--color-text-success-strong);
-      font-weight: 600;
-    }
-
-    /* Maschinen-Log Sub-Section (innerhalb #drill_section) */
-    .drill-log-subsection {
-      margin-top: 18px;
-      padding-top: 16px;
-      border-top: 2px solid var(--color-border-strong);
-    }
-    .drill-log-subsection .subsection-header {
-      font-size: 0.78rem;
-      font-weight: 700;
-      text-transform: uppercase;
-      letter-spacing: 0.06em;
-      color: var(--color-text-muted);
-      border-bottom: none;
+    .dashboard-header h2 {
+      margin: 0;
       padding: 0;
-      margin: 0 0 10px 0;
-      display: flex;
-      align-items: center;
-      gap: 8px;
-    }
-    .drill-savings {
-      font-size: 0.88rem;
-      color: var(--color-text-success-strong);
-      font-weight: 600;
-      padding: 2px 0;
-    }
-    .drill-savings .entry-text::before { content: '↘ '; }
-    .drill-carryover {
-      font-size: 0.88rem;
-      color: var(--color-info);
-      font-weight: 600;
-      padding: 2px 0;
-    }
-    .drill-carryover .entry-text::before { content: '↗ '; }
-    .drill-excess {
-      font-size: 0.78rem;
-      color: var(--color-text-danger);
-      text-transform: uppercase;
-    }
-    .drill-excess .entry-text::before { content: '↘ '; }
-    .carryover-hint { color: var(--color-info); }
-    .excess-hint { color: var(--color-danger-soft); }
-    .net-totals-line {
-      font-size: 0.9rem;
-      font-weight: 600;
-      padding: 2px 0;
-    }
-    .net-totals-savings { color: var(--color-text-success-strong); }
-    .net-totals-excess { color: var(--color-text-danger); }
-    .r-carryover-row {
-      font-size: 0.85rem;
-      padding: 2px 0;
-      font-weight: 600;
-    }
-    .r-carryover-savings { color: var(--color-text-success); }
-    .r-carryover-carryover { color: var(--color-info); }
-    .r-carryover-excess { color: var(--color-danger-soft); }
-    .summary-muted {
-      font-size: 0.85rem;
-      font-weight: 600;
-      color: var(--color-text-label-strong);
-    }
-    .drill-summary-total {
-      margin-top: 10px;
-      padding-top: 10px;
-      border-top: 2px solid var(--color-primary);
-      font-size: 0.95rem;
-      font-weight: 700;
+      border: none;
+      font-size: 1.1rem;
       color: var(--color-primary-dark);
-      text-align: center;
     }
-
-    .inline-row {
-      display: flex;
-      gap: 8px;
-    }
-    .inline-row .field {
-      flex: 1;
-      margin-bottom: 8px;
-    }
-    .drill-machine-row {
-      display: flex;
-      gap: 10px;
-    }
-    .drill-machine-row .field {
-      flex: 1;
-      margin-bottom: 0;
-    }
-
-    /* ===== Schlag-Cards (drill prio list) ===== */
-    .drill-tabs-section {
-      margin: 0 0 14px 0;
-    }
-    .drill-tabs-header {
-      font-size: 0.78rem;
-      color: var(--color-text-label-strong);
-      margin-bottom: 8px;
-      font-weight: 700;
-      text-transform: uppercase;
-      letter-spacing: 0.06em;
-    }
-    .drill-tab-row {
-      display: flex;
-      align-items: center;
-      gap: 12px;
-      margin-bottom: 8px;
-      padding: 14px 14px 14px 12px;
-      border-radius: 14px;
-      background: var(--color-cream-card);
-      box-shadow: var(--shadow-soft);
-      transition: background 0.15s;
-    }
-    .drill-tab-row.done {
-      opacity: 0.55;
-      background: var(--color-bg-soft);
-    }
-    .drill-prio-btn {
+    .dashboard-close {
+      background: var(--color-border-soft);
+      border: none;
+      border-radius: 50%;
       width: 36px;
       height: 36px;
-      border-radius: 50%;
-      border: 1.5px solid var(--color-border-soft);
-      background: var(--color-cream-card);
-      font-size: 0.92rem;
-      font-weight: 700;
-      color: var(--color-text-muted);
+      font-size: 1.2rem;
       cursor: pointer;
+      color: var(--color-primary);
       display: flex;
       align-items: center;
       justify-content: center;
-      flex-shrink: 0;
-      transition: all 0.15s;
-      touch-action: manipulation;
     }
-    .drill-prio-btn.active {
+    .dashboard-close:active {
+      background: var(--color-bg-hover);
+    }
+
+    .dashboard-open-btn {
       background: var(--color-primary-dark);
-      border-color: var(--color-primary-dark);
-      color: var(--color-card-text);
-    }
-    .drill-prio-btn:active { transform: scale(0.92); }
-    .drill-tab-row .drill-tab-name-wrap {
-      flex: 1;
-      min-width: 0;
-    }
-    .drill-tab-row .drill-tab-name {
-      font-family: var(--font-serif);
-      font-weight: 700;
-      font-size: 1.02rem;
-      color: var(--color-primary-dark);
-    }
-    .drill-tab-row .drill-tab-need {
-      font-size: 0.78rem;
-      color: var(--color-text-muted);
-      margin-top: 3px;
-    }
-    .drill-tab-row .drill-tab-need.done {
-      color: var(--color-text-success-strong);
-      font-weight: 700;
-    }
-    .drill-tab-row .drill-prio-badge {
-      display: inline-block;
-      padding: 2px 8px;
-      border-radius: var(--radius-pill);
-      background: var(--color-sage-badge);
-      color: var(--color-primary-darker);
-      font-size: 0.7rem;
-      font-weight: 700;
-      letter-spacing: 0.04em;
-      margin-left: 6px;
-    }
-    .drill-tab-row .drill-tab-values {
-      display: none;
-    }
-    .drill-done-btn {
-      flex-shrink: 0;
-      padding: 6px 10px;
-      font-size: 0.78rem;
-      font-weight: 600;
+      color: var(--color-ios-banner-text);
+      border: none;
       border-radius: 8px;
-      border: 1px solid var(--color-border-soft);
-      background: var(--color-cream-card);
-      color: var(--color-text-label-strong);
-      cursor: pointer;
-      transition: background 0.15s, border-color 0.15s, color 0.15s;
-      touch-action: manipulation;
-      white-space: nowrap;
-    }
-    .drill-done-btn:hover { border-color: var(--color-primary); }
-    .drill-done-btn.active {
-      background: var(--color-primary-dark);
-      border-color: var(--color-primary-dark);
-      color: var(--color-card-text);
-    }
-    .drill-done-btn:active { transform: scale(0.96); }
-    .btn-add {
-      width: 100%;
-      padding: 16px;
-      font-size: 1.05rem;
-      font-weight: 700;
-      background: var(--color-primary-dark);
-      color: var(--color-card-text);
-      border: none;
-      border-radius: var(--radius-button);
-      cursor: pointer;
-      margin-top: 6px;
-      font-family: var(--font-sans);
-    }
-    .btn-add:active { background: var(--color-primary-darker); }
-
-    /* ===== Reset-tab button (replaces footer reset) ===== */
-    .reset-this-tab-btn {
-      width: 100%;
-      padding: 14px 18px;
-      font-size: 0.95rem;
-      font-weight: 600;
-      border: 1.5px solid var(--color-border-soft);
-      border-radius: var(--radius-button);
-      background: transparent;
-      color: var(--color-text-label-strong);
-      cursor: pointer;
-      margin-top: 8px;
-      transition: background 0.15s, color 0.15s, border-color 0.15s;
-    }
-    .reset-this-tab-btn:active {
-      background: var(--color-cream-hover);
-    }
-
-    /* ===== Übersicht View ===== */
-    .uebersicht-summary {
-      background: linear-gradient(160deg, var(--color-primary-dark), var(--color-primary));
-      border-radius: 18px;
-      padding: 22px;
-      color: var(--color-card-text);
-      margin-bottom: 16px;
-      box-shadow: var(--shadow-card);
-    }
-    .uebersicht-summary-label {
-      font-size: 0.82rem;
-      opacity: 0.85;
-      font-weight: 500;
-      margin-bottom: 6px;
-    }
-    .uebersicht-summary-value {
-      font-family: var(--font-serif);
-      font-size: 2.2rem;
-      font-weight: 700;
-      line-height: 1.05;
-      margin-bottom: 8px;
-    }
-    .uebersicht-summary-meta {
+      padding: 6px 14px;
       font-size: 0.85rem;
-      opacity: 0.85;
+      font-weight: 600;
+      cursor: pointer;
+      margin-left: 8px;
+      flex-shrink: 0;
     }
-    .uebersicht-stat-tiles {
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      gap: 12px;
-      margin-bottom: 16px;
+    .dashboard-open-btn:active {
+      background: var(--color-dashboard-open-active);
     }
-    .uebersicht-stat-tile {
-      background: var(--color-primary-dark);
-      border-radius: 14px;
-      padding: 14px 16px;
-      color: var(--color-card-text);
-    }
-    .uebersicht-stat-tile-label {
-      font-size: 0.78rem;
-      opacity: 0.85;
-      font-weight: 500;
-      margin-bottom: 4px;
-    }
-    .uebersicht-stat-tile-value {
-      font-family: var(--font-serif);
-      font-size: 1.3rem;
-      font-weight: 700;
-      line-height: 1.1;
-    }
-    .uebersicht-section-header {
-      font-size: 0.78rem;
-      font-weight: 700;
-      text-transform: uppercase;
-      letter-spacing: 0.06em;
-      color: var(--color-text-muted);
-      margin: 16px 4px 8px;
-    }
-    /* Per-tab progress card — keeps dashboard-reiter-card class for test compat */
-    .dashboard-reiter-card {
-      margin: 0 0 12px 0;
-      background: var(--color-cream-card);
-      border: none;
-      border-radius: var(--radius-card);
-      padding: 16px 18px;
-      box-shadow: var(--shadow-card);
-    }
-    .dashboard-reiter-name {
-      font-family: var(--font-serif);
-      font-weight: 700;
-      color: var(--color-primary-dark);
-      font-size: 1.05rem;
-      margin-bottom: 4px;
+    .dashboard-tabs-header {
       display: flex;
       align-items: center;
-      justify-content: space-between;
-      gap: 8px;
+      padding: 12px 20px 0;
     }
-    .dashboard-reiter-name .ha-badge {
-      font-family: var(--font-sans);
-      font-size: 0.85rem;
-      font-weight: 600;
-      color: var(--color-text-muted);
+    .dashboard-empty {
+      text-align: center;
+      color: var(--color-text-hint);
+      font-size: 0.9rem;
+      padding: 32px 20px;
+    }
+    .dashboard-summary {
+      margin: 0 20px 16px;
+      background: linear-gradient(135deg, var(--color-primary), var(--color-primary-bright));
+      border-radius: 14px;
+      padding: 16px 18px;
+      color: var(--color-ios-banner-text);
+    }
+    .dashboard-summary-title {
+      font-weight: 700;
+      font-size: 1rem;
+      margin-bottom: 12px;
+    }
+    .dashboard-summary-stats {
+      display: flex;
+      gap: 20px;
+      margin-bottom: 12px;
+    }
+    .dashboard-summary-stat {
+      flex: 1;
+    }
+    .dashboard-summary-label {
+      font-size: 0.7rem;
+      opacity: 0.85;
+      margin-bottom: 2px;
+    }
+    .dashboard-summary-value {
+      font-size: 1.1rem;
+      font-weight: 700;
+    }
+    .dashboard-summary-value.done { color: var(--color-dashboard-done); }
+    .dashboard-summary-value.remaining { color: var(--color-dashboard-remaining); }
+    .dashboard-reiter-card {
+      margin: 12px 20px;
+      background: var(--color-bg-card);
+      border: 2px solid var(--color-border-soft);
+      border-radius: 12px;
+      padding: 14px;
+    }
+    .dashboard-reiter-name {
+      font-weight: 700;
+      color: var(--color-primary-dark);
+      font-size: 0.95rem;
+      margin-bottom: 10px;
     }
     .dashboard-reiter-stats {
       display: grid;
       grid-template-columns: 1fr 1fr;
       gap: 8px;
-      margin-bottom: 8px;
     }
     .dashboard-stat {
-      background: transparent;
-      border-radius: 0;
-      padding: 0;
+      background: var(--color-card-bg);
+      border-radius: 8px;
+      padding: 8px 10px;
     }
     .dashboard-stat-label {
       font-size: 0.75rem;
@@ -1296,38 +1021,169 @@
       font-weight: 600;
       color: var(--color-text);
     }
-    .dashboard-stat-value.remaining { color: var(--color-danger); }
-    .dashboard-stat-value.done { color: var(--color-primary); }
-    .dashboard-stat-value.na { color: var(--color-text-subtle); }
+    .dashboard-stat-value.remaining {
+      color: var(--color-danger);
+    }
+    .dashboard-stat-value.done {
+      color: var(--color-primary);
+    }
+    .dashboard-stat-value.na {
+      color: var(--color-text-subtle);
+    }
     .dashboard-progress-bar {
       grid-column: 1 / -1;
-      height: 8px;
-      background: var(--color-sage-progress-bg);
-      border-radius: 4px;
+      height: 6px;
+      background: var(--color-border-soft);
+      border-radius: 3px;
       overflow: hidden;
       margin-top: 4px;
-      margin-bottom: 6px;
     }
     .dashboard-progress-fill {
       height: 100%;
-      background: var(--color-primary-dark);
-      border-radius: 4px;
+      background: var(--color-primary);
+      border-radius: 3px;
       transition: width 0.3s;
     }
-    .dashboard-progress-legend {
+
+    /* Dark mode toggle */
+    .theme-toggle {
+      background: var(--color-border-soft);
+      border: 2px solid var(--color-divider);
+      border-radius: 8px;
+      width: 40px;
+      height: 40px;
+      font-size: 1.15rem;
+      cursor: pointer;
       display: flex;
-      justify-content: space-between;
-      font-size: 0.85rem;
-      color: var(--color-text-muted);
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+      transition: background 0.2s, border-color 0.2s;
+      touch-action: manipulation;
     }
-    .dashboard-progress-legend strong {
-      color: var(--color-text);
+    .theme-toggle:active {
+      transform: scale(0.92);
     }
 
-    /* ===== iOS Install Banner ===== */
+    /* ===== Dark mode ===== */
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+
+    
+    
+    
+    
+    
+    
+    
+
+    
+    
+    
+    
+    
+    
+    
+    
+
+    
+    
+    
+    
+
+    /* Tabs dark */
+    
+    
+    
+    
+    
+    
+    
+    
+    
+
+    /* Toggle dark */
+    
+    
+    
+    
+    
+
+    /* Sticky footer dark */
+    
+    
+    
+    
+    
+
+    /* Dashboard dark */
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+
+    /* Drill section dark */
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+
+    
+    
+    
+
+    /* iOS Install Banner */
     .ios-install-banner {
       position: fixed;
-      bottom: 90px;
+      bottom: 80px;
       left: 12px;
       right: 12px;
       background: var(--color-ios-banner-bg);
@@ -1339,15 +1195,19 @@
       align-items: center;
       gap: 12px;
       z-index: 999;
-      box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+      box-shadow: 0 4px 16px rgba(0,0,0,0.25);
     }
     .ios-install-banner.show {
       display: flex;
     }
-    .ios-install-banner .ios-install-text { flex: 1; }
-    .ios-install-banner .ios-install-text strong { color: var(--color-primary-light); }
+    .ios-install-banner .ios-install-text {
+      flex: 1;
+    }
+    .ios-install-banner .ios-install-text strong {
+      color: var(--color-primary-light);
+    }
     .ios-install-banner .ios-install-dismiss {
-      background: rgba(255, 255, 255, 0.15);
+      background: rgba(255,255,255,0.15);
       border: none;
       color: var(--color-ios-banner-text);
       border-radius: 50%;
@@ -1361,10 +1221,10 @@
       justify-content: center;
     }
     .ios-install-banner .ios-install-dismiss:active {
-      background: rgba(255, 255, 255, 0.3);
+      background: rgba(255,255,255,0.3);
     }
 
-    /* ===== Update Banner ===== */
+    /* Update Banner ("What's New") */
     .update-banner {
       position: fixed;
       top: 12px;
@@ -1379,18 +1239,24 @@
       align-items: center;
       gap: 12px;
       z-index: 1000;
-      box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+      box-shadow: 0 4px 16px rgba(0,0,0,0.3);
       animation: slideDown 0.25s ease;
     }
-    .update-banner.show { display: flex; }
+    .update-banner.show {
+      display: flex;
+    }
     .update-banner .update-icon {
       font-size: 1.2rem;
       flex-shrink: 0;
     }
-    .update-banner .update-text { flex: 1; }
-    .update-banner .update-text strong { color: var(--color-highlight-soft); }
+    .update-banner .update-text {
+      flex: 1;
+    }
+    .update-banner .update-text strong {
+      color: var(--color-highlight-soft);
+    }
     .update-banner .update-dismiss {
-      background: rgba(255, 255, 255, 0.15);
+      background: rgba(255,255,255,0.15);
       border: none;
       color: var(--color-ios-banner-text);
       border-radius: 50%;
@@ -1404,10 +1270,10 @@
       justify-content: center;
     }
     .update-banner .update-dismiss:active {
-      background: rgba(255, 255, 255, 0.3);
+      background: rgba(255,255,255,0.3);
     }
 
-    /* ===== Accessibility: prefers-reduced-motion ===== */
+    /* Accessibility: prefers-reduced-motion */
     @media (prefers-reduced-motion: reduce) {
       *, *::before, *::after {
         animation-duration: 0.01ms !important;
@@ -1417,7 +1283,27 @@
       }
     }
 
-    /* ===== Reset-Modal (bestehend, leicht angepasst) ===== */
+    /* ===== Reset confirmation modal (Issue #236) =====
+       shown as a centered modal via the .open class, same as the dashboard
+       sheet pattern. See public/js/ui-handlers.js for openResetModal(). */
+
+    .footer-actions {
+      display: flex;
+      justify-content: center;
+      margin-top: -8px;
+      margin-bottom: 8px;
+    }
+
+    /* Focus ring for keyboard navigation (Accessibility) */
+    .btn:focus-visible, .btn-add:focus-visible, .btn-danger:focus-visible,
+    .toggle-btn:focus-visible, .tab-btn:focus-visible,
+    input:focus-visible, .drill-prio-btn:focus-visible, .drill-done-btn:focus-visible,
+    .tab-close:focus-visible, .theme-toggle:focus-visible, .dashboard-close:focus-visible {
+      outline: 2.5px solid var(--color-primary);
+      outline-offset: 2px;
+    }
+
+    /* Reset modal: hidden by default, shown via .open class */
     .reset-overlay {
       display: none;
       position: fixed;
@@ -1509,6 +1395,7 @@
       gap: 12px;
       margin-bottom: 14px;
     }
+    /* --- Option cards: clickable rows with icon + title + description --- */
     .reset-option {
       position: relative;
       display: flex;
@@ -1562,6 +1449,7 @@
       color: var(--color-text-muted);
       line-height: 1.35;
     }
+    /* --- Tab reset: safe option — green accent, neutral card --- */
     .reset-option-tab::before { background: var(--color-primary); }
     .reset-option-tab:hover {
       border-color: var(--color-primary);
@@ -1573,6 +1461,7 @@
       background: var(--color-success-soft);
       color: var(--color-text-success-strong);
     }
+    /* --- All-data reset: destructive — red accent + subtle red wash + solid red on hover --- */
     .reset-option-all {
       background: var(--color-danger-bg-soft);
       border-color: var(--color-danger-soft);
@@ -1617,82 +1506,24 @@
     }
     .reset-modal-cancel:active { background: var(--color-bg-hover); }
 
-    /* ===== Settings-Modal ===== */
-    .settings-option {
-      position: relative;
-      display: flex;
+    /* --- Footer reset trigger button --- */
+    .footer-reset-btn {
+      display: inline-flex;
       align-items: center;
-      gap: 14px;
-      width: 100%;
-      padding: 16px 16px 16px 20px;
-      border: 2px solid var(--color-border);
-      border-radius: 16px;
-      background: var(--color-card-bg);
-      text-align: left;
+      gap: 8px;
+      padding: 10px 18px;
+      border: 2px solid var(--color-danger-soft);
+      border-radius: 12px;
+      background: var(--color-danger-bg-soft);
+      color: var(--color-text-danger);
+      font-size: 0.95rem;
+      font-weight: 600;
       cursor: pointer;
-      overflow: hidden;
-      transition: transform 0.12s, border-color 0.15s, background 0.15s;
+      transition: background 0.15s, border-color 0.15s, color 0.15s, transform 0.1s;
     }
-    .settings-option:active { transform: scale(0.985); }
-    .settings-option-icon {
-      flex-shrink: 0;
-      width: 44px;
-      height: 44px;
-      border-radius: 12px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 1.4rem;
-      background: var(--color-bg-soft);
-      color: var(--color-primary-dark);
+    .footer-reset-btn:hover {
+      background: var(--color-danger);
+      border-color: var(--color-danger-dark);
+      color: var(--color-card-text);
     }
-    .settings-option-body {
-      display: flex;
-      flex-direction: column;
-      gap: 3px;
-      flex: 1;
-      min-width: 0;
-    }
-    .settings-option-title {
-      font-size: 1.02rem;
-      font-weight: 700;
-      color: var(--color-text);
-    }
-    .settings-option-desc {
-      font-size: 0.82rem;
-      color: var(--color-text-muted);
-      line-height: 1.35;
-    }
-    .settings-option-info-row {
-      display: flex;
-      align-items: center;
-      gap: 6px;
-      padding: 6px 12px;
-      background: var(--color-bg-soft);
-      border-radius: var(--radius-pill);
-      font-size: 0.78rem;
-      color: var(--color-text-muted);
-    }
-    .settings-info {
-      padding: 14px 16px;
-      background: var(--color-bg-soft);
-      border-radius: 12px;
-      margin-bottom: 14px;
-      font-size: 0.85rem;
-      color: var(--color-text-muted);
-      line-height: 1.5;
-    }
-    .settings-info strong { color: var(--color-text); }
-
-    /* Focus rings */
-    .btn:focus-visible, .btn-add:focus-visible, .btn-danger:focus-visible,
-    .toggle-btn:focus-visible, .tab-btn:focus-visible,
-    input:focus-visible, .drill-prio-btn:focus-visible, .drill-done-btn:focus-visible,
-    .tab-close:focus-visible, .settings-btn:focus-visible, .bottom-nav-item:focus-visible,
-    .settings-option:focus-visible, .reset-option:focus-visible, .icon-btn:focus-visible {
-      outline: 2.5px solid var(--color-primary);
-      outline-offset: 2px;
-    }
-
-    /* Hide old dashboard sheet CSS (kept IDs removed in HTML; rules no-op) */
-    .dashboard-overlay, .dashboard-sheet { display: none !important; }
+    .footer-reset-btn:active { transform: scale(0.97); }

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1,595 +1,307 @@
     * { box-sizing: border-box; margin: 0; padding: 0; -webkit-tap-highlight-color: transparent; -webkit-user-select: none; user-select: none; }
     input, textarea { -webkit-user-select: auto; user-select: auto; }
 
-    /* ===== CSS Variables (light mode) — warme Erdtöne ===== */
+    /* ===== CSS Variables (light mode) ===== */
     :root {
-    --color-bg: #F6F2E9;
-    --color-card: #FFFDF8;
-    --color-bg-hover: #F0EBDB;
-    --color-bg-soft: #EDE7D6;
-    --color-bg-success-soft: #DEEBD8;
-    --color-ink: #33301F;
-    --color-ink-soft: #7C7458;
-    --color-ink-faint: #B0A886;
-    --color-separator: rgba(51, 48, 31, 0.11);
-    --color-border: rgba(51, 48, 31, 0.18);
-    --color-border-soft: rgba(51, 48, 31, 0.08);
-    --color-border-faint: rgba(51, 48, 31, 0.05);
-
-    --color-moss: #355E30;
-    --color-moss-dark: #254321;
-    --color-moss-bright: #5C9450;
-    --color-moss-soft: #DEEBD8;
-    --color-moss-hover: #28471F;
-
-    --color-amber: #B8892E;
-    --color-amber-dark: #8C6A22;
-    --color-amber-soft: #F3E6C7;
-
-    --color-danger: #B4483A;
-    --color-danger-dark: #8E3328;
-    --color-danger-soft: #F5E1DD;
-
-    --color-result-bg: #FFFDF8;
-
-    --color-primary: #355E30;
-    --color-primary-active: #28471F;
-    --color-primary-bright: #5C9450;
-    --color-primary-dark: #254321;
-
-    --color-text: #33301F;
-    --color-text-hint: #7C7458;
-    --color-text-muted: #B0A886;
-    --color-text-subtle: #B0A886;
-    --color-text-success: #355E30;
-    --color-text-success-strong: #254321;
-    --color-text-danger: #B4483A;
-
-    --color-ios-banner-bg: #33301F;
-    --color-ios-banner-text: #FFFDF8;
-
-    --color-warning-bg: #F3E6C7;
-    --color-warning-border: #B8892E;
-    --color-warning-text: #8C6A22;
-
-    --font-serif: 'Source Serif 4', 'Georgia', 'Times New Roman', serif;
-    --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-
-    --shadow-card: 0 1px 3px rgba(0, 0, 0, 0.04);
-    --shadow-bubble: 0 2px 8px rgba(51, 48, 31, 0.06);
-    --shadow-nav: 0 -2px 12px rgba(51, 48, 31, 0.06);
-    --shadow-soft: 0 1px 2px rgba(51, 48, 31, 0.04);
-
-    --radius-card: 20px;
-    --radius-bubble: 24px 24px 24px 6px;
+    --color-cream-bg: #efeae0;
+    --color-cream-card: #fbf8f0;
+    --color-cream-hover: #e6e0d2;
+    --color-bg: #efeae0;
+    --color-bg-card: #fbf8f0;
+    --color-bg-hover: #e6e0d2;
+    --color-bg-soft: #f3eee2;
+    --color-bg-success-soft: #d8e3c8;
+    --color-bg-soft-input: #d8e3c8;
+    --color-border: #d6c9a8;
+    --color-border-dashed: #b8d4a0;
+    --color-border-disabled: #c9c2ae;
+    --color-border-faint: #ddd5bf;
+    --color-border-soft: #e0d8c4;
+    --color-border-strong: #c8dcc0;
+    --color-card-bg: #fbf8f0;
+    --color-card-text: white;
+    --color-danger: #c0392b;
+    --color-danger-dark: #962d22;
+    --color-danger-soft: #c0392b;
+    --color-danger-bg-soft: #f5e3df;
+    --color-dashboard-done: #ffe066;
+    --color-dashboard-open-active: #1e3410;
+    --color-dashboard-remaining: #ffd700;
+    --color-divider: #d6cdb1;
+    --color-entry-diff-negative: #c0392b;
+    --color-entry-diff-positive: #4a7c23;
+    --color-highlight-soft: #a5d6a7;
+    --color-info: #1565c0;
+    --color-ios-banner-bg: #1a1a1a;
+    --color-ios-banner-text: white;
+    --color-primary: #4a7c23;
+    --color-primary-active: #6b9e45;
+    --color-primary-bright: #6aa336;
+    --color-primary-dark: #2d4a1a;
+    --color-primary-darker: #1f3a12;
+    --color-primary-hover: #2d4a1a;
+    --color-primary-light: #8bc34a;
+    --color-result-bg: #f3eee2;
+    --color-success-soft: #d8e3c8;
+    --color-sage-input: #d8e3c8;
+    --color-sage-input-focus: #c5d4b0;
+    --color-sage-badge: #b9cca3;
+    --color-sage-progress-bg: #d8e3c8;
+    --color-accent-brown: #b8704a;
+    --color-subtitle-green: #5a7a3a;
+    --color-text: #1a1a1a;
+    --color-text-danger: #c0392b;
+    --color-text-hint: #616161;
+    --color-text-hint-2: #5f6368;
+    --color-text-label: #444;
+    --color-text-label-darker: #2a2a2a;
+    --color-text-label-strong: #555;
+    --color-text-muted: #6b6b6b;
+    --color-text-subtle: #757575;
+    --color-text-success: #2e7d32;
+    --color-text-success-strong: #3d6b1a;
+    --color-update-banner-highlight: #a5d6a7;
+    --color-warning-bg: #fff3cd;
+    --color-warning-border: #ffc107;
+    --color-warning-text: #856404;
+    --font-serif: 'Georgia', 'Times New Roman', 'Garamond', serif;
+    --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    --shadow-card: 0 2px 8px rgba(0, 0, 0, 0.06);
+    --shadow-soft: 0 1px 3px rgba(0, 0, 0, 0.04);
+    --shadow-nav: 0 -2px 12px rgba(0, 0, 0, 0.06);
+    --radius-card: 18px;
     --radius-pill: 999px;
-    --radius-button: 12px;
-    --radius-input: 12px;
-
-    --max-content-width: 460px;
+    --radius-button: 14px;
     }
 
-    /* ===== CSS Variables (dark mode) ===== */
+    /* ===== CSS Variables (dark mode overrides) ===== */
     html.dark {
-    --color-bg: #1a1a14;
-    --color-card: #25251f;
-    --color-bg-hover: #2a2a23;
-    --color-bg-soft: #2a2a23;
-    --color-bg-success-soft: #1a3320;
-    --color-ink: #e8e6dc;
-    --color-ink-soft: #b8b09c;
-    --color-ink-faint: #6f6a5c;
-    --color-separator: rgba(232, 230, 220, 0.11);
-    --color-border: rgba(232, 230, 220, 0.18);
-    --color-border-soft: rgba(232, 230, 220, 0.08);
-    --color-border-faint: rgba(232, 230, 220, 0.05);
-    --color-moss: #5C9450;
-    --color-moss-dark: #8FB985;
-    --color-moss-bright: #8FB985;
-    --color-moss-soft: #1f2e1c;
-    --color-moss-hover: #6fa963;
-    --color-amber: #d4a14a;
-    --color-amber-dark: #e0b866;
-    --color-amber-soft: #3a2e16;
-    --color-danger: #c66b5e;
-    --color-danger-dark: #d2857a;
-    --color-danger-soft: #3a201c;
-    --color-result-bg: #25251f;
-    --color-primary: #5C9450;
-    --color-primary-active: #6fa963;
-    --color-primary-dark: #8FB985;
-    --color-text: #e8e6dc;
-    --color-text-hint: #b8b09c;
-    --color-text-muted: #6f6a5c;
-    --color-text-subtle: #6f6a5c;
-    --color-text-success: #8FB985;
-    --color-text-success-strong: #b8d9b2;
-    --color-text-danger: #c66b5e;
-    --color-ios-banner-bg: #25251f;
-    --color-ios-banner-text: #e8e6dc;
-    --color-warning-bg: #3a2e16;
-    --color-warning-border: #d4a14a;
-    --color-warning-text: #d4a14a;
-    --shadow-card: 0 1px 3px rgba(0, 0, 0, 0.2);
-    --shadow-bubble: 0 2px 8px rgba(0, 0, 0, 0.25);
-    --shadow-nav: 0 -2px 12px rgba(0, 0, 0, 0.3);
-    --shadow-soft: 0 1px 2px rgba(0, 0, 0, 0.15);
+    --color-accent-green: #66bb6a;
+    --color-bg: #1a1f16;
+    --color-bg-card: #252b20;
+    --color-bg-elevated: #2a3320;
+    --color-bg-hover: #333d28;
+    --color-bg-hover-dark: #333d28;
+    --color-bg-soft: #1e241a;
+    --color-bg-soft-input: #1e241a;
+    --color-bg-success-soft: #1a2e1a;
+    --color-cream-bg: #1a1f16;
+    --color-cream-card: #252b20;
+    --color-cream-hover: #333d28;
+    --color-border: #3a4030;
+    --color-border-soft: #3a4030;
+    --color-card-bg: #252b20;
+    --color-card-text: #e0e8d6;
+    --color-carryover-bright: #42a5f5;
+    --color-danger: #ef5350;
+    --color-danger-bright: #ef5350;
+    --color-danger-dark: #b71c1c;
+    --color-danger-soft: #ef5350;
+    --color-danger-bg-soft: #3a2424;
+    --color-divider: #3a4030;
+    --color-entry-diff-negative: #ef5350;
+    --color-entry-diff-positive: #66bb6a;
+    --color-highlight-soft: #a5d6a7;
+    --color-info: #42a5f5;
+    --color-ios-banner-text: white;
+    --color-primary: #5a9a2a;
+    --color-primary-active: #4a7c23;
+    --color-primary-bright: #6aa336;
+    --color-primary-dark: #a5d6a7;
+    --color-primary-darker: #5a9a2a;
+    --color-primary-hover: #3a6318;
+    --color-result-bg: #2a3320;
+    --color-summary-muted: #b0b8a8;
+    --color-sage-input: #1e2a18;
+    --color-sage-input-focus: #2a3a20;
+    --color-sage-badge: #2a3a20;
+    --color-sage-progress-bg: #2a3a20;
+    --color-accent-brown: #c97a52;
+    --color-subtitle-green: #8bc34a;
+    --color-text: #e0e8d6;
+    --color-text-danger: #ef5350;
+    --color-text-hint: #9ca896;
+    --color-text-hint-2: #9ca896;
+    --color-text-label: #9aa88a;
+    --color-text-label-darker: #c8d0b8;
+    --color-text-muted: #9ca896;
+    --color-text-placeholder: #8a9480;
+    --color-text-strong: #c8d0b8;
+    --color-text-subtle: #8a9480;
+    --color-text-success-strong: #a5d6a7;
+    --color-update-banner-bg: #4a7c23;
     }
 
     body {
       font-family: var(--font-sans);
-      background: var(--color-bg);
+      background: var(--color-cream-bg);
       min-height: 100dvh;
-      padding: max(12px, env(safe-area-inset-top)) 0 max(96px, calc(72px + env(safe-area-inset-bottom)));
+      padding: max(20px, env(safe-area-inset-top)) 20px max(120px, calc(80px + env(safe-area-inset-bottom)));
       color: var(--color-text);
       overflow-x: hidden;
-      -webkit-font-smoothing: antialiased;
     }
-    button { font-family: inherit; }
-
-    .app-layout {
-      max-width: var(--max-content-width);
+    .container {
+      max-width: 420px;
       margin: 0 auto;
-      display: flex;
-      flex-direction: column;
-      min-height: calc(100dvh - 96px);
     }
-    .scrollable-content { flex: 1; overflow-y: auto; -webkit-overflow-scrolling: touch; }
-    .content { flex: 1; overflow-y: auto; padding: 0 16px 110px; }
 
-    /* ===== Persistent Header ===== */
-    .app-header {
-      padding: 18px 16px 4px;
+    /* ===== App Header ===== */
+    .header-row {
       display: flex;
+      justify-content: space-between;
       align-items: flex-start;
-      justify-content: space-between;
-      gap: 8px;
+      margin-bottom: 16px;
+      gap: 12px;
     }
-    .app-header-meta {
-      font-size: 0.8rem;
-      color: var(--color-moss);
+    .header-titles {
+      flex: 1;
+      min-width: 0;
+    }
+    .header-meta {
+      font-size: 0.78rem;
+      color: var(--color-subtitle-green);
       font-weight: 600;
+      letter-spacing: 0.02em;
+      margin-bottom: 2px;
+      text-align: left;
     }
-    .app-header-title {
+    .header-titles h1 {
+      text-align: left;
+      color: var(--color-primary-dark);
       font-family: var(--font-serif);
+      font-size: 1.85rem;
       font-weight: 700;
-      font-size: 1.5rem;
-      letter-spacing: -0.01em;
-      margin-top: 3px;
-      color: var(--color-ink);
-      line-height: 1.15;
+      margin-bottom: 0;
+      line-height: 1.1;
     }
-    .gear-btn {
-      width: 36px;
-      height: 36px;
-      border-radius: 11px;
-      border: 1px solid var(--color-separator);
-      background: var(--color-card);
-      color: var(--color-ink);
-      font-size: 1rem;
-      cursor: pointer;
-      flex-shrink: 0;
-      margin-top: 2px;
-      transition: background 0.2s, color 0.2s, border-color 0.2s;
-    }
-    .gear-btn.open {
-      background: var(--color-moss);
-      border-color: var(--color-moss);
-      color: var(--color-card);
-    }
-
-    /* ===== Settings Panel (inline, slide-down) ===== */
-    .settings-panel {
-      display: none;
-      margin: 12px 16px 0;
-      background: var(--color-card);
-      border: 1px solid var(--color-separator);
-      border-radius: 18px;
-      padding: 18px;
-    }
-    .settings-panel.open { display: block; }
-    .settings-title {
-      font-weight: 700;
-      font-size: 0.92rem;
-      color: var(--color-ink);
-      margin-bottom: 14px;
-    }
-    .settings-row {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      padding: 11px 0;
-      border-top: 1px solid var(--color-separator);
-    }
-    .settings-row:first-of-type { border-top: none; padding-top: 0; }
-    .settings-row-title { font-size: 0.88rem; font-weight: 500; color: var(--color-ink); }
-    .settings-row-desc { font-size: 0.74rem; color: var(--color-ink-soft); margin-top: 2px; }
-
-    /* Switch (toggle) */
-    .switch {
-      width: 44px; height: 26px;
-      border-radius: 13px;
-      background: var(--color-bg);
-      border: 1px solid var(--color-separator);
-      position: relative;
-      cursor: pointer;
-      flex-shrink: 0;
-      transition: background 0.2s, border-color 0.2s;
-      padding: 0;
-    }
-    .switch::after {
-      content: '';
-      position: absolute;
-      width: 19px; height: 19px;
-      border-radius: 50%;
-      background: var(--color-ink-soft);
-      top: 2.5px; left: 3px;
-      transition: 0.2s;
-    }
-    .switch.on {
-      background: var(--color-moss-soft);
-      border-color: var(--color-moss);
-    }
-    .switch.on::after {
-      left: 21px;
-      background: var(--color-moss);
-    }
-
-    /* Settings detail (expanded inputs) */
-    .settings-detail {
-      display: none;
-      padding: 4px 0 12px;
-    }
-    .settings-detail.open { display: block; }
-    .settings-detail .input-shell { margin-top: 8px; }
-    .settings-hint {
-      font-size: 0.76rem;
-      color: var(--color-moss-dark);
-      margin-top: 7px;
-      font-weight: 500;
-    }
-    .btn-danger-block {
-      width: 100%;
-      margin-top: 14px;
-      background: var(--color-danger-soft);
-      color: var(--color-danger);
-      border: none;
-      border-radius: var(--radius-button);
-      padding: 12px 0;
-      font-weight: 600;
-      font-size: 0.88rem;
-      cursor: pointer;
-    }
-    .btn-danger-block:active {
-      background: var(--color-danger-soft);
-      filter: brightness(0.95);
-    }
-
-    /* ===== Field chips (Schläge) ===== */
-    .field-chips-wrap {
-      padding: 16px 16px 4px;
-      position: relative;
-    }
-    .field-chips {
+    .header-actions {
       display: flex;
       gap: 8px;
-      overflow-x: auto;
-      padding-bottom: 4px;
-      scrollbar-width: none;
+      align-items: flex-start;
     }
-    .field-chips::-webkit-scrollbar { display: none; }
-
-    .chip {
-      flex-shrink: 0;
-      display: inline-flex;
-      align-items: center;
-      gap: 6px;
-      background: var(--color-card);
-      border: 1px solid var(--color-separator);
-      border-radius: 20px;
-      padding: 9px 14px;
-      font-size: 0.86rem;
-      font-weight: 600;
-      color: var(--color-ink-soft);
-      cursor: pointer;
-      white-space: nowrap;
-    }
-    .chip.active {
-      background: var(--color-moss);
-      border-color: var(--color-moss);
-      color: var(--color-card);
-    }
-    .chip .dot {
-      width: 6px; height: 6px;
+    .settings-btn {
+      width: 44px;
+      height: 44px;
       border-radius: 50%;
-      background: var(--color-amber);
-    }
-    .chip.active .dot { background: var(--color-card); }
-    .chip-close {
-      flex-shrink: 0;
-      width: 16px; height: 16px;
-      border-radius: 50%;
-      background: transparent;
-      color: inherit;
+      background: var(--color-cream-card);
+      color: var(--color-primary-dark);
       border: none;
-      font-size: 0.85rem;
-      line-height: 1;
-      display: inline-flex;
+      font-size: 1.15rem;
+      cursor: pointer;
+      display: flex;
       align-items: center;
       justify-content: center;
-      cursor: pointer;
-      margin-left: 2px;
-      opacity: 0.6;
-    }
-    .chip.active .chip-close { color: var(--color-card); }
-    .chip-add, .chip-edit {
+      box-shadow: var(--shadow-card);
       flex-shrink: 0;
-      width: 38px; height: 38px;
-      border-radius: 50%;
-      background: var(--color-card);
-      border: 1px dashed var(--color-ink-faint);
-      color: var(--color-ink-soft);
-      font-size: 1.05rem;
-      font-weight: 600;
-      cursor: pointer;
+    }
+    .settings-btn:active {
+      transform: scale(0.94);
     }
 
-    /* ===== Views (only one visible at a time) ===== */
-    #view_rechner, #view_protokoll, #view_uebersicht { display: block; padding: 14px 16px 0; }
-    #view_protokoll, #view_uebersicht { display: none; }
-
-    /* ===== Cards (used everywhere) ===== */
+    /* ===== Cards (inputs + sections) ===== */
     .card {
-      background: var(--color-card);
-      border: 1px solid var(--color-separator);
+      background: var(--color-cream-card);
       border-radius: var(--radius-card);
-      padding: 18px 20px;
+      padding: 18px;
       margin-bottom: 14px;
       box-shadow: var(--shadow-card);
     }
     .card h2 {
-      font-size: 0.92rem;
-      font-weight: 600;
-      color: var(--color-ink);
-      margin-bottom: 16px;
+      font-size: 1rem;
+      color: var(--color-primary-dark);
+      margin-bottom: 14px;
       padding-bottom: 0;
       border-bottom: none;
+      font-weight: 600;
       display: flex;
       align-items: center;
-      gap: 9px;
+      gap: 10px;
     }
     .card h2 .section-badge {
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      width: 26px; height: 26px;
+      width: 28px;
+      height: 28px;
       border-radius: 8px;
-      background: var(--color-moss);
-      color: var(--color-card);
+      background: var(--color-primary-dark);
+      color: var(--color-card-text);
       font-family: var(--font-sans);
       font-weight: 700;
-      font-size: 0.78rem;
+      font-size: 0.95rem;
     }
     .card h2 .section-meta {
-      font-size: 0.78rem;
+      font-size: 0.85rem;
       color: var(--color-text-muted);
       font-weight: 500;
       margin-left: auto;
     }
-    .card-title {
-      font-size: 0.92rem;
-      font-weight: 600;
-      color: var(--color-ink);
-      margin-bottom: 16px;
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
+    .field {
+      margin-bottom: 14px;
     }
-    .card-title .edit-name {
-      background: none;
+    .field:last-child {
+      margin-bottom: 0;
+    }
+    label {
+      display: block;
+      font-size: 0.88rem;
+      font-weight: 500;
+      color: var(--color-text-label);
+      margin-bottom: 6px;
+    }
+    /* ===== Inputs (sage-green filled) ===== */
+    input[type="text"], input[type="number"], input:not([type]) {
+      width: 100%;
+      padding: 12px 14px;
+      font-size: 1.1rem;
       border: none;
-      color: var(--color-ink-soft);
-      font-size: 0.8rem;
-      cursor: pointer;
+      border-radius: var(--radius-button);
+      background: var(--color-sage-input);
+      color: var(--color-text);
+      outline: none;
+      transition: background 0.15s;
+      font-family: var(--font-sans);
       font-weight: 500;
     }
-
-    /* ===== Result bubble (speech bubble style) ===== */
-    .bubble {
-      background: var(--color-card);
-      border: 1px solid var(--color-separator);
-      border-radius: var(--radius-bubble);
-      padding: 22px;
-      margin-bottom: 14px;
-      box-shadow: var(--shadow-bubble);
+    input:focus {
+      background: var(--color-sage-input-focus);
+      box-shadow: 0 0 0 2px var(--color-primary) inset;
     }
-    .bubble-head {
-      display: flex;
-      align-items: center;
-      gap: 9px;
-      margin-bottom: 16px;
+    input::placeholder {
+      color: var(--color-text-subtle);
+      font-weight: 400;
     }
-    .avatar {
-      width: 26px; height: 26px;
-      border-radius: 8px;
-      background: var(--color-moss);
-      flex-shrink: 0;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      color: var(--color-card);
-      font-size: 0.78rem;
-      font-weight: 700;
+    input[type="text"][disabled],
+    input[type="number"][disabled],
+    input:not([type])[disabled] {
+      opacity: 0.6;
+      cursor: not-allowed;
     }
-    .bubble-head-name {
-      font-size: 0.83rem;
-      font-weight: 600;
-      color: var(--color-ink-soft);
-    }
-    .bubble-body {
-      display: flex;
-      align-items: center;
-      gap: 18px;
-    }
-
-    /* ===== Ring chart ===== */
-    .ring-wrap {
+    /* Unit suffix inside input wrapper */
+    .input-wrap {
       position: relative;
-      width: 96px; height: 96px;
-      flex-shrink: 0;
     }
-    .ring-wrap svg {
-      width: 100%; height: 100%;
-      transform: rotate(-90deg);
+    .input-wrap input {
+      padding-right: 60px;
     }
-    .ring-track {
-      fill: none;
-      stroke: var(--color-moss-soft);
-      stroke-width: 10;
-    }
-    .ring-fill {
-      fill: none;
-      stroke: url(#mossgrad);
-      stroke-width: 10;
-      stroke-linecap: round;
-      transition: stroke-dashoffset 0.55s cubic-bezier(.22, 1, .36, 1);
-    }
-    .ring-center {
+    .input-unit {
       position: absolute;
-      inset: 0;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
+      right: 14px;
+      top: 50%;
+      transform: translateY(-50%);
+      color: var(--color-text-muted);
+      font-size: 0.95rem;
       pointer-events: none;
     }
-    .ring-center .n {
-      font-family: var(--font-serif);
-      font-weight: 700;
-      font-size: 1.25rem;
-      color: var(--color-moss-dark);
-      line-height: 1;
+    .error-msg {
+      font-size: 0.8rem;
+      color: var(--color-danger);
+      margin-top: 4px;
+      min-height: 18px;
     }
-    .ring-center .u {
-      font-size: 0.58rem;
-      color: var(--color-ink-soft);
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.03em;
-      margin-top: 3px;
-    }
-
-    .bubble-text { min-width: 0; flex: 1; }
-    .bubble-text .headline {
-      font-family: var(--font-serif);
-      font-weight: 600;
-      font-size: 1.02rem;
-      color: var(--color-moss-dark);
-    }
-    .bubble-text .desc {
-      font-size: 0.83rem;
-      color: var(--color-ink-soft);
-      margin-top: 7px;
-      line-height: 1.5;
-    }
-
-    .progress-strip {
-      margin-top: 16px;
-      padding-top: 14px;
-      border-top: 1px solid var(--color-separator);
-    }
-    .bar-track {
-      height: 8px;
-      background: var(--color-moss-soft);
-      border-radius: 5px;
-      overflow: hidden;
-      margin-bottom: 8px;
-    }
-    .bar-fill {
-      height: 100%;
-      background: linear-gradient(90deg, var(--color-moss-bright), var(--color-moss-dark));
-      border-radius: 5px;
-      transition: width 0.4s ease;
-    }
-    .progress-foot {
-      display: flex;
-      justify-content: space-between;
-      font-size: 0.78rem;
-      color: var(--color-ink-soft);
-    }
-    .progress-foot .rem {
-      font-weight: 600;
-      color: var(--color-moss-dark);
-    }
-
-    /* ===== Stat row (Körner gesamt / Dünger gesamt) ===== */
-    .stat-row {
-      display: flex;
-      gap: 10px;
-      margin-bottom: 18px;
-    }
-    .stat-card {
-      flex: 1;
-      background: var(--color-card);
-      border: 1px solid var(--color-separator);
-      border-radius: 16px;
-      padding: 14px 16px;
-    }
-    .stat-card .l {
-      font-size: 0.74rem;
-      color: var(--color-ink-soft);
-    }
-    .stat-card .v {
-      font-family: var(--font-serif);
-      font-weight: 700;
-      font-size: 1.15rem;
-      margin-top: 3px;
-    }
-
-    /* ===== Inputs ===== */
-    .field { margin-bottom: 14px; }
-    .field:last-child { margin-bottom: 0; }
-    .field label {
-      display: block;
-      font-size: 0.82rem;
-      color: var(--color-ink-soft);
-      margin-bottom: 7px;
-    }
-    .input-shell {
-      display: flex;
-      align-items: center;
-      background: var(--color-moss-soft);
-      border: 1.5px solid transparent;
-      border-radius: var(--radius-input);
-      transition: border-color 0.15s, background 0.15s;
-    }
-    .input-shell:focus-within {
-      border-color: var(--color-moss);
-      background: var(--color-card);
-    }
-    .input-shell.err {
-      border-color: var(--color-danger);
-      background: var(--color-danger-soft);
-    }
-    .input-shell input {
-      flex: 1;
-      border: none;
-      background: transparent;
-      padding: 12px 14px;
-      font-size: 1rem;
-      font-weight: 500;
-      color: var(--color-ink);
-      min-width: 0;
-      outline: none;
-    }
-    .input-shell .suffix {
-      padding-right: 14px;
-      font-size: 0.82rem;
-      color: var(--color-ink-soft);
-    }
-    .hint {
-      font-size: 0.74rem;
-      color: var(--color-ink-soft);
+    .unit, .hint-text {
+      font-size: 0.8rem;
+      color: var(--color-text-hint);
       margin-top: 6px;
     }
     .hint-block {
@@ -598,121 +310,42 @@
       line-height: 1.45;
       margin-top: 10px;
     }
-    .err-text {
-      font-size: 0.76rem;
-      color: var(--color-danger);
-      margin-top: 6px;
-      font-weight: 500;
-      display: none;
-    }
-    .err-text.show { display: block; }
-    .warn-banner {
-      background: var(--color-danger-soft);
-      color: var(--color-danger);
-      border-radius: 14px;
-      padding: 12px 14px;
-      font-size: 0.82rem;
-      margin-bottom: 14px;
-      display: none;
-      line-height: 1.5;
-    }
-    .warn-banner.show { display: block; }
-
-    /* ===== Result details (hidden but kept for tests) ===== */
-    .result-details {
-      padding-top: 14px;
-      border-top: 1px solid var(--color-separator);
-      margin-top: 14px;
-    }
-    .drill-separator {
-      height: 1px;
-      background: var(--color-separator);
-      margin: 12px 0;
-    }
-    .result-row {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      padding: 8px 0;
-      border-bottom: 1px solid var(--color-separator);
-      font-size: 0.92rem;
-    }
-    .result-row:last-child { border-bottom: none; }
-    .result-row .label { font-size: 0.9rem; color: var(--color-text-label, var(--color-ink-soft)); }
-    .result-row .value {
-      font-size: 1.05rem;
-      font-weight: 700;
-      color: var(--color-moss-dark);
-    }
-    .result-row .value.small { font-size: 0.95rem; }
-    .result-row.remaining .value { color: var(--color-danger); }
-    .result-row.done .value { color: var(--color-moss); }
-    .drill-entry-inline {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      padding: 8px 0;
-      border-bottom: 1px solid var(--color-separator);
-      font-size: 0.9rem;
-    }
-    .drill-entry-inline:last-of-type { border-bottom: none; }
-    .drill-entry-inline .entry-text { color: var(--color-ink-soft); }
-    .drill-entry-inline .entry-text span { font-weight: 600; color: var(--color-moss-dark); }
-    .info { font-size: 0.8rem; color: var(--color-text-hint); text-align: center; margin-top: 8px; }
-
-    /* ===== Buttons ===== */
     .btn, .btn-add, .btn-danger, .toggle-btn, .tab-btn, .bottom-nav-item {
       touch-action: manipulation;
     }
+
+    /* ===== Primary Buttons ===== */
     .btn {
       width: 100%;
       padding: 14px;
       font-size: 1rem;
       font-weight: 700;
-      background: var(--color-moss);
-      color: var(--color-card);
+      background: var(--color-primary-dark);
+      color: var(--color-card-text);
       border: none;
       border-radius: var(--radius-button);
       cursor: pointer;
-      transition: background 0.2s, transform 0.1s;
+      transition: background 0.15s, transform 0.1s;
+      font-family: var(--font-sans);
     }
-    .btn:active { background: var(--color-moss-hover); transform: scale(0.98); }
-    .btn-primary {
-      background: var(--color-moss);
-      color: var(--color-card);
-      border: none;
-      border-radius: 12px;
-      padding: 0 20px;
-      font-weight: 600;
-      font-size: 0.92rem;
-      cursor: pointer;
-      white-space: nowrap;
+    .btn:active {
+      background: var(--color-primary-darker);
+      transform: scale(0.98);
     }
     .btn-secondary {
-      width: 100%;
-      background: var(--color-bg);
-      border: 1px solid var(--color-separator);
-      color: var(--color-ink-soft);
-      border-radius: 12px;
-      padding: 12px 0;
-      font-weight: 600;
-      font-size: 0.86rem;
-      cursor: pointer;
-      margin-top: 4px;
+      background: transparent;
+      color: var(--color-primary-dark);
+      border: 1.5px solid var(--color-primary-dark);
     }
-    .btn-add {
-      width: 100%;
-      padding: 16px;
+    .btn-secondary:active {
+      background: var(--color-bg-hover);
+    }
+    .btn-block-big {
+      padding: 16px 18px;
       font-size: 1.05rem;
-      font-weight: 700;
-      background: var(--color-moss);
-      color: var(--color-card);
-      border: none;
       border-radius: var(--radius-button);
-      cursor: pointer;
-      margin-top: 6px;
+      width: 100%;
     }
-    .btn-add:active { background: var(--color-moss-hover); }
     .btn-danger {
       background: var(--color-danger);
       width: auto;
@@ -721,36 +354,433 @@
       border-radius: 8px;
       margin-left: 8px;
     }
-    .btn-danger:active { background: var(--color-danger-dark); }
-    .reset-this-tab-btn {
-      width: 100%;
-      padding: 12px 18px;
-      font-size: 0.88rem;
-      font-weight: 600;
-      border: 1px solid var(--color-separator);
-      border-radius: var(--radius-button);
-      background: transparent;
-      color: var(--color-ink-soft);
+    .btn-danger:active {
+      background: var(--color-danger-dark);
+    }
+    .icon-btn {
+      width: 36px;
+      height: 36px;
+      border-radius: 50%;
+      border: 1px solid var(--color-border-soft);
+      background: var(--color-cream-card);
+      color: var(--color-text-muted);
       cursor: pointer;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 1rem;
+    }
+    .icon-btn:active {
+      background: var(--color-bg-hover);
+    }
+    .icon-btn.success {
+      color: var(--color-primary);
+      border-color: var(--color-primary-light);
+    }
+
+    /* ===== Result card ===== */
+    .result {
+      background: var(--color-cream-card);
+      border: none;
+    }
+    .result h2 .section-badge { background: var(--color-primary-dark); }
+
+    .result-layout {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      gap: 18px;
+      align-items: center;
+      padding: 8px 0;
+    }
+    .result-ring-chart {
+      width: 110px;
+      height: 110px;
+      position: relative;
+      flex-shrink: 0;
+    }
+    .result-ring-chart svg {
+      width: 100%;
+      height: 100%;
+      transform: rotate(-90deg);
+    }
+    .result-ring-bg {
+      fill: none;
+      stroke: var(--color-sage-progress-bg);
+      stroke-width: 10;
+    }
+    .result-ring-fg {
+      fill: none;
+      stroke: var(--color-primary-dark);
+      stroke-width: 10;
+      stroke-linecap: round;
+      transition: stroke-dashoffset 0.3s ease-out;
+    }
+    .result-ring-center {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      pointer-events: none;
+    }
+    .result-ring-value {
+      font-family: var(--font-serif);
+      font-weight: 700;
+      font-size: 1.75rem;
+      color: var(--color-primary-dark);
+      line-height: 1;
+    }
+    .result-ring-sub {
+      font-size: 0.7rem;
+      color: var(--color-text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      margin-top: 4px;
+    }
+    .result-side {
+      min-width: 0;
+    }
+    .result-side-title {
+      font-family: var(--font-serif);
+      font-weight: 700;
+      font-size: 1.1rem;
+      color: var(--color-primary-dark);
+      margin-bottom: 4px;
+    }
+    .result-side-sub {
+      font-size: 0.85rem;
+      color: var(--color-text-muted);
+      line-height: 1.35;
+    }
+    .result-side-sub.hidden { display: none; }
+    .result-progress {
+      margin-top: 16px;
+      padding-top: 14px;
+      border-top: 1px solid var(--color-divider);
+    }
+    .result-progress-bar {
+      width: 100%;
+      height: 8px;
+      border-radius: 4px;
+      background: var(--color-sage-progress-bg);
+      overflow: hidden;
+      margin-bottom: 8px;
+    }
+    .result-progress-fill {
+      height: 100%;
+      background: var(--color-primary-dark);
+      border-radius: 4px;
+      transition: width 0.3s ease-out;
+    }
+    .result-progress-legend {
+      display: flex;
+      justify-content: space-between;
+      font-size: 0.85rem;
+    }
+    .result-progress-legend .legend-used {
+      color: var(--color-text-muted);
+    }
+    .result-progress-legend .legend-open {
+      color: var(--color-text);
+      font-weight: 600;
+    }
+    .drill-separator {
+      height: 1px;
+      background: var(--color-divider);
+      margin: 12px 0;
+    }
+
+    /* Hidden result details (carryover, drill section, etc.) — keep IDs intact */
+    .result-details {
+      padding-top: 14px;
+      border-top: 1px solid var(--color-divider);
+      margin-top: 14px;
+    }
+    .result-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 8px 0;
+      border-bottom: 1px solid var(--color-divider);
+      font-size: 0.92rem;
+    }
+    .result-row:last-child {
+      border-bottom: none;
+    }
+    .result-row .label {
+      font-size: 0.9rem;
+      color: var(--color-text-label);
+    }
+    .result-row .value {
+      font-size: 1.05rem;
+      font-weight: 700;
+      color: var(--color-primary-dark);
+    }
+    .result-row .value.small {
+      font-size: 0.95rem;
+    }
+    .result-row.remaining .value {
+      color: var(--color-danger);
+    }
+    .result-row.done .value {
+      color: var(--color-primary);
+    }
+    .info {
+      font-size: 0.8rem;
+      color: var(--color-text-hint);
+      text-align: center;
       margin-top: 8px;
     }
-    .reset-this-tab-btn:active { background: var(--color-bg-hover); }
 
-    /* ===== Toggle-Button (Rechner Fahrgassen-Toggle) ===== */
+    /* ===== Two-column stat cards (Körner gesamt / Dünger gesamt) ===== */
+    .stat-row {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 12px;
+      margin-bottom: 14px;
+    }
+    .stat-card {
+      background: var(--color-cream-card);
+      border-radius: var(--radius-card);
+      padding: 16px 18px;
+      box-shadow: var(--shadow-card);
+    }
+    .stat-card-label {
+      font-size: 0.82rem;
+      color: var(--color-text-muted);
+      margin-bottom: 6px;
+      font-weight: 500;
+    }
+    .stat-card-value {
+      font-family: var(--font-serif);
+      font-weight: 700;
+      font-size: 1.35rem;
+      color: var(--color-primary-dark);
+      line-height: 1.1;
+    }
+    .stat-card-na {
+      color: var(--color-text-subtle);
+      font-family: var(--font-sans);
+    }
+
+    /* ===== Drill inline entries — kept visual structure, retinted ===== */
+    .drill-entry-inline {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 8px 0;
+      border-bottom: 1px solid var(--color-divider);
+      font-size: 0.9rem;
+    }
+    .drill-entry-inline:last-of-type {
+      border-bottom: none;
+    }
+    .drill-entry-inline .entry-text {
+      color: var(--color-text-label);
+    }
+    .drill-entry-inline .entry-text span {
+      font-weight: 600;
+      color: var(--color-primary-dark);
+    }
+
+    /* ===== Tabs (pill style) ===== */
+    .tab-bar {
+      display: flex;
+      gap: 8px;
+      margin-bottom: 16px;
+      flex-wrap: nowrap;
+      align-items: center;
+      overflow-x: auto;
+      -webkit-overflow-scrolling: touch;
+      padding: 4px 0 8px;
+      scrollbar-width: none;
+    }
+    .tab-bar::-webkit-scrollbar { display: none; }
+    .tab-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      background: var(--color-cream-card);
+      border: 1.5px solid transparent;
+      border-radius: var(--radius-pill);
+      padding: 0;
+      font-size: 0.85rem;
+      font-weight: 600;
+      color: var(--color-text);
+      cursor: pointer;
+      transition: background 0.15s, border-color 0.15s, color 0.15s, transform 0.1s;
+      max-width: 180px;
+      min-height: 40px;
+      position: relative;
+      flex-shrink: 0;
+    }
+    .tab-btn:active { transform: scale(0.97); }
+    .tab-btn.field-tab.active {
+      background: var(--color-primary-dark);
+      border-color: var(--color-primary-dark);
+      color: var(--color-card-text);
+    }
+    .tab-btn.field-tab:not(.active):hover {
+      background: var(--color-cream-hover);
+    }
+    .pill-tab-dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: var(--color-accent-brown);
+      flex-shrink: 0;
+    }
+    .tab-btn.active .pill-tab-dot {
+      background: var(--color-card-text);
+    }
+    .tab-name {
+      background: transparent;
+      border: none;
+      font-size: 0.85rem;
+      font-weight: 600;
+      color: inherit;
+      width: auto;
+      max-width: 130px;
+      padding: 10px 12px 10px 4px;
+      outline: none;
+      pointer-events: auto;
+      cursor: pointer;
+      min-height: 40px;
+      display: inline-block;
+      flex: 1;
+      text-align: left;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      -webkit-touch-callout: none;
+    }
+    .tab-name:focus {
+      cursor: text;
+      background: rgba(255, 255, 255, 0.15);
+      -webkit-user-select: text;
+      user-select: text;
+    }
+    .tab-btn:not(.active) .tab-name:focus {
+      background: var(--color-bg-soft);
+    }
+    .tab-close {
+      background: none;
+      border: none;
+      cursor: pointer;
+      color: inherit;
+      opacity: 0.55;
+      flex-shrink: 0;
+      width: 36px;
+      height: 36px;
+      min-width: 36px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 50%;
+      font-size: 0.9rem;
+      transition: opacity 0.15s, background 0.15s;
+      margin-right: 4px;
+    }
+    .tab-close:hover { opacity: 1; }
+    .tab-close:active {
+      background: rgba(0, 0, 0, 0.1);
+      opacity: 1;
+    }
+    .tab-add {
+      background: var(--color-cream-card);
+      border: 1.5px dashed var(--color-primary-dark);
+      border-radius: var(--radius-pill);
+      padding: 0 14px;
+      font-size: 0.85rem;
+      font-weight: 600;
+      color: var(--color-primary-dark);
+      cursor: pointer;
+      flex-shrink: 0;
+      min-height: 40px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .tab-add:active { background: var(--color-cream-hover); }
+
+    /* ===== Bottom Navigation (sticky) ===== */
+    .bottom-nav {
+      position: fixed;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      background: var(--color-cream-card);
+      display: flex;
+      justify-content: space-around;
+      align-items: center;
+      padding: 6px 8px calc(6px + env(safe-area-inset-bottom));
+      z-index: 80;
+      box-shadow: var(--shadow-nav);
+      border-top: 1px solid var(--color-border-soft);
+    }
+    .bottom-nav-item {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 2px;
+      padding: 8px 4px;
+      border: none;
+      background: transparent;
+      color: var(--color-text-muted);
+      font-size: 0.72rem;
+      font-weight: 500;
+      cursor: pointer;
+      transition: color 0.15s, transform 0.1s;
+      border-radius: 10px;
+    }
+    .bottom-nav-item:active { transform: scale(0.95); }
+    .bottom-nav-icon {
+      font-size: 1.25rem;
+      line-height: 1;
+      filter: grayscale(40%);
+      transition: filter 0.15s;
+    }
+    .bottom-nav-item.active {
+      color: var(--color-primary-dark);
+      font-weight: 700;
+    }
+    .bottom-nav-item.active .bottom-nav-icon {
+      filter: none;
+    }
+
+    /* ===== Views (only one visible at a time) ===== */
+    #view_rechner, #view_protokoll, #view_uebersicht {
+      display: block;
+    }
+    #view_protokoll, #view_uebersicht {
+      display: none;
+    }
+
+    /* ===== Fahrgassen / Toggle rows ===== */
     .fahrgassen-toggle {
       display: flex;
       align-items: center;
       justify-content: space-between;
-      padding: 12px 0;
+      padding: 10px 0;
       border-bottom: 1px solid var(--color-border-soft);
       margin-top: 4px;
     }
-    .fahrgassen-toggle:last-child { border-bottom: none; }
-    .fahrgassen-toggle label { margin: 0; font-size: 0.92rem; }
+    .fahrgassen-toggle:last-child {
+      border-bottom: none;
+    }
+    .fahrgassen-toggle label {
+      margin: 0;
+      font-size: 0.92rem;
+    }
     .toggle-btn {
-      width: 52px; min-height: 28px; height: 28px;
+      width: 52px;
+      min-height: 28px;
+      height: 28px;
       border-radius: 14px;
-      background: var(--color-border-disabled, var(--color-ink-faint));
+      background: var(--color-border-disabled);
       border: none;
       cursor: pointer;
       position: relative;
@@ -761,23 +791,31 @@
     .toggle-btn::after {
       content: '';
       position: absolute;
-      top: 2px; left: 2px;
-      width: 24px; height: 24px;
+      top: 2px;
+      left: 2px;
+      width: 24px;
+      height: 24px;
       border-radius: 12px;
       background: white;
       box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
       transition: left 0.2s;
     }
-    .toggle-btn.active { background: var(--color-moss-dark); }
-    .toggle-btn.active::after { left: 26px; }
+    .toggle-btn.active {
+      background: var(--color-primary-dark);
+    }
+    .toggle-btn.active::after {
+      left: 26px;
+    }
     .fahrgassen-settings {
       margin-top: 12px;
-      padding: 12px;
+      padding: 14px;
       background: var(--color-bg-soft);
       border-radius: 12px;
       display: none;
     }
-    .fahrgassen-settings.open { display: block; }
+    .fahrgassen-settings.open {
+      display: block;
+    }
     .fahrgassen-info {
       font-size: 0.8rem;
       color: var(--color-text-hint);
@@ -785,190 +823,119 @@
     }
     .fahrgassen-saved {
       font-size: 0.85rem;
-      color: var(--color-moss-dark);
+      color: var(--color-primary-dark);
       font-weight: 600;
       margin-top: 8px;
       text-align: center;
     }
-    .unit, .hint-text {
-      font-size: 0.8rem;
-      color: var(--color-text-hint);
-      margin-top: 6px;
-    }
-    .entry-diff.positive { color: var(--color-moss); font-weight: 600; }
-    .entry-diff.negative { color: var(--color-danger); font-weight: 600; }
+    .entry-diff.positive { color: var(--color-entry-diff-positive); font-weight: 600; }
+    .entry-diff.negative { color: var(--color-entry-diff-negative); font-weight: 600; }
 
-    /* ===== Drill view ===== */
-    .drill-tabs-section { margin-bottom: 14px; }
-    .drill-tabs-header {
-      font-size: 0.8rem;
-      font-weight: 600;
-      color: var(--color-ink-soft);
-      text-transform: uppercase;
-      letter-spacing: 0.03em;
-      margin: 0 2px 10px;
-    }
-    .section-title {
-      font-size: 0.8rem;
-      font-weight: 600;
-      color: var(--color-ink-soft);
-      text-transform: uppercase;
-      letter-spacing: 0.03em;
-      margin: 0 2px 10px;
-    }
-    .drill-tab-row, .prio-row {
+    /* ===== Sticky layout ===== */
+    .app-layout {
       display: flex;
-      align-items: center;
-      gap: 12px;
-      background: var(--color-card);
-      border: 1px solid var(--color-separator);
-      border-radius: 16px;
-      padding: 13px 14px;
-      margin-bottom: 8px;
+      flex-direction: column;
+      min-height: calc(100dvh - max(20px, env(safe-area-inset-top)) - max(120px, calc(80px + env(safe-area-inset-bottom))));
     }
-    .drill-tab-row.done, .prio-row.done { opacity: 0.55; }
-    .drill-prio-btn, .prio-btn {
-      width: 32px; height: 32px;
-      border-radius: 50%;
-      border: 1.5px solid var(--color-separator);
-      background: var(--color-bg);
-      color: var(--color-ink-soft);
-      font-weight: 700;
-      font-size: 0.88rem;
-      cursor: pointer;
-      flex-shrink: 0;
-      padding: 0;
+    .scrollable-content {
+      flex: 1;
+      overflow-y: auto;
+      -webkit-overflow-scrolling: touch;
     }
-    .drill-prio-btn.active, .prio-btn.active {
-      background: var(--color-amber);
-      border-color: var(--color-amber);
-      color: #fff;
-    }
-    .drill-prio-btn:active, .prio-btn:active { transform: scale(0.92); }
-    .drill-tab-row .drill-tab-name-wrap, .prio-info {
-      flex: 1; min-width: 0;
-    }
-    .drill-tab-row .drill-tab-name, .prio-info .n {
-      font-weight: 600;
-      font-size: 0.92rem;
-      display: flex;
-      align-items: center;
-      gap: 6px;
-    }
-    .drill-tab-row .drill-tab-need, .prio-info .s {
-      font-size: 0.78rem;
-      color: var(--color-ink-soft);
-      margin-top: 2px;
-    }
-    .drill-tab-row .drill-tab-need.done, .prio-info .s.fertig {
-      color: var(--color-moss-dark);
-      font-weight: 600;
-    }
-    .drill-prio-badge, .sink-badge {
-      display: inline-block;
-      padding: 2px 7px;
+    .save-error-banner {
+      background: var(--color-warning-bg);
+      border: 2px solid var(--color-warning-border);
       border-radius: 8px;
-      background: var(--color-moss-soft);
-      color: var(--color-moss-dark);
-      font-size: 0.62rem;
-      font-weight: 700;
-      text-transform: uppercase;
-      letter-spacing: 0.03em;
-      margin-left: 4px;
-    }
-    .drill-done-btn, .done-toggle {
-      width: 30px; height: 30px;
-      border-radius: 9px;
-      border: 1.5px solid var(--color-separator);
-      background: var(--color-card);
-      color: var(--color-moss);
+      padding: 10px 14px;
+      margin-bottom: 12px;
       font-size: 0.9rem;
-      cursor: pointer;
-      flex-shrink: 0;
-      padding: 0;
-    }
-    .drill-done-btn.active, .done-toggle.on {
-      background: var(--color-moss);
-      border-color: var(--color-moss);
-      color: var(--color-card);
-    }
-    .drill-done-btn:active, .done-toggle:active { transform: scale(0.96); }
-    .drill-machine-row {
-      display: flex;
-      gap: 10px;
-    }
-    .drill-machine-row .field { flex: 1; margin-bottom: 0; }
-
-    .add-entry-row { display: flex; gap: 10px; }
-    .add-entry-row .input-shell { flex: 1; }
-
-    .entry-list { margin-bottom: 0; }
-    .entry {
+      color: var(--color-warning-text);
       display: flex;
       align-items: center;
-      justify-content: space-between;
-      background: var(--color-card);
-      border: 1px solid var(--color-separator);
-      border-radius: 14px;
-      padding: 12px 14px;
-      margin-bottom: 8px;
+      gap: 8px;
+      animation: slideDown 0.2s ease;
     }
-    .entry .info .d { font-size: 0.78rem; color: var(--color-ink-soft); }
-    .entry .info .v { font-size: 0.92rem; font-weight: 600; margin-top: 2px; }
-    .entry .remove {
-      width: 28px; height: 28px;
-      border-radius: 50%;
+    .save-error-banner button {
+      margin-left: auto;
+      background: none;
       border: none;
-      background: var(--color-bg);
-      color: var(--color-danger);
-      font-size: 0.9rem;
+      font-size: 1rem;
       cursor: pointer;
-      flex-shrink: 0;
+      color: var(--color-warning-text);
+      padding: 0 4px;
     }
-    .empty-note {
-      text-align: center;
-      padding: 18px 10px;
-      color: var(--color-ink-faint);
-      font-size: 0.86rem;
+    @keyframes slideDown {
+      from { opacity: 0; transform: translateY(-8px); }
+      to { opacity: 1; transform: translateY(0); }
     }
 
-    /* ===== Drill log / entries ===== */
+    .version-footer {
+      text-align: center;
+      color: var(--color-text-hint);
+      font-size: 0.75rem;
+      margin-top: 14px;
+      padding-bottom: 8px;
+    }
+
+    /* ===== Drill-Log (Protokoll view) ===== */
     .drill-entry {
       display: flex;
       justify-content: space-between;
       align-items: center;
-      padding: 10px 0;
-      border-bottom: 1px solid var(--color-border-soft);
-      font-size: 0.9rem;
-    }
-    .drill-entry:last-of-type { border-bottom: none; }
-    .drill-entry .entry-text { color: var(--color-text-label, var(--color-ink-soft)); }
-    .drill-entry .entry-text span { font-weight: 600; color: var(--color-moss-dark); }
-    .drill-entry-tab-header {
-      font-size: 0.78rem;
-      font-weight: 700;
-      text-transform: uppercase;
-      letter-spacing: 0.06em;
-      color: var(--color-ink-soft);
-      padding: 12px 0 6px 0;
-      border-bottom: 1px solid var(--color-border-faint);
-      margin-bottom: 6px;
+      padding: 8px 0;
     }
     #drill_machine_log {
       margin-bottom: 12px;
       padding-bottom: 8px;
       border-bottom: 2px solid var(--color-border-strong);
     }
+    .drill-entry-tab-header {
+      font-size: 0.78rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: var(--color-text-muted);
+      padding: 12px 0 6px 0;
+      border-bottom: 1px solid var(--color-border-faint);
+      margin-bottom: 6px;
+    }
+    .drill-entry {
+      border-bottom: 1px solid var(--color-border-soft);
+      font-size: 0.92rem;
+    }
+    .drill-entry:last-of-type {
+      border-bottom: none;
+    }
+    .drill-entry .entry-text {
+      color: var(--color-text-label);
+    }
+    .drill-entry .entry-text span {
+      font-weight: 600;
+      color: var(--color-primary-dark);
+    }
     .drill-prognose {
       font-size: 0.78rem;
-      color: var(--color-ink-soft);
+      color: var(--color-text-muted);
       padding: 2px 0 8px 4px;
     }
-    .drill-prognose span { display: inline-block; margin-right: 10px; }
-    .drill-prognose .prog-label { font-weight: 600; color: var(--color-text-label-strong, var(--color-ink)); }
-    .drill-prognose .prog-val { color: var(--color-moss-dark); font-weight: 700; }
-    .drill-empty { text-align: center; color: var(--color-text-hint); font-size: 0.9rem; padding: 14px 0; }
-
+    .drill-prognose span {
+      display: inline-block;
+      margin-right: 10px;
+    }
+    .drill-prognose .prog-label {
+      font-weight: 600;
+      color: var(--color-text-label-strong);
+    }
+    .drill-prognose .prog-val {
+      color: var(--color-primary-dark);
+      font-weight: 700;
+    }
+    .drill-empty {
+      text-align: center;
+      color: var(--color-text-hint);
+      font-size: 0.9rem;
+      padding: 14px 0;
+    }
     .drill-summary {
       background: var(--color-bg-soft);
       border-radius: 12px;
@@ -998,147 +965,322 @@
       color: var(--color-text-success-strong);
       font-weight: 600;
     }
-    .drill-savings { font-size: 0.88rem; color: var(--color-text-success-strong); font-weight: 600; padding: 2px 0; }
-    .drill-savings .entry-text::before { content: '↘ '; }
-    .drill-carryover { font-size: 0.88rem; color: var(--color-amber-dark); font-weight: 600; padding: 2px 0; }
-    .drill-carryover .entry-text::before { content: '↗ '; }
-    .drill-excess { font-size: 0.78rem; color: var(--color-text-danger); text-transform: uppercase; }
-    .drill-excess .entry-text::before { content: '↘ '; }
-    .carryover-hint { color: var(--color-info); }
-    .excess-hint { color: var(--color-danger); }
-    .net-totals-line { font-size: 0.9rem; font-weight: 600; padding: 2px 0; }
-    .net-totals-savings { color: var(--color-text-success-strong); }
-    .net-totals-excess { color: var(--color-text-danger); }
-    .r-carryover-row { font-size: 0.85rem; padding: 2px 0; font-weight: 600; }
-    .r-carryover-savings { color: var(--color-text-success); }
-    .r-carryover-carryover { color: var(--color-info); }
-    .r-carryover-excess { color: var(--color-danger); }
-    .summary-muted { font-size: 0.85rem; font-weight: 600; color: var(--color-text-label-strong, var(--color-ink)); }
-    .drill-total-summary {
-      margin-bottom: 8px;
-      font-weight: bold;
-    }
 
-    /* ===== Dashboard / Übersicht view ===== */
-    .dash-hero {
-      background: linear-gradient(155deg, var(--color-moss) 0%, #1E3A1B 100%);
-      border-radius: 22px;
-      padding: 22px;
-      color: #fff;
-      margin-bottom: 16px;
-      box-shadow: var(--shadow-bubble);
+    /* Maschinen-Log Sub-Section (innerhalb #drill_section) */
+    .drill-log-subsection {
+      margin-top: 18px;
+      padding-top: 16px;
+      border-top: 2px solid var(--color-border-strong);
     }
-    .dash-hero .label {
-      font-size: 0.8rem;
-      color: rgba(255, 255, 255, 0.75);
-    }
-    .dash-hero .value {
-      font-family: var(--font-serif);
+    .drill-log-subsection .subsection-header {
+      font-size: 0.78rem;
       font-weight: 700;
-      font-size: 2.1rem;
-      margin-top: 4px;
-      line-height: 1.05;
-    }
-    .dash-hero .sub {
-      font-size: 0.8rem;
-      color: rgba(255, 255, 255, 0.7);
-      margin-top: 8px;
-    }
-    .dash-stat-row {
-      display: flex;
-      gap: 10px;
-      margin-top: 16px;
-    }
-    .dash-stat {
-      flex: 1;
-      background: rgba(255, 255, 255, 0.1);
-      border-radius: 12px;
-      padding: 10px 12px;
-    }
-    .dash-stat .l { font-size: 0.7rem; color: rgba(255, 255, 255, 0.7); }
-    .dash-stat .v { font-weight: 700; font-size: 1rem; margin-top: 2px; }
-
-    .field-card {
-      background: var(--color-card);
-      border: 1px solid var(--color-separator);
-      border-radius: 16px;
-      padding: 16px;
-      margin-bottom: 10px;
-      cursor: pointer;
-    }
-    .field-card-head {
-      display: flex;
-      justify-content: space-between;
-      align-items: baseline;
-      margin-bottom: 8px;
-      gap: 8px;
-    }
-    .field-card-head .n {
-      font-weight: 700;
-      font-size: 0.98rem;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: var(--color-text-muted);
+      border-bottom: none;
+      padding: 0;
+      margin: 0 0 10px 0;
       display: flex;
       align-items: center;
-      gap: 6px;
+      gap: 8px;
     }
-    .field-card-head .ha {
-      font-size: 0.8rem;
-      color: var(--color-ink-soft);
+    .drill-savings {
+      font-size: 0.88rem;
+      color: var(--color-text-success-strong);
+      font-weight: 600;
+      padding: 2px 0;
+    }
+    .drill-savings .entry-text::before { content: '↘ '; }
+    .drill-carryover {
+      font-size: 0.88rem;
+      color: var(--color-info);
+      font-weight: 600;
+      padding: 2px 0;
+    }
+    .drill-carryover .entry-text::before { content: '↗ '; }
+    .drill-excess {
+      font-size: 0.78rem;
+      color: var(--color-text-danger);
+      text-transform: uppercase;
+    }
+    .drill-excess .entry-text::before { content: '↘ '; }
+    .carryover-hint { color: var(--color-info); }
+    .excess-hint { color: var(--color-danger-soft); }
+    .net-totals-line {
+      font-size: 0.9rem;
+      font-weight: 600;
+      padding: 2px 0;
+    }
+    .net-totals-savings { color: var(--color-text-success-strong); }
+    .net-totals-excess { color: var(--color-text-danger); }
+    .r-carryover-row {
+      font-size: 0.85rem;
+      padding: 2px 0;
+      font-weight: 600;
+    }
+    .r-carryover-savings { color: var(--color-text-success); }
+    .r-carryover-carryover { color: var(--color-info); }
+    .r-carryover-excess { color: var(--color-danger-soft); }
+    .summary-muted {
+      font-size: 0.85rem;
+      font-weight: 600;
+      color: var(--color-text-label-strong);
+    }
+    .drill-summary-total {
+      margin-top: 10px;
+      padding-top: 10px;
+      border-top: 2px solid var(--color-primary);
+      font-size: 0.95rem;
+      font-weight: 700;
+      color: var(--color-primary-dark);
+      text-align: center;
+    }
+
+    .inline-row {
+      display: flex;
+      gap: 8px;
+    }
+    .inline-row .field {
+      flex: 1;
+      margin-bottom: 8px;
+    }
+    .drill-machine-row {
+      display: flex;
+      gap: 10px;
+    }
+    .drill-machine-row .field {
+      flex: 1;
+      margin-bottom: 0;
+    }
+
+    /* ===== Schlag-Cards (drill prio list) ===== */
+    .drill-tabs-section {
+      margin: 0 0 14px 0;
+    }
+    .drill-tabs-header {
+      font-size: 0.78rem;
+      color: var(--color-text-label-strong);
+      margin-bottom: 8px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+    }
+    .drill-tab-row {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin-bottom: 8px;
+      padding: 14px 14px 14px 12px;
+      border-radius: 14px;
+      background: var(--color-cream-card);
+      box-shadow: var(--shadow-soft);
+      transition: background 0.15s;
+    }
+    .drill-tab-row.done {
+      opacity: 0.55;
+      background: var(--color-bg-soft);
+    }
+    .drill-prio-btn {
+      width: 36px;
+      height: 36px;
+      border-radius: 50%;
+      border: 1.5px solid var(--color-border-soft);
+      background: var(--color-cream-card);
+      font-size: 0.92rem;
+      font-weight: 700;
+      color: var(--color-text-muted);
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+      transition: all 0.15s;
+      touch-action: manipulation;
+    }
+    .drill-prio-btn.active {
+      background: var(--color-primary-dark);
+      border-color: var(--color-primary-dark);
+      color: var(--color-card-text);
+    }
+    .drill-prio-btn:active { transform: scale(0.92); }
+    .drill-tab-row .drill-tab-name-wrap {
+      flex: 1;
+      min-width: 0;
+    }
+    .drill-tab-row .drill-tab-name {
+      font-family: var(--font-serif);
+      font-weight: 700;
+      font-size: 1.02rem;
+      color: var(--color-primary-dark);
+    }
+    .drill-tab-row .drill-tab-need {
+      font-size: 0.78rem;
+      color: var(--color-text-muted);
+      margin-top: 3px;
+    }
+    .drill-tab-row .drill-tab-need.done {
+      color: var(--color-text-success-strong);
+      font-weight: 700;
+    }
+    .drill-tab-row .drill-prio-badge {
+      display: inline-block;
+      padding: 2px 8px;
+      border-radius: var(--radius-pill);
+      background: var(--color-sage-badge);
+      color: var(--color-primary-darker);
+      font-size: 0.7rem;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      margin-left: 6px;
+    }
+    .drill-tab-row .drill-tab-values {
+      display: none;
+    }
+    .drill-done-btn {
+      flex-shrink: 0;
+      padding: 6px 10px;
+      font-size: 0.78rem;
+      font-weight: 600;
+      border-radius: 8px;
+      border: 1px solid var(--color-border-soft);
+      background: var(--color-cream-card);
+      color: var(--color-text-label-strong);
+      cursor: pointer;
+      transition: background 0.15s, border-color 0.15s, color 0.15s;
+      touch-action: manipulation;
       white-space: nowrap;
     }
-    .field-card .bar-track { height: 7px; margin-bottom: 8px; }
-    .field-card-foot {
-      display: flex;
-      justify-content: space-between;
-      font-size: 0.78rem;
-      color: var(--color-ink-soft);
+    .drill-done-btn:hover { border-color: var(--color-primary); }
+    .drill-done-btn.active {
+      background: var(--color-primary-dark);
+      border-color: var(--color-primary-dark);
+      color: var(--color-card-text);
     }
-    .field-card-foot .done { color: var(--color-moss); font-weight: 600; }
-
-    /* legacy dashboard wrapper classes for tests */
-    .dashboard-reiter-card {
-      background: var(--color-card);
-      border: 1px solid var(--color-separator);
-      border-radius: 16px;
+    .drill-done-btn:active { transform: scale(0.96); }
+    .btn-add {
+      width: 100%;
       padding: 16px;
-      margin-bottom: 10px;
+      font-size: 1.05rem;
+      font-weight: 700;
+      background: var(--color-primary-dark);
+      color: var(--color-card-text);
+      border: none;
+      border-radius: var(--radius-button);
+      cursor: pointer;
+      margin-top: 6px;
+      font-family: var(--font-sans);
+    }
+    .btn-add:active { background: var(--color-primary-darker); }
+
+    /* ===== Reset-tab button (replaces footer reset) ===== */
+    .reset-this-tab-btn {
+      width: 100%;
+      padding: 14px 18px;
+      font-size: 0.95rem;
+      font-weight: 600;
+      border: 1.5px solid var(--color-border-soft);
+      border-radius: var(--radius-button);
+      background: transparent;
+      color: var(--color-text-label-strong);
+      cursor: pointer;
+      margin-top: 8px;
+      transition: background 0.15s, color 0.15s, border-color 0.15s;
+    }
+    .reset-this-tab-btn:active {
+      background: var(--color-cream-hover);
+    }
+
+    /* ===== Übersicht View ===== */
+    .uebersicht-summary {
+      background: linear-gradient(160deg, var(--color-primary-dark), var(--color-primary));
+      border-radius: 18px;
+      padding: 22px;
+      color: var(--color-card-text);
+      margin-bottom: 16px;
+      box-shadow: var(--shadow-card);
+    }
+    .uebersicht-summary-label {
+      font-size: 0.82rem;
+      opacity: 0.85;
+      font-weight: 500;
+      margin-bottom: 6px;
+    }
+    .uebersicht-summary-value {
+      font-family: var(--font-serif);
+      font-size: 2.2rem;
+      font-weight: 700;
+      line-height: 1.05;
+      margin-bottom: 8px;
+    }
+    .uebersicht-summary-meta {
+      font-size: 0.85rem;
+      opacity: 0.85;
+    }
+    .uebersicht-stat-tiles {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 12px;
+      margin-bottom: 16px;
+    }
+    .uebersicht-stat-tile {
+      background: var(--color-primary-dark);
+      border-radius: 14px;
+      padding: 14px 16px;
+      color: var(--color-card-text);
+    }
+    .uebersicht-stat-tile-label {
+      font-size: 0.78rem;
+      opacity: 0.85;
+      font-weight: 500;
+      margin-bottom: 4px;
+    }
+    .uebersicht-stat-tile-value {
+      font-family: var(--font-serif);
+      font-size: 1.3rem;
+      font-weight: 700;
+      line-height: 1.1;
+    }
+    .uebersicht-section-header {
+      font-size: 0.78rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: var(--color-text-muted);
+      margin: 16px 4px 8px;
+    }
+    /* Per-tab progress card — keeps dashboard-reiter-card class for test compat */
+    .dashboard-reiter-card {
+      margin: 0 0 12px 0;
+      background: var(--color-cream-card);
+      border: none;
+      border-radius: var(--radius-card);
+      padding: 16px 18px;
+      box-shadow: var(--shadow-card);
     }
     .dashboard-reiter-name {
+      font-family: var(--font-serif);
       font-weight: 700;
-      color: var(--color-moss-dark);
-      font-size: 0.98rem;
+      color: var(--color-primary-dark);
+      font-size: 1.05rem;
       margin-bottom: 4px;
       display: flex;
       align-items: center;
       justify-content: space-between;
+      gap: 8px;
     }
     .dashboard-reiter-name .ha-badge {
-      font-size: 0.8rem;
-      color: var(--color-ink-soft);
-      font-weight: 500;
-    }
-    .dashboard-summary-stat {
-      flex: 1;
-      background: rgba(255, 255, 255, 0.1);
-      border-radius: 12px;
-      padding: 10px 12px;
-    }
-    .dashboard-summary-label {
-      font-size: 0.7rem;
-      color: rgba(255, 255, 255, 0.7);
-    }
-    .dashboard-summary-value { font-weight: 700; font-size: 1rem; margin-top: 2px; }
-    .dashboard-summary-value.remaining { color: #ffd54f; }
-    .dashboard-summary-value.done { color: #ffe066; }
-    .dashboard-summary { display: none; }
-    .dashboard-stats-header {
-      font-size: 0.8rem;
+      font-family: var(--font-sans);
+      font-size: 0.85rem;
       font-weight: 600;
-      color: var(--color-ink-soft);
-      text-transform: uppercase;
-      letter-spacing: 0.03em;
-      margin: 16px 0 10px;
+      color: var(--color-text-muted);
     }
-    .dashboard-reiter-stats { display: block; margin-bottom: 8px; }
+    .dashboard-reiter-stats {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 8px;
+      margin-bottom: 8px;
+    }
     .dashboard-stat {
       background: transparent;
       border-radius: 0;
@@ -1149,14 +1291,18 @@
       color: var(--color-text-hint);
       margin-bottom: 2px;
     }
-    .dashboard-stat-value { font-size: 0.95rem; font-weight: 600; }
+    .dashboard-stat-value {
+      font-size: 0.95rem;
+      font-weight: 600;
+      color: var(--color-text);
+    }
     .dashboard-stat-value.remaining { color: var(--color-danger); }
-    .dashboard-stat-value.done { color: var(--color-moss); }
+    .dashboard-stat-value.done { color: var(--color-primary); }
     .dashboard-stat-value.na { color: var(--color-text-subtle); }
     .dashboard-progress-bar {
       grid-column: 1 / -1;
       height: 8px;
-      background: var(--color-moss-soft);
+      background: var(--color-sage-progress-bg);
       border-radius: 4px;
       overflow: hidden;
       margin-top: 4px;
@@ -1164,172 +1310,119 @@
     }
     .dashboard-progress-fill {
       height: 100%;
-      background: var(--color-moss);
+      background: var(--color-primary-dark);
       border-radius: 4px;
       transition: width 0.3s;
     }
     .dashboard-progress-legend {
       display: flex;
       justify-content: space-between;
-      font-size: 0.78rem;
-      color: var(--color-ink-soft);
+      font-size: 0.85rem;
+      color: var(--color-text-muted);
     }
-    .dashboard-progress-legend strong { color: var(--color-ink); }
-    .dashboard-empty {
-      text-align: center;
-      color: var(--color-text-hint);
-      font-size: 0.9rem;
-      padding: 32px 20px;
+    .dashboard-progress-legend strong {
+      color: var(--color-text);
     }
 
-    /* ===== Bottom Navigation (sticky, blur) ===== */
-    .bottom-nav {
-      position: sticky;
-      bottom: 0;
-      background: rgba(246, 242, 233, 0.92);
-      backdrop-filter: blur(16px);
-      -webkit-backdrop-filter: blur(16px);
-      border-top: 1px solid var(--color-separator);
-      display: flex;
-      padding: 8px 8px calc(8px + env(safe-area-inset-bottom));
-      z-index: 50;
-    }
-    html.dark .bottom-nav { background: rgba(26, 26, 20, 0.92); }
-    .nav-btn {
-      flex: 1;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      gap: 3px;
-      background: none;
-      border: none;
-      padding: 8px 4px;
-      color: var(--color-ink-faint);
-      font-size: 0.7rem;
-      font-weight: 600;
-      cursor: pointer;
-    }
-    .nav-btn .ic { font-size: 1.15rem; line-height: 1; }
-    .nav-btn.active { color: var(--color-moss); }
-
-    /* ===== Tabs (Schläge) — kept for back-compat ===== */
-    .tab-bar {
-      display: flex;
-      gap: 8px;
-      margin-bottom: 16px;
-      flex-wrap: nowrap;
-      align-items: center;
-      overflow-x: auto;
-      -webkit-overflow-scrolling: touch;
-      padding: 4px 0 8px;
-      scrollbar-width: none;
-    }
-    .tab-bar::-webkit-scrollbar { display: none; }
-    .tab-bar-left { display: flex; gap: 6px; flex-wrap: nowrap; align-items: center; flex: 1; overflow-x: auto; scrollbar-width: none; }
-    .tab-bar-left::-webkit-scrollbar { display: none; }
-    .tab-btn {
-      display: inline-flex;
-      align-items: center;
-      gap: 6px;
-      background: var(--color-card);
-      border: 1px solid var(--color-separator);
-      border-radius: var(--radius-pill);
-      padding: 0;
+    /* ===== iOS Install Banner ===== */
+    .ios-install-banner {
+      position: fixed;
+      bottom: 90px;
+      left: 12px;
+      right: 12px;
+      background: var(--color-ios-banner-bg);
+      color: var(--color-ios-banner-text);
+      padding: 12px 16px;
+      border-radius: 12px;
       font-size: 0.85rem;
-      font-weight: 600;
-      color: var(--color-ink-soft);
-      cursor: pointer;
-      transition: background 0.15s, border-color 0.15s, color 0.15s, transform 0.1s;
-      max-width: 180px;
-      min-height: 38px;
-      position: relative;
-      flex-shrink: 0;
+      display: none;
+      align-items: center;
+      gap: 12px;
+      z-index: 999;
+      box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
     }
-    .tab-btn:active { transform: scale(0.97); }
-    .tab-btn.field-tab.active {
-      background: var(--color-moss);
-      border-color: var(--color-moss);
-      color: var(--color-card);
+    .ios-install-banner.show {
+      display: flex;
     }
-    .tab-btn.field-tab:not(.active):hover { background: var(--color-bg-hover); }
-    .pill-tab-dot {
-      width: 8px; height: 8px;
-      border-radius: 50%;
-      background: var(--color-amber);
-      flex-shrink: 0;
-    }
-    .tab-btn.active .pill-tab-dot { background: var(--color-card); }
-    .tab-name {
-      background: transparent;
-      border: none;
-      font-size: 0.85rem;
-      font-weight: 600;
-      color: inherit;
-      max-width: 130px;
-      padding: 9px 6px 9px 4px;
-      outline: none;
-      pointer-events: auto;
-      cursor: pointer;
-      min-height: 38px;
-      display: inline-block;
-      flex: 1;
-      text-align: left;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      -webkit-touch-callout: none;
-    }
-    .tab-name:focus {
-      cursor: text;
+    .ios-install-banner .ios-install-text { flex: 1; }
+    .ios-install-banner .ios-install-text strong { color: var(--color-primary-light); }
+    .ios-install-banner .ios-install-dismiss {
       background: rgba(255, 255, 255, 0.15);
-      -webkit-user-select: text;
-      user-select: text;
-    }
-    .tab-btn:not(.active) .tab-name:focus { background: var(--color-bg-soft); }
-    .tab-close {
-      background: none;
       border: none;
+      color: var(--color-ios-banner-text);
+      border-radius: 50%;
+      width: 28px;
+      height: 28px;
       cursor: pointer;
-      color: inherit;
-      opacity: 0.55;
+      font-size: 1rem;
       flex-shrink: 0;
-      width: 36px; height: 36px; min-width: 36px;
       display: flex;
       align-items: center;
       justify-content: center;
-      border-radius: 50%;
-      font-size: 0.9rem;
-      transition: opacity 0.15s, background 0.15s;
-      margin-right: 4px;
     }
-    .tab-close:hover { opacity: 1; }
-    .tab-close:active {
-      background: rgba(0, 0, 0, 0.1);
-      opacity: 1;
+    .ios-install-banner .ios-install-dismiss:active {
+      background: rgba(255, 255, 255, 0.3);
     }
-    .tab-add {
-      background: var(--color-card);
-      border: 1.5px dashed var(--color-ink-faint);
-      border-radius: 18px;
-      padding: 0 14px;
-      font-size: 0.78rem;
-      font-weight: 600;
-      color: var(--color-moss);
-      cursor: pointer;
+
+    /* ===== Update Banner ===== */
+    .update-banner {
+      position: fixed;
+      top: 12px;
+      left: 12px;
+      right: 12px;
+      background: var(--color-primary-dark);
+      color: var(--color-ios-banner-text);
+      padding: 12px 16px;
+      border-radius: 12px;
+      font-size: 0.85rem;
+      display: none;
+      align-items: center;
+      gap: 12px;
+      z-index: 1000;
+      box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+      animation: slideDown 0.25s ease;
+    }
+    .update-banner.show { display: flex; }
+    .update-banner .update-icon {
+      font-size: 1.2rem;
       flex-shrink: 0;
-      min-height: 36px;
-      display: inline-flex;
+    }
+    .update-banner .update-text { flex: 1; }
+    .update-banner .update-text strong { color: var(--color-highlight-soft); }
+    .update-banner .update-dismiss {
+      background: rgba(255, 255, 255, 0.15);
+      border: none;
+      color: var(--color-ios-banner-text);
+      border-radius: 50%;
+      width: 28px;
+      height: 28px;
+      cursor: pointer;
+      font-size: 1rem;
+      flex-shrink: 0;
+      display: flex;
       align-items: center;
       justify-content: center;
     }
-    .tab-add:active { background: var(--color-bg-hover); }
+    .update-banner .update-dismiss:active {
+      background: rgba(255, 255, 255, 0.3);
+    }
 
-    /* ===== Reset-Modal (kept) ===== */
+    /* ===== Accessibility: prefers-reduced-motion ===== */
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+      }
+    }
+
+    /* ===== Reset-Modal (bestehend, leicht angepasst) ===== */
     .reset-overlay {
       display: none;
       position: fixed;
       inset: 0;
-      background: rgba(51, 48, 31, 0.55);
+      background: rgba(10, 16, 6, 0.55);
       backdrop-filter: blur(2px);
       -webkit-backdrop-filter: blur(2px);
       z-index: 200;
@@ -1343,11 +1436,11 @@
       top: 50%;
       transform: translate(-50%, -50%);
       width: min(94vw, 440px);
-      background: var(--color-card);
+      background: var(--color-card-bg);
       border-radius: 22px;
       padding: 28px 24px 18px;
       z-index: 201;
-      box-shadow: 0 24px 60px rgba(51, 48, 31, 0.45), 0 2px 8px rgba(0, 0, 0, 0.1);
+      box-shadow: 0 24px 60px rgba(0, 0, 0, 0.45), 0 2px 8px rgba(0, 0, 0, 0.1);
       text-align: center;
     }
     .reset-modal.open {
@@ -1356,17 +1449,22 @@
     }
     @keyframes popIn {
       from { opacity: 0; transform: translate(-50%, -50%) scale(0.92); }
-      to { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+      to   { opacity: 1; transform: translate(-50%, -50%) scale(1); }
     }
-    @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+    @keyframes fadeIn {
+      from { opacity: 0; }
+      to   { opacity: 1; }
+    }
     .reset-modal-x {
       position: absolute;
-      top: 14px; right: 14px;
-      width: 36px; height: 36px;
+      top: 14px;
+      right: 14px;
+      width: 36px;
+      height: 36px;
       border: none;
       border-radius: 50%;
       background: var(--color-bg-soft);
-      color: var(--color-text-muted, var(--color-ink-soft));
+      color: var(--color-text-muted);
       font-size: 1rem;
       cursor: pointer;
       display: flex;
@@ -1374,10 +1472,14 @@
       justify-content: center;
       transition: background 0.15s, color 0.15s, transform 0.1s;
     }
-    .reset-modal-x:hover { background: var(--color-bg-hover); color: var(--color-ink); }
+    .reset-modal-x:hover {
+      background: var(--color-bg-hover);
+      color: var(--color-text);
+    }
     .reset-modal-x:active { transform: scale(0.9); }
     .reset-modal-badge {
-      width: 64px; height: 64px;
+      width: 64px;
+      height: 64px;
       border-radius: 50%;
       background: var(--color-warning-bg);
       color: var(--color-warning-text);
@@ -1386,17 +1488,17 @@
       justify-content: center;
       font-size: 2rem;
       margin: 0 auto 14px;
-      box-shadow: 0 0 0 6px rgba(184, 137, 46, 0.12);
+      box-shadow: 0 0 0 6px rgba(255, 193, 7, 0.12);
     }
     .reset-modal-title {
       font-size: 1.25rem;
       font-weight: 800;
-      color: var(--color-moss-dark);
+      color: var(--color-primary-dark);
       margin: 0 0 6px;
     }
     .reset-modal-subtitle {
       font-size: 0.88rem;
-      color: var(--color-text-muted, var(--color-ink-soft));
+      color: var(--color-text-muted);
       line-height: 1.45;
       margin: 0 auto 22px;
       max-width: 320px;
@@ -1416,7 +1518,7 @@
       padding: 16px 16px 16px 20px;
       border: 2px solid var(--color-border);
       border-radius: 16px;
-      background: var(--color-card);
+      background: var(--color-card-bg);
       text-align: left;
       cursor: pointer;
       overflow: hidden;
@@ -1425,7 +1527,9 @@
     .reset-option::before {
       content: '';
       position: absolute;
-      left: 0; top: 0; bottom: 0;
+      left: 0;
+      top: 0;
+      bottom: 0;
       width: 5px;
       border-radius: 16px 0 0 16px;
       transition: width 0.15s;
@@ -1433,7 +1537,8 @@
     .reset-option:active { transform: scale(0.985); }
     .reset-option-icon {
       flex-shrink: 0;
-      width: 44px; height: 44px;
+      width: 44px;
+      height: 44px;
       border-radius: 12px;
       display: flex;
       align-items: center;
@@ -1447,29 +1552,51 @@
       gap: 3px;
       min-width: 0;
     }
-    .reset-option-title { font-size: 1.02rem; font-weight: 700; color: var(--color-ink); }
-    .reset-option-desc { font-size: 0.82rem; color: var(--color-text-muted, var(--color-ink-soft)); line-height: 1.35; }
-    .reset-option-tab::before { background: var(--color-moss); }
-    .reset-option-tab:hover {
-      border-color: var(--color-moss);
-      background: var(--color-bg-success-soft);
-      box-shadow: 0 4px 12px rgba(53, 94, 48, 0.15);
+    .reset-option-title {
+      font-size: 1.02rem;
+      font-weight: 700;
+      color: var(--color-text);
     }
-    .reset-option-tab .reset-option-icon { background: var(--color-bg-success-soft); color: var(--color-text-success-strong); }
-    .reset-option-all { background: var(--color-danger-soft); border-color: var(--color-danger-soft); }
+    .reset-option-desc {
+      font-size: 0.82rem;
+      color: var(--color-text-muted);
+      line-height: 1.35;
+    }
+    .reset-option-tab::before { background: var(--color-primary); }
+    .reset-option-tab:hover {
+      border-color: var(--color-primary);
+      background: var(--color-bg-success-soft);
+      box-shadow: 0 4px 12px rgba(74, 124, 35, 0.15);
+    }
+    .reset-option-tab:hover::before { width: 8px; }
+    .reset-option-tab .reset-option-icon {
+      background: var(--color-success-soft);
+      color: var(--color-text-success-strong);
+    }
+    .reset-option-all {
+      background: var(--color-danger-bg-soft);
+      border-color: var(--color-danger-soft);
+    }
     .reset-option-all::before { background: var(--color-danger); }
     .reset-option-all:hover {
       background: var(--color-danger);
       border-color: var(--color-danger-dark);
-      box-shadow: 0 6px 16px rgba(180, 72, 58, 0.3);
+      box-shadow: 0 6px 16px rgba(211, 47, 47, 0.3);
+    }
+    .reset-option-all:hover::before {
+      width: 8px;
+      background: var(--color-danger-dark);
     }
     .reset-option-all:hover .reset-option-icon,
     .reset-option-all:hover .reset-option-title,
     .reset-option-all:hover .reset-option-desc {
       background: var(--color-danger);
-      color: var(--color-card);
+      color: var(--color-card-text);
     }
-    .reset-option-all .reset-option-icon { background: var(--color-danger); color: var(--color-card); }
+    .reset-option-all .reset-option-icon {
+      background: var(--color-danger-soft);
+      color: var(--color-card-text);
+    }
     .reset-option-all .reset-option-title { color: var(--color-text-danger); }
     .reset-option-all .reset-option-desc { color: var(--color-text-danger); }
     .reset-modal-cancel {
@@ -1478,147 +1605,94 @@
       border: none;
       border-radius: 10px;
       background: transparent;
-      color: var(--color-text-muted, var(--color-ink-soft));
+      color: var(--color-text-muted);
       font-size: 0.95rem;
       font-weight: 600;
       cursor: pointer;
+      transition: background 0.15s, color 0.15s;
     }
-    .reset-modal-cancel:hover { background: var(--color-bg-soft); color: var(--color-ink); }
+    .reset-modal-cancel:hover {
+      background: var(--color-bg-soft);
+      color: var(--color-text);
+    }
     .reset-modal-cancel:active { background: var(--color-bg-hover); }
 
-    /* ===== Legacy settings-modal (hidden, Backwards-Compat) ===== */
-    .settings-option { display: none; }
-
-    /* ===== Legacy dashboard sheet (hidden) ===== */
-    .dashboard-overlay, .dashboard-sheet, .dashboard_close { display: none !important; }
-
-    /* ===== Legacy protokoll tab button (hidden) ===== */
-    #protokoll_tab_btn { display: none !important; }
-
-    /* ===== Save-error banner ===== */
-    .save-error-banner {
-      background: var(--color-warning-bg);
-      border: 2px solid var(--color-warning-border);
-      border-radius: 8px;
-      padding: 10px 14px;
-      margin: 8px 16px 12px;
-      font-size: 0.9rem;
-      color: var(--color-warning-text);
+    /* ===== Settings-Modal ===== */
+    .settings-option {
+      position: relative;
       display: flex;
       align-items: center;
-      gap: 8px;
-      animation: slideDown 0.2s ease;
-    }
-    .save-error-banner button {
-      margin-left: auto;
-      background: none;
-      border: none;
-      font-size: 1rem;
+      gap: 14px;
+      width: 100%;
+      padding: 16px 16px 16px 20px;
+      border: 2px solid var(--color-border);
+      border-radius: 16px;
+      background: var(--color-card-bg);
+      text-align: left;
       cursor: pointer;
-      color: var(--color-warning-text);
-      padding: 0 4px;
+      overflow: hidden;
+      transition: transform 0.12s, border-color 0.15s, background 0.15s;
     }
-    @keyframes slideDown {
-      from { opacity: 0; transform: translateY(-8px); }
-      to { opacity: 1; transform: translateY(0); }
-    }
-    .version-footer {
-      text-align: center;
-      color: var(--color-text-hint);
-      font-size: 0.75rem;
-      margin-top: 16px;
-      padding-bottom: 8px;
-    }
-
-    /* ===== iOS / Update banners ===== */
-    .ios-install-banner {
-      position: fixed;
-      bottom: 90px;
-      left: 12px;
-      right: 12px;
-      background: var(--color-ios-banner-bg);
-      color: var(--color-ios-banner-text);
-      padding: 12px 16px;
-      border-radius: 12px;
-      font-size: 0.85rem;
-      display: none;
-      align-items: center;
-      gap: 12px;
-      z-index: 999;
-      box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
-    }
-    .ios-install-banner.show { display: flex; }
-    .ios-install-banner .ios-install-text { flex: 1; }
-    .ios-install-banner .ios-install-text strong { color: var(--color-moss-light, var(--color-moss-bright)); }
-    .ios-install-banner .ios-install-dismiss {
-      background: rgba(255, 255, 255, 0.15);
-      border: none;
-      color: var(--color-ios-banner-text);
-      border-radius: 50%;
-      width: 28px; height: 28px;
-      cursor: pointer;
-      font-size: 1rem;
+    .settings-option:active { transform: scale(0.985); }
+    .settings-option-icon {
       flex-shrink: 0;
+      width: 44px;
+      height: 44px;
+      border-radius: 12px;
       display: flex;
       align-items: center;
       justify-content: center;
+      font-size: 1.4rem;
+      background: var(--color-bg-soft);
+      color: var(--color-primary-dark);
     }
-    .ios-install-banner .ios-install-dismiss:active { background: rgba(255, 255, 255, 0.3); }
-
-    .update-banner {
-      position: fixed;
-      top: 12px;
-      left: 12px;
-      right: 12px;
-      background: var(--color-moss);
-      color: var(--color-card);
-      padding: 12px 16px;
-      border-radius: 12px;
-      font-size: 0.85rem;
-      display: none;
-      align-items: center;
-      gap: 12px;
-      z-index: 1000;
-      box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
-      animation: slideDown 0.25s ease;
+    .settings-option-body {
+      display: flex;
+      flex-direction: column;
+      gap: 3px;
+      flex: 1;
+      min-width: 0;
     }
-    .update-banner.show { display: flex; }
-    .update-banner .update-icon { font-size: 1.2rem; flex-shrink: 0; }
-    .update-banner .update-text { flex: 1; }
-    .update-banner .update-text strong { color: var(--color-moss-soft); }
-    .update-banner .update-dismiss {
-      background: rgba(255, 255, 255, 0.15);
-      border: none;
-      color: var(--color-card);
-      border-radius: 50%;
-      width: 28px; height: 28px;
-      cursor: pointer;
-      font-size: 1rem;
-      flex-shrink: 0;
+    .settings-option-title {
+      font-size: 1.02rem;
+      font-weight: 700;
+      color: var(--color-text);
+    }
+    .settings-option-desc {
+      font-size: 0.82rem;
+      color: var(--color-text-muted);
+      line-height: 1.35;
+    }
+    .settings-option-info-row {
       display: flex;
       align-items: center;
-      justify-content: center;
+      gap: 6px;
+      padding: 6px 12px;
+      background: var(--color-bg-soft);
+      border-radius: var(--radius-pill);
+      font-size: 0.78rem;
+      color: var(--color-text-muted);
     }
-    .update-banner .update-dismiss:active { background: rgba(255, 255, 255, 0.3); }
+    .settings-info {
+      padding: 14px 16px;
+      background: var(--color-bg-soft);
+      border-radius: 12px;
+      margin-bottom: 14px;
+      font-size: 0.85rem;
+      color: var(--color-text-muted);
+      line-height: 1.5;
+    }
+    .settings-info strong { color: var(--color-text); }
 
-    /* ===== Focus rings ===== */
+    /* Focus rings */
     .btn:focus-visible, .btn-add:focus-visible, .btn-danger:focus-visible,
     .toggle-btn:focus-visible, .tab-btn:focus-visible,
     input:focus-visible, .drill-prio-btn:focus-visible, .drill-done-btn:focus-visible,
     .tab-close:focus-visible, .settings-btn:focus-visible, .bottom-nav-item:focus-visible,
-    .reset-option:focus-visible, .reset-modal-x:focus-visible,
-    .nav-btn:focus-visible, .gear-btn:focus-visible, .switch:focus-visible,
-    .chip:focus-visible, .field-card:focus-visible {
-      outline: 2.5px solid var(--color-moss);
+    .settings-option:focus-visible, .reset-option:focus-visible, .icon-btn:focus-visible {
+      outline: 2.5px solid var(--color-primary);
       outline-offset: 2px;
     }
 
-    /* ===== prefers-reduced-motion ===== */
-    @media (prefers-reduced-motion: reduce) {
-      *, *::before, *::after {
-        animation-duration: 0.01ms !important;
-        animation-iteration-count: 1 !important;
-        transition-duration: 0.01ms !important;
-        scroll-behavior: auto !important;
-      }
-    }
+    /* Hide old dashboard sheet CSS (kept IDs removed in HTML; rules no-op) */
+    .dashboard-overlay, .dashboard-sheet { display: none !important; }

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="theme-color" content="#254321">
+  <meta name="theme-color" content="#2d4a1a">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <link rel="manifest" href="manifest.json">
@@ -15,304 +15,327 @@
 </head>
 <body>
   <div class="app-layout">
-
     <div id="save_error_banner" class="save-error-banner" style="display:none">
       <span>⚠️ <strong>Speichern fehlgeschlagen</strong> — localStorage voll. Daten gehen bei Neuladung verloren!</span>
       <button onclick="dismissSaveError()" aria-label="Schließen">✕</button>
     </div>
-
     <div class="scrollable-content">
-      <div class="content">
+  <div class="container">
 
-        <!-- ===== Persistent Header ===== -->
-        <header class="app-header">
-          <div>
-            <div class="app-header-meta">Demo · Vollständiger Funktionsumfang</div>
-            <h1 class="app-header-title" id="page-title">Agrar-Rechner</h1>
+    <!-- ===== View: Rechner (default) ===== -->
+    <section id="view_rechner">
+      <!-- App Header -->
+      <div class="header-row">
+        <div class="header-titles">
+          <div class="header-meta">Demo · Vollständiger Funktionsumfang</div>
+          <h1>Agrar-Rechner</h1>
+        </div>
+        <div class="header-actions">
+          <button class="settings-btn" onclick="openSettings()" aria-label="Einstellungen">⚙️</button>
+        </div>
+      </div>
+
+      <!-- Tabs (only field tabs, no Protokoll button) -->
+      <div class="tab-bar" id="tab_bar">
+        <div class="tab-bar-left" id="tab_bar_left"></div>
+      </div>
+
+      <!-- Input card: Fläche & Aussaatstärke -->
+      <div class="card card-input" id="card_input">
+        <h2>
+          <span class="section-badge">1</span>
+          Fläche &amp; Aussaatstärke
+        </h2>
+        <div class="field">
+          <label for="hektar">Hektar (SOLL)</label>
+          <div class="input-wrap">
+            <input type="text" inputmode="decimal" autocomplete="off" autocorrect="off" spellcheck="false" id="hektar" placeholder="z.B. 12,5" maxlength="8" oninput="onInputFormat(this, 'decimal', event)" onchange="onInputHektar(this)" onblur="onInputHektar(this)" aria-describedby="err_hektar">
+            <span class="input-unit">ha</span>
           </div>
-          <button class="gear-btn" id="gear-btn" onclick="toggleSettings()" aria-label="Einstellungen">⚙️</button>
-        </header>
-
-        <!-- ===== Settings Panel (inline) ===== -->
-        <section class="settings-panel" id="settings_panel">
-          <div class="settings-title">Einstellungen</div>
-
-          <div class="settings-row">
-            <div>
-              <div class="settings-row-title">Fahrgassen berücksichtigen</div>
-              <div class="settings-row-desc">Reduziert die bestellte Fläche um 1 Spur je Breite</div>
-            </div>
-            <button class="switch" id="sw_fahrgassen" onclick="toggleFahrgassenGlobal()" aria-label="Fahrgassen"></button>
+          <div class="error-msg" id="err_hektar" role="alert"></div>
+        </div>
+        <div class="field">
+          <label for="ist_hektar">Hektar (IST) — optional, tatsächlich gefahren</label>
+          <div class="input-wrap">
+            <input type="text" inputmode="decimal" autocomplete="off" autocorrect="off" spellcheck="false" id="ist_hektar" placeholder="z.B. 12,3" oninput="onInputFormat(this, 'decimal', event)" onchange="onInputIstHektar(this)" onblur="onInputIstHektar(this)">
+            <span class="input-unit">ha</span>
           </div>
-          <div class="settings-detail" id="detail_fahrgassen">
-            <div class="input-shell">
-              <input id="fahrgassen_breite" inputmode="decimal" placeholder="Breite in Metern" oninput="updateFahrgassenBreite()">
-              <span class="suffix">m</span>
-            </div>
-            <div class="settings-hint" id="fahrgassen_hint"></div>
+          <div class="hint-block">Weicht die IST- von der SOLL-Fläche ab, wird der Ausgleich im Senken-Feld sichtbar (siehe Übersicht).</div>
+        </div>
+        <div class="field">
+          <label for="koerner">Körner pro Hektar</label>
+          <div class="input-wrap">
+            <input type="text" inputmode="numeric" id="koerner" placeholder="z.B. 90000" maxlength="8" oninput="onInputFormat(this, 'integer', event)" onchange="onInputKoerner(this)" onblur="onInputKoerner(this)" aria-describedby="err_koerner">
+            <span class="input-unit">/ha</span>
           </div>
-
-          <div class="settings-row">
-            <div>
-              <div class="settings-row-title">Andere Gebindegröße</div>
-              <div class="settings-row-desc">Körner pro Einheit anpassen (Standard: 50.000)</div>
-            </div>
-            <button class="switch" id="sw_einheitgroesse" onclick="toggleEinheitgroesseGlobal()" aria-label="Einheitsgröße"></button>
-          </div>
-          <div class="settings-detail" id="detail_einheitgroesse">
-            <div class="input-shell">
-              <input id="koerner_pro_einheit" inputmode="numeric" placeholder="z.B. 80000" oninput="updateEinheitgroesse()">
-              <span class="suffix">Körner</span>
-            </div>
-            <div class="settings-hint" id="einheitgroesse_hint"></div>
-          </div>
-
-          <button class="btn-danger-block" onclick="doResetAll()">Alle Daten zurücksetzen</button>
-        </section>
-
-        <!-- ===== Field chips (Schläge) — above all views ===== -->
-        <div class="field-chips-wrap">
-          <div class="field-chips" id="field-chips"></div>
+          <div class="unit">üblich: 80.000 – 100.000</div>
+          <div class="error-msg" id="err_koerner" role="alert"></div>
         </div>
 
-        <!-- ===== View: Rechner ===== -->
-        <section id="view_rechner">
-          <div class="warn-banner" id="overflow_warn">Die neuen Werte weichen von den bereits eingetragenen Mengen ab. Prüfe die Einträge im Protokoll.</div>
+        <div class="fahrgassen-toggle">
+          <label for="einheit_groesse_toggle">Einheiten-Größe anpassen</label>
+          <button class="toggle-btn" id="einheit_groesse_toggle" onclick="einheitGroesseToggle()" aria-label="Einheiten-Größe" aria-pressed="false"></button>
+        </div>
+        <div class="fahrgassen-settings" id="einheit_groesse_settings">
+          <div class="field" style="margin-bottom:8px">
+            <label for="koerner_pro_einheit">Körner pro Einheit</label>
+            <input type="text" inputmode="numeric" id="koerner_pro_einheit" placeholder="z.B. 50000" oninput="onInputFormat(this, 'integer', event)" onchange="einheitGroesseUpdate()" onblur="einheitGroesseUpdate()">
+          </div>
+          <div class="fahrgassen-saved" id="einheit_groesse_saved"></div>
+          <div class="fahrgassen-info">Wie viele Körner eine "Einheit" Saatgut entsprechen (üblich: 50.000).</div>
+        </div>
+      </div>
 
-          <!-- Speech-bubble result card -->
-          <div class="bubble" id="results" style="display:none">
-            <div class="bubble-head">
-              <div class="avatar">A</div>
-              <div class="bubble-head-name">Ergebnis</div>
-            </div>
-            <div class="bubble-body">
-              <div class="ring-wrap">
-                <svg viewBox="0 0 96 96">
-                  <defs><linearGradient id="mossgrad" x1="0%" y1="0%" x2="100%" y2="100%">
-                    <stop offset="0%" stop-color="#5C9450"/>
-                    <stop offset="100%" stop-color="#254321"/>
-                  </linearGradient></defs>
-                  <circle class="ring-track" cx="48" cy="48" r="40"/>
-                  <circle class="ring-fill" id="ringFill" cx="48" cy="48" r="40" stroke-dasharray="251.3" stroke-dashoffset="251.3"/>
-                </svg>
-                <div class="ring-center">
-                  <div class="n" id="ring_val">0</div>
-                  <div class="u">EINH.</div>
-                </div>
-              </div>
-              <div class="bubble-text">
-                <div class="headline" id="hero_line">— Einheiten Saatgut</div>
-                <div class="desc" id="hero_sub">Trag Hektar und Körner pro Hektar ein.</div>
-              </div>
-            </div>
-            <div class="progress-strip">
-              <div class="bar-track"><div class="bar-fill" id="rechner_bar" style="width:0%"></div></div>
-              <div class="progress-foot">
-                <span id="rechner_used">0 verbraucht</span>
-                <span class="rem" id="rechner_remaining">— offen</span>
-              </div>
+      <!-- Input card: Dünger -->
+      <div class="card">
+        <h2>
+          <span class="section-badge">2</span>
+          Dünger
+        </h2>
+        <div class="field">
+          <label for="duenger">Dünger</label>
+          <div class="input-wrap">
+            <input type="text" inputmode="decimal" autocomplete="off" autocorrect="off" spellcheck="false" id="duenger" placeholder="z.B. 150" oninput="onInputFormat(this, 'decimal', event)" onchange="onInputDuenger(this)" onblur="onInputDuenger(this)">
+            <span class="input-unit">kg/ha</span>
+          </div>
+        </div>
+
+        <div class="fahrgassen-toggle">
+          <label for="fahrgassen_toggle">Fahrgassen berücksichtigen</label>
+          <button class="toggle-btn" id="fahrgassen_toggle" onclick="fahrgassenToggle()" aria-label="Fahrgassen" aria-pressed="false"></button>
+        </div>
+        <div class="fahrgassen-settings" id="fahrgassen_settings">
+          <div class="field" style="margin-bottom:8px">
+            <label for="fahrgassen_breite">Fahrgassenbreite (m)</label>
+            <input type="text" inputmode="decimal" autocomplete="off" autocorrect="off" spellcheck="false" id="fahrgassen_breite" placeholder="z.B. 24" oninput="onInputFormat(this, 'decimal', event)" onchange="fahrgassenUpdate()" onblur="fahrgassenUpdate()">
+          </div>
+          <div class="fahrgassen-saved" id="fahrgassen_saved"></div>
+          <div class="fahrgassen-info">Die Körnerzahl wird um ca. 1/Fahrgassenbreite × 100 % reduziert.</div>
+        </div>
+      </div><!-- Dünger card -->
+
+      <!-- Result card (kept IDs intact) -->
+      <div class="card result" id="results" style="display:none">
+        <h2>
+          <span class="section-badge">A</span>
+          Ergebnis
+          <span class="section-meta" id="r_info"></span>
+        </h2>
+
+        <!-- Hidden but kept for data binding via renderResults (legacy) -->
+        <div id="r_korner" style="display:none"></div>
+        <div id="r_einheiten" style="display:none"></div>
+        <div id="r_duenger" style="display:none"></div>
+
+        <!-- New ring-chart layout -->
+        <div class="result-layout">
+          <div class="result-ring-chart" id="result_ring_chart">
+            <svg viewBox="0 0 100 100">
+              <circle class="result-ring-bg" cx="50" cy="50" r="44"></circle>
+              <circle class="result-ring-fg" id="r_ring_fg" cx="50" cy="50" r="44"
+                      stroke-dasharray="276.46" stroke-dashoffset="276.46"></circle>
+            </svg>
+            <div class="result-ring-center">
+              <div class="result-ring-value" id="r_ring_value">—</div>
+              <div class="result-ring-sub" id="r_ring_sub">EINH.</div>
             </div>
           </div>
+          <div class="result-side">
+            <div class="result-side-title" id="r_side_title">Ergebnis</div>
+            <div class="result-side-sub" id="r_side_sub">Bitte Hektar und Körner/ha eingeben.</div>
+          </div>
+        </div>
 
-          <!-- Legacy r_*-IDs (hidden, kept for tests + backend data binding) -->
-          <div id="r_korner" style="display:none"></div>
-          <div id="r_einheiten" style="display:none"></div>
-          <div id="r_duenger" style="display:none"></div>
-          <div id="r_side_title" style="display:none"></div>
-          <div id="r_side_sub" style="display:none"></div>
-          <div id="r_ring_value" style="display:none"></div>
-          <div id="r_ring_sub" style="display:none"></div>
-          <div id="r_ring_fg" style="display:none"></div>
-          <div id="r_progress_fill" style="display:none"></div>
-          <div id="r_progress_used" style="display:none"></div>
-          <div id="r_progress_open" style="display:none"></div>
-          <div id="r_info" style="display:none"></div>
+        <div class="result-progress">
+          <div class="result-progress-bar">
+            <div class="result-progress-fill" id="r_progress_fill" style="width:0%"></div>
+          </div>
+          <div class="result-progress-legend">
+            <span class="legend-used" id="r_progress_used">— verbraucht</span>
+            <span class="legend-open" id="r_progress_open">— offen</span>
+          </div>
+        </div>
 
-          <!-- Stat row -->
-          <div class="stat-row" id="stat_row_cards"></div>
+        <!-- Legacy details (SOLL/IST/Abweichung, Carryover, Drill-Entries) -->
+        <div id="r_soll_ist_section" class="result-details" style="display:none">
+          <div class="result-row">
+            <span class="label">SOLL-Fläche</span>
+            <span class="value small" id="r_soll_ha">—</span>
+          </div>
+          <div class="result-row">
+            <span class="label">IST-Fläche</span>
+            <span class="value small" id="r_ist_ha">—</span>
+          </div>
+          <div class="result-row">
+            <span class="label">Abweichung</span>
+            <span class="value small" id="r_diff_ha">—</span>
+          </div>
+        </div>
+        <div id="r_carryover_hint" style="font-size:0.85rem;padding:4px 0;"></div>
 
-          <!-- Card: Fläche & Aussaatstärke -->
-          <div class="card" id="card_input">
-            <div class="card-title">
-              <span id="field_card_title">Fläche &amp; Aussaatstärke</span>
-              <button class="edit-name" onclick="renameActiveField()">✎ Umbenennen</button>
+        <div id="r_drill_section" style="display:none">
+          <div class="drill-separator"></div>
+          <div class="result-row">
+            <span class="label">Einheiten eingefüllt</span>
+            <span class="value small" id="r_drill_e_used">—</span>
+          </div>
+          <div class="result-row" id="r_drill_e_rem_row">
+            <span class="label">Einheiten verbleibend</span>
+            <span class="value small" id="r_drill_e_rem">—</span>
+          </div>
+          <div class="result-row" id="r_drill_d_used_row" style="display:none">
+            <span class="label">Dünger eingefüllt</span>
+            <span class="value small" id="r_drill_d_used">—</span>
+          </div>
+          <div class="result-row" id="r_drill_d_rem_row" style="display:none">
+            <span class="label">Dünger verbleibend</span>
+            <span class="value small" id="r_drill_d_rem">—</span>
+          </div>
+          <div id="r_drill_entries"></div>
+        </div>
+      </div><!-- end results card -->
+
+      <!-- Reset this tab -->
+      <button class="reset-this-tab-btn" onclick="resetActiveTab()">
+        Diesen Schlag zurücksetzen
+      </button>
+    </section><!-- end #view_rechner -->
+
+    <!-- ===== View: Protokoll ===== -->
+    <section id="view_protokoll">
+      <div class="header-row">
+        <div class="header-titles">
+          <div class="header-meta">Demo · Vollständiger Funktionsumfang</div>
+          <h1>Drill-Protokoll</h1>
+        </div>
+        <div class="header-actions">
+          <button class="settings-btn" onclick="openSettings()" aria-label="Einstellungen">⚙️</button>
+        </div>
+      </div>
+
+      <div class="card" id="drill_section">
+        <div class="drill-tabs-section">
+          <div class="drill-tabs-header">Priorität &amp; Status je Schlag</div>
+          <div id="drill_tab_list"></div>
+        </div>
+
+        <h2>
+          <span class="section-badge">+</span>
+          Maschine eingefüllt
+        </h2>
+        <div id="drill_mask">
+          <div class="drill-machine-row">
+            <div class="field">
+              <label for="drill_einheit">Einheiten gesamt</label>
+              <div class="input-wrap">
+                <input type="text" inputmode="decimal" autocomplete="off" autocorrect="off" spellcheck="false" id="drill_einheit" placeholder="z.B. 4" oninput="drillCalcDebounced(); onInputFormat(this, 'decimal', event)">
+              </div>
             </div>
             <div class="field">
-              <label for="hektar">Hektar (SOLL)</label>
-              <div class="input-shell" id="shell_hektar">
-                <input type="text" inputmode="decimal" autocomplete="off" autocorrect="off" spellcheck="false" id="hektar" placeholder="z.B. 12,5" oninput="onHektarInput()">
-                <span class="suffix">ha</span>
+              <label for="drill_duenger">Dünger gesamt</label>
+              <div class="input-wrap">
+                <input type="text" inputmode="decimal" autocomplete="off" autocorrect="off" spellcheck="false" id="drill_duenger" placeholder="z.B. 200" oninput="drillCalcDebounced(); onInputFormat(this, 'decimal', event)">
+                <span class="input-unit">kg</span>
               </div>
-              <div class="err-text" id="err_hektar"></div>
-            </div>
-            <div class="field">
-              <label for="ist_hektar">Hektar (IST) — optional, tatsächlich gefahren</label>
-              <div class="input-shell">
-                <input type="text" inputmode="decimal" autocomplete="off" autocorrect="off" spellcheck="false" id="ist_hektar" placeholder="z.B. 12,3" oninput="onIstHektarInput()">
-                <span class="suffix">ha</span>
-              </div>
-              <div class="hint-block">Weicht die IST- von der SOLL-Fläche ab, wird der Ausgleich im Senken-Feld sichtbar (siehe Übersicht).</div>
-            </div>
-            <div class="field">
-              <label for="koerner">Körner pro Hektar</label>
-              <div class="input-shell" id="shell_koerner">
-                <input type="text" inputmode="numeric" id="koerner" placeholder="z.B. 90000" oninput="onKoernerInput()">
-                <span class="suffix">/ha</span>
-              </div>
-              <div class="hint">üblich: 80.000 – 100.000</div>
-              <div class="err-text" id="err_koerner"></div>
-            </div>
-
-            <div class="fahrgassen-toggle">
-              <label for="einheit_groesse_toggle">Einheiten-Größe anpassen</label>
-              <button class="toggle-btn" id="einheit_groesse_toggle" onclick="einheitGroesseToggle()" aria-label="Einheiten-Größe"></button>
-            </div>
-            <div class="fahrgassen-settings" id="einheit_groesse_settings">
-              <div class="field" style="margin-bottom:8px">
-                <label for="koerner_pro_einheit">Körner pro Einheit</label>
-                <div class="input-shell">
-                  <input type="text" inputmode="numeric" id="koerner_pro_einheit" placeholder="z.B. 50000" oninput="onInputFormat(this, 'integer', event)" onchange="einheitGroesseUpdate()" onblur="einheitGroesseUpdate()">
-                </div>
-              </div>
-              <div class="fahrgassen-saved" id="einheit_groesse_saved"></div>
-              <div class="fahrgassen-info">Wie viele Körner eine "Einheit" Saatgut entsprechen (üblich: 50.000).</div>
             </div>
           </div>
-
-          <!-- Card: Dünger -->
-          <div class="card">
-            <div class="card-title">Dünger</div>
-            <div class="field">
-              <label for="duenger">Dünger</label>
-              <div class="input-shell">
-                <input type="text" inputmode="decimal" autocomplete="off" autocorrect="off" spellcheck="false" id="duenger" placeholder="z.B. 150" oninput="onDuengerInput()">
-                <span class="suffix">kg/ha</span>
-              </div>
-            </div>
-
-            <div class="fahrgassen-toggle">
-              <label for="fahrgassen_toggle">Fahrgassen berücksichtigen</label>
-              <button class="toggle-btn" id="fahrgassen_toggle" onclick="fahrgassenToggle()" aria-label="Fahrgassen"></button>
-            </div>
-            <div class="fahrgassen-settings" id="fahrgassen_settings">
-              <div class="field" style="margin-bottom:8px">
-                <label for="fahrgassen_breite">Fahrgassenbreite (m)</label>
-                <div class="input-shell">
-                  <input type="text" inputmode="decimal" autocomplete="off" autocorrect="off" spellcheck="false" id="fahrgassen_breite" placeholder="z.B. 24" oninput="onInputFormat(this, 'decimal', event)" onchange="fahrgassenUpdate()" onblur="fahrgassenUpdate()">
-                </div>
-              </div>
-              <div class="fahrgassen-saved" id="fahrgassen_saved"></div>
-              <div class="fahrgassen-info">Die Körnerzahl wird um ca. 1/Fahrgassenbreite × 100 % reduziert.</div>
+          <div class="field">
+            <label for="drill_hektar">Zählerstand (ha) — optional</label>
+            <div class="input-wrap">
+              <input type="text" inputmode="decimal" autocomplete="off" autocorrect="off" spellcheck="false" id="drill_hektar" placeholder="z.B. 5,2" oninput="onInputFormat(this, 'decimal', event)">
+              <span class="input-unit">ha</span>
             </div>
           </div>
-
-          <button class="reset-this-tab-btn" onclick="doResetActiveTab()">Diesen Schlag zurücksetzen</button>
-
-          <!-- Legacy result details (keep for carryover hints + drill entries) -->
-          <div id="r_soll_ist_section" class="result-details" style="display:none">
-            <div class="result-row"><span class="label">SOLL-Fläche</span><span class="value small" id="r_soll_ha">—</span></div>
-            <div class="result-row"><span class="label">IST-Fläche</span><span class="value small" id="r_ist_ha">—</span></div>
-            <div class="result-row"><span class="label">Abweichung</span><span class="value small" id="r_diff_ha">—</span></div>
+          <div class="hint-block">Ohne gesetzte Prioritäten wird alles auf den aktiven Schlag ("Schlag Nord") gebucht.</div>
+          <button class="btn-add" onclick="drillAdd()">+ Verteilen &amp; eintragen</button>
+        </div>
+        <div id="drill_summary" class="drill-summary" style="display:none">
+          <div id="ds_total_summary" class="drill-total-summary" style="margin-bottom:8px;font-weight:bold;"></div>
+          <div class="drill-summary-row">
+            <span>Einheiten gesamt</span>
+            <span id="ds_saat_total">—</span>
           </div>
-          <div id="r_carryover_hint" style="font-size:0.85rem;padding:4px 0;"></div>
-          <div id="r_drill_section" style="display:none">
-            <div class="drill-separator"></div>
-            <div class="result-row"><span class="label">Einheiten eingefüllt</span><span class="value small" id="r_drill_e_used">—</span></div>
-            <div class="result-row" id="r_drill_e_rem_row"><span class="label">Einheiten verbleibend</span><span class="value small" id="r_drill_e_rem">—</span></div>
-            <div class="result-row" id="r_drill_d_used_row" style="display:none"><span class="label">Dünger eingefüllt</span><span class="value small" id="r_drill_d_used">—</span></div>
-            <div class="result-row" id="r_drill_d_rem_row" style="display:none"><span class="label">Dünger verbleibend</span><span class="value small" id="r_drill_d_rem">—</span></div>
-            <div id="r_drill_entries"></div>
+          <div class="drill-summary-row">
+            <span>Einheiten verwendet</span>
+            <span id="ds_saat_used">—</span>
           </div>
-        </section><!-- end #view_rechner -->
-
-        <!-- ===== View: Drill-Protokoll ===== -->
-        <section id="view_protokoll">
-          <div class="drill-tabs-section">
-            <div class="drill-tabs-header">Priorität &amp; Status je Schlag</div>
-            <div id="drill_tab_list"></div>
+          <div class="drill-summary-row remaining">
+            <span>Einheiten verbleibend</span>
+            <span id="ds_saat_remaining">—</span>
           </div>
-
-          <div class="card" id="drill_section">
-            <div class="card-title">+ Maschine eingefüllt</div>
-            <div id="drill_mask">
-              <div class="drill-machine-row">
-                <div class="field">
-                  <label for="drill_einheit">Einheiten gesamt</label>
-                  <div class="input-shell">
-                    <input type="text" inputmode="decimal" autocomplete="off" autocorrect="off" spellcheck="false" id="drill_einheit" placeholder="z.B. 4" oninput="drillCalcDebounced(); onInputFormat(this, 'decimal', event)">
-                  </div>
-                </div>
-                <div class="field">
-                  <label for="drill_duenger">Dünger gesamt</label>
-                  <div class="input-shell">
-                    <input type="text" inputmode="decimal" autocomplete="off" autocorrect="off" spellcheck="false" id="drill_duenger" placeholder="z.B. 200" oninput="drillCalcDebounced(); onInputFormat(this, 'decimal', event)">
-                    <span class="suffix">kg</span>
-                  </div>
-                </div>
-              </div>
-              <div class="field">
-                <label for="drill_hektar">Zählerstand (ha) — optional</label>
-                <div class="input-shell">
-                  <input type="text" inputmode="decimal" autocomplete="off" autocorrect="off" spellcheck="false" id="drill_hektar" placeholder="z.B. 5,2" oninput="onInputFormat(this, 'decimal', event)">
-                  <span class="suffix">ha</span>
-                </div>
-              </div>
-              <div class="hint" id="drill_mode_hint" style="margin: 8px 0 12px;">Ohne gesetzte Prioritäten wird alles auf den aktiven Schlag ("Schlag Nord") gebucht.</div>
-              <button class="btn-add" onclick="drillAdd()">+ Verteilen &amp; eintragen</button>
-            </div>
-
-            <div id="drill_summary" class="drill-summary" style="display:none">
-              <div id="ds_total_summary" class="drill-total-summary"></div>
-              <div class="drill-summary-row"><span>Einheiten gesamt</span><span id="ds_saat_total">—</span></div>
-              <div class="drill-summary-row"><span>Einheiten verwendet</span><span id="ds_saat_used">—</span></div>
-              <div class="drill-summary-row remaining"><span>Einheiten verbleibend</span><span id="ds_saat_remaining">—</span></div>
-              <div class="drill-summary-row"><span>Dünger gesamt</span><span id="ds_duenger_total">—</span></div>
-              <div class="drill-summary-row"><span>Dünger verwendet</span><span id="ds_duenger_used">—</span></div>
-              <div class="drill-summary-row remaining"><span>Dünger verbleibend</span><span id="ds_duenger_remaining">—</span></div>
-              <div class="drill-summary-savings" id="ds_savings" style="display:none"></div>
-            </div>
+          <div class="drill-summary-row">
+            <span>Dünger gesamt</span>
+            <span id="ds_duenger_total">—</span>
           </div>
+          <div class="drill-summary-row">
+            <span>Dünger verwendet</span>
+            <span id="ds_duenger_used">—</span>
+          </div>
+          <div class="drill-summary-row remaining">
+            <span>Dünger verbleibend</span>
+            <span id="ds_duenger_remaining">—</span>
+          </div>
+          <div class="drill-summary-savings" id="ds_savings" style="display:none"></div>
+        </div>
 
-          <!-- Maschinen-Log (in-page, nicht in eigener Card) -->
-          <div class="section-title" style="margin-top:18px;">Maschinen-Log</div>
-          <div class="entry-list" id="drill_machine_log"></div>
+        <!-- Maschinen-Log (innerhalb #drill_section, damit nur eine .card
+             in #view_protokoll existiert → tests/15-render-view + 22-contract) -->
+        <section class="drill-log-subsection">
+          <h2 class="subsection-header">Maschinen-Log</h2>
+          <div id="drill_machine_log"></div>
           <div id="drill_entries"></div>
-        </section><!-- end #view_protokoll -->
+        </section>
+      </div>
+    </section><!-- end #view_protokoll -->
 
-        <!-- ===== View: Übersicht ===== -->
-        <section id="view_uebersicht">
-          <div id="dashboard_content"></div>
-        </section><!-- end #view_uebersicht -->
+    <!-- ===== View: Übersicht ===== -->
+    <section id="view_uebersicht">
+      <div class="header-row">
+        <div class="header-titles">
+          <div class="header-meta">Demo · Vollständiger Funktionsumfang</div>
+          <h1>Übersicht</h1>
+        </div>
+        <div class="header-actions">
+          <button class="settings-btn" onclick="openSettings()" aria-label="Einstellungen">⚙️</button>
+        </div>
+      </div>
+      <div id="dashboard_content"></div>
+    </section><!-- end #view_uebersicht -->
 
-      </div><!-- end .content -->
+  </div><!-- end .container -->
+
     </div><!-- end .scrollable-content -->
 
-    <!-- ===== Sticky Bottom Navigation ===== -->
+    <!-- Sticky Bottom Navigation -->
     <nav class="bottom-nav" id="bottom_nav" aria-label="Hauptnavigation">
-      <button class="nav-btn active" id="bn_rechner" onclick="switchToRechner()">
-        <span class="ic" aria-hidden="true">🌾</span>
+      <button class="bottom-nav-item" id="bn_rechner" onclick="switchToRechner()">
+        <span class="bottom-nav-icon" aria-hidden="true">🌾</span>
         <span>Rechner</span>
       </button>
-      <button class="nav-btn" id="bn_protokoll" onclick="switchToProtokoll()">
-        <span class="ic" aria-hidden="true">📋</span>
+      <button class="bottom-nav-item" id="bn_protokoll" onclick="switchToProtokoll()">
+        <span class="bottom-nav-icon" aria-hidden="true">📋</span>
         <span>Protokoll</span>
       </button>
-      <button class="nav-btn" id="bn_uebersicht" onclick="switchToUebersicht()">
-        <span class="ic" aria-hidden="true">📊</span>
+      <button class="bottom-nav-item" id="bn_uebersicht" onclick="switchToUebersicht()">
+        <span class="bottom-nav-icon" aria-hidden="true">📊</span>
         <span>Übersicht</span>
       </button>
     </nav>
 
-    <!-- Hidden version-footer (für Tests) -->
-    <div id="version_footer" style="display:none"></div>
-
+    <!-- Hidden legacy protokoll_tab_btn (für Test-Backwards-Compat).
+         Die Bottom-Nav Button bn_protokoll triggers die echte View-Switch. -->
+    <button id="protokoll_tab_btn" onclick="switchToProtokoll()" style="display:none" aria-hidden="true"></button>
   </div><!-- end .app-layout -->
 
+  <!-- iOS Install Hint Banner -->
   <div class="ios-install-banner" id="ios_install_banner">
-    <div class="ios-install-text"><strong>App installieren:</strong> Teile-Taste → <strong>Zum Home-Bildschirm</strong></div>
+    <div class="ios-install-text">
+      <strong>App installieren:</strong> Teile-Taste → <strong>Zum Home-Bildschirm</strong>
+    </div>
     <button class="ios-install-dismiss" onclick="dismissIosInstallHint()" aria-label="Hinweis schließen">✕</button>
   </div>
 
+  <!-- Update Banner ("What's New") -->
   <div class="update-banner" id="update_banner">
     <div class="update-icon">✨</div>
     <div class="update-text">
@@ -322,16 +345,26 @@
     <button class="update-dismiss" onclick="dismissUpdateHint()" aria-label="Schließen">✕</button>
   </div>
 
-  <!-- Legacy protokoll tab button (hidden) — keeps test backwards-compat -->
-  <button id="protokoll_tab_btn" onclick="switchToProtokoll()" style="display:none" aria-hidden="true"></button>
-  <div id="dashboard_overlay" style="display:none"></div>
-  <div id="dashboard_sheet" style="display:none">
-    <button id="dashboard_close" onclick="closeDashboard()" aria-label="Schließen">✕</button>
-  </div>
-
-  <!-- Theme toggle (hidden, für Settings-Panel aufrufbar) -->
-  <button id="theme_toggle" style="display:none" aria-hidden="true">🌙</button>
-
+  <!-- Main content start -->
+  <script>
+    // ============================================================================
+    // agrar-rechner — Modulare Architektur
+    //
+    // Lade-Reihenfolge (wichtig!):
+    //   state.js → calculations.js → ui-handlers.js
+    //     → render-tabs.js → render-results.js → render-drill.js → render-dashboard.js
+    //     → main.js
+    //
+    //   state.js definiert: state, saveState(), loadState()
+    //   calculations.js braucht: state, _internal (von state.js)
+    //   ui-handlers.js braucht: state, calculations.js (getActiveReiter, etc.)
+    //   render-tabs.js braucht: state, ui-handlers.js, calculations.js
+    //   render-results.js braucht: state, render-tabs.js, render-drill.js, calculations.js
+    //   render-drill.js braucht: state, ui-handlers.js, calculations.js
+    //   render-dashboard.js braucht: state, calculations.js
+    //   main.js: APP_VERSION, Event-Emitter, initTheme
+    // ============================================================================
+  </script>
   <script src="js/app-globals.js"></script>
   <script src="js/state.js"></script>
   <script src="js/calculations.js"></script>
@@ -341,13 +374,47 @@
   <script src="js/render-drill.js"></script>
   <script src="js/render-dashboard.js"></script>
   <script src="js/main.js"></script>
-  <script>
-    document.addEventListener('DOMContentLoaded', function() {
-      if (window.AppGlobals && typeof AppGlobals.initUI === 'function') {
-        AppGlobals.initUI();
-      }
-    });
-  </script>
+  <div class="version-footer" id="version_footer"></div>
+
+  <!-- Settings Modal -->
+  <div class="reset-overlay" id="settings_overlay" onclick="_onSettingsOverlayClick(event)"></div>
+  <div class="reset-modal" id="settings_modal" role="dialog" aria-modal="true" aria-labelledby="settings_modal_title">
+    <button class="reset-modal-x" onclick="_onSettingsCancel()" aria-label="Schließen">✕</button>
+    <div class="reset-modal-badge" aria-hidden="true">⚙️</div>
+    <h2 class="reset-modal-title" id="settings_modal_title">Einstellungen</h2>
+    <p class="reset-modal-subtitle">
+      Anpassungen für Aussehen und Datenverwaltung.
+    </p>
+    <div class="settings-info" id="settings_info">
+      <strong>Version <span id="settings_version">—</span></strong><br>
+      Agrar-Rechner — Einheiten &amp; Dünger für Aussaat
+    </div>
+    <div class="reset-options">
+      <button class="settings-option" id="settings_dark_mode" onclick="_onSettingsDarkMode()">
+        <span class="settings-option-icon" aria-hidden="true" id="settings_dark_icon">🌙</span>
+        <span class="settings-option-body">
+          <span class="settings-option-title" id="settings_dark_title">Dark Mode</span>
+          <span class="settings-option-desc" id="settings_dark_desc">Helles Farbschema aktivieren</span>
+        </span>
+        <span class="settings-option-info-row" id="settings_dark_state">Aus</span>
+      </button>
+      <button class="reset-option reset-option-tab" id="settings_reset_tab" onclick="_onSettingsResetTab()">
+        <span class="reset-option-icon" aria-hidden="true">🗂️</span>
+        <span class="reset-option-body">
+          <span class="reset-option-title">Aktuellen Schlag zurücksetzen</span>
+          <span class="reset-option-desc">Leert Felder &amp; Protokoll dieses Schlags</span>
+        </span>
+      </button>
+      <button class="reset-option reset-option-all" id="settings_reset_all" onclick="_onSettingsResetAll()">
+        <span class="reset-option-icon" aria-hidden="true">🗑️</span>
+        <span class="reset-option-body">
+          <span class="reset-option-title">Alle Daten löschen</span>
+          <span class="reset-option-desc">Entfernt alle Schläge &amp; Einstellungen</span>
+        </span>
+      </button>
+    </div>
+    <button class="reset-modal-cancel" onclick="_onSettingsCancel()">Schließen</button>
+  </div>
 
   <!-- Reset Confirmation Modal (Issue #236) -->
   <div class="reset-overlay" id="reset_overlay" onclick="_onOverlayClick(event)"></div>
@@ -362,7 +429,7 @@
       <button class="reset-option reset-option-tab" id="reset_modal_tab" onclick="_onResetTab()">
         <span class="reset-option-icon" aria-hidden="true">🗂️</span>
         <span class="reset-option-body">
-          <span class="reset-option-title">Aktueller Schlag</span>
+          <span class="reset-option-title">Aktuellen Schlag</span>
           <span class="reset-option-desc" id="reset_modal_tab_ctx">Leert Felder &amp; Protokoll dieses Schlags</span>
         </span>
       </button>
@@ -375,6 +442,16 @@
       </button>
     </div>
     <button class="reset-modal-cancel" onclick="_onCancel()">Abbrechen</button>
+  </div>
+
+  <!-- Hidden theme_toggle (clicked programmatically by settings modal) -->
+  <button id="theme_toggle" style="display:none" aria-hidden="true">🌙</button>
+
+  <!-- Legacy Dashboard-Sheet-DOM (für Test-Backwards-Compat). Wird vom JS nicht
+       mehr aktiv genutzt — Übersicht ist jetzt eine reguläre View. -->
+  <div id="dashboard_overlay" style="display:none"></div>
+  <div id="dashboard_sheet" style="display:none">
+    <button id="dashboard_close" onclick="closeDashboard()" aria-label="Schließen">✕</button>
   </div>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="theme-color" content="#2d4a1a">
+  <meta name="theme-color" content="#2d5016">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <link rel="manifest" href="manifest.json">
@@ -21,310 +21,191 @@
     </div>
     <div class="scrollable-content">
   <div class="container">
+    <div class="header-row">
+      <div class="header-titles">
+        <h1>🌾 Agrar-Rechner</h1>
+        <p class="subtitle">Einheiten & Dünger für Aussaat</p>
+      </div>
+      <div style="display:flex;gap:8px;align-items:flex-start;">
+        <button class="theme-toggle" onclick="toggleTheme()" id="theme_toggle" aria-label="Dark Mode umschalten">🌙</button>
+        <button class="dashboard-open-btn" onclick="openDashboard()">📊 Dashboard</button>
+      </div>
+    </div>
 
-    <!-- ===== View: Rechner (default) ===== -->
-    <section id="view_rechner">
-      <!-- App Header -->
-      <div class="header-row">
-        <div class="header-titles">
-          <div class="header-meta">Demo · Vollständiger Funktionsumfang</div>
-          <h1>Agrar-Rechner</h1>
-        </div>
-        <div class="header-actions">
-          <button class="settings-btn" onclick="openSettings()" aria-label="Einstellungen">⚙️</button>
-        </div>
+    <!-- Tabs -->
+    <div class="tab-bar" id="tab_bar">
+      <div class="tab-bar-left" id="tab_bar_left"><button class="tab-add" onclick="addReiter()">+ Tab</button></div>
+      <div class="tab-separator"></div>
+      <button class="tab-btn protokoll-tab" id="protokoll_tab_btn" onclick="switchToProtokoll()">🔧 Protokoll</button>
+    </div>
+
+    <div class="card card-input" id="card_input">
+      <h2>📐 Fläche & Aussaatstärke</h2>
+      <div class="field">
+        <label for="hektar">Hektar (SOLL)</label>
+        <input type="text" inputmode="decimal" autocomplete="off" autocorrect="off" spellcheck="false" id="hektar" placeholder="z.B. 12,5" maxlength="8" oninput="onInputFormat(this, 'decimal', event)" onchange="onInputHektar(this)" onblur="onInputHektar(this)" aria-describedby="err_hektar">
+        <div class="error-msg" id="err_hektar" role="alert"></div>
+      </div>
+      <div class="field">
+        <label for="ist_hektar">IST-Fläche (ha)</label>
+        <input type="text" inputmode="decimal" autocomplete="off" autocorrect="off" spellcheck="false" id="ist_hektar" placeholder="z.B. 12,3" oninput="onInputFormat(this, 'decimal', event)" onchange="onInputIstHektar(this)" onblur="onInputIstHektar(this)">
+      </div>
+      <div class="field">
+        <label for="koerner">Körner pro Hektar</label>
+        <input type="text" inputmode="numeric" id="koerner" placeholder="z.B. 90000" maxlength="8" oninput="onInputFormat(this, 'integer', event)" onchange="onInputKoerner(this)" onblur="onInputKoerner(this)" aria-describedby="err_koerner">
+        <div class="unit">üblich: 80.000 – 100.000</div>
+        <div class="error-msg" id="err_koerner" role="alert"></div>
       </div>
 
-      <!-- Tabs (only field tabs, no Protokoll button) -->
-      <div class="tab-bar" id="tab_bar">
-        <div class="tab-bar-left" id="tab_bar_left"></div>
+      <div class="fahrgassen-toggle">
+        <label for="einheit_groesse_toggle">Einheiten-Größe anpassen</label>
+        <button class="toggle-btn" id="einheit_groesse_toggle" onclick="einheitGroesseToggle()" aria-label="Einheiten-Größe" aria-pressed="false"></button>
+      </div>
+      <div class="fahrgassen-settings" id="einheit_groesse_settings">
+        <div class="field" style="margin-bottom:8px">
+          <label for="koerner_pro_einheit">Körner pro Einheit</label>
+          <input type="text" inputmode="numeric" id="koerner_pro_einheit" placeholder="z.B. 50000" oninput="onInputFormat(this, 'integer', event)" onchange="einheitGroesseUpdate()" onblur="einheitGroesseUpdate()">
+        </div>
+        <div class="fahrgassen-saved" id="einheit_groesse_saved"></div>
+        <div class="fahrgassen-info">Wie viele Körner eine "Einheit" Saatgut entsprechen (üblich: 50.000).</div>
+      </div>
+    </div>
+
+    <div class="card">
+      <h2>🧪 Dünger</h2>
+      <div class="field">
+        <label for="duenger">Dünger (kg/ha)</label>
+        <input type="text" inputmode="decimal" autocomplete="off" autocorrect="off" spellcheck="false" id="duenger" placeholder="z.B. 150" oninput="onInputFormat(this, 'decimal', event)" onchange="onInputDuenger(this)" onblur="onInputDuenger(this)">
       </div>
 
-      <!-- Input card: Fläche & Aussaatstärke -->
-      <div class="card card-input" id="card_input">
-        <h2>
-          <span class="section-badge">1</span>
-          Fläche &amp; Aussaatstärke
-        </h2>
-        <div class="field">
-          <label for="hektar">Hektar (SOLL)</label>
-          <div class="input-wrap">
-            <input type="text" inputmode="decimal" autocomplete="off" autocorrect="off" spellcheck="false" id="hektar" placeholder="z.B. 12,5" maxlength="8" oninput="onInputFormat(this, 'decimal', event)" onchange="onInputHektar(this)" onblur="onInputHektar(this)" aria-describedby="err_hektar">
-            <span class="input-unit">ha</span>
-          </div>
-          <div class="error-msg" id="err_hektar" role="alert"></div>
+      <div class="fahrgassen-toggle">
+        <label for="fahrgassen_toggle">Fahrgassen berücksichtigen</label>
+        <button class="toggle-btn" id="fahrgassen_toggle" onclick="fahrgassenToggle()" aria-label="Fahrgassen" aria-pressed="false"></button>
+      </div>
+      <div class="fahrgassen-settings" id="fahrgassen_settings">
+        <div class="field" style="margin-bottom:8px">
+          <label for="fahrgassen_breite">Fahrgassenbreite (m)</label>
+          <input type="text" inputmode="decimal" autocomplete="off" autocorrect="off" spellcheck="false" id="fahrgassen_breite" placeholder="z.B. 24" oninput="onInputFormat(this, 'decimal', event)" onchange="fahrgassenUpdate()" onblur="fahrgassenUpdate()">
         </div>
-        <div class="field">
-          <label for="ist_hektar">Hektar (IST) — optional, tatsächlich gefahren</label>
-          <div class="input-wrap">
-            <input type="text" inputmode="decimal" autocomplete="off" autocorrect="off" spellcheck="false" id="ist_hektar" placeholder="z.B. 12,3" oninput="onInputFormat(this, 'decimal', event)" onchange="onInputIstHektar(this)" onblur="onInputIstHektar(this)">
-            <span class="input-unit">ha</span>
-          </div>
-          <div class="hint-block">Weicht die IST- von der SOLL-Fläche ab, wird der Ausgleich im Senken-Feld sichtbar (siehe Übersicht).</div>
-        </div>
-        <div class="field">
-          <label for="koerner">Körner pro Hektar</label>
-          <div class="input-wrap">
-            <input type="text" inputmode="numeric" id="koerner" placeholder="z.B. 90000" maxlength="8" oninput="onInputFormat(this, 'integer', event)" onchange="onInputKoerner(this)" onblur="onInputKoerner(this)" aria-describedby="err_koerner">
-            <span class="input-unit">/ha</span>
-          </div>
-          <div class="unit">üblich: 80.000 – 100.000</div>
-          <div class="error-msg" id="err_koerner" role="alert"></div>
-        </div>
+        <div class="fahrgassen-saved" id="fahrgassen_saved"></div>
+        <div class="fahrgassen-info">Die Körnerzahl wird um ca. 1/Fahrgassenbreite × 100 % reduziert.</div>
+      </div>
+    </div><!-- Dünger card -->
 
-        <div class="fahrgassen-toggle">
-          <label for="einheit_groesse_toggle">Einheiten-Größe anpassen</label>
-          <button class="toggle-btn" id="einheit_groesse_toggle" onclick="einheitGroesseToggle()" aria-label="Einheiten-Größe" aria-pressed="false"></button>
-        </div>
-        <div class="fahrgassen-settings" id="einheit_groesse_settings">
-          <div class="field" style="margin-bottom:8px">
-            <label for="koerner_pro_einheit">Körner pro Einheit</label>
-            <input type="text" inputmode="numeric" id="koerner_pro_einheit" placeholder="z.B. 50000" oninput="onInputFormat(this, 'integer', event)" onchange="einheitGroesseUpdate()" onblur="einheitGroesseUpdate()">
-          </div>
-          <div class="fahrgassen-saved" id="einheit_groesse_saved"></div>
-          <div class="fahrgassen-info">Wie viele Körner eine "Einheit" Saatgut entsprechen (üblich: 50.000).</div>
-        </div>
+    <div class="card result" id="results" style="display:none">
+      <h2>📊 Ergebnis</h2>
+      <div class="result-row">
+        <span class="label">Körner gesamt</span>
+        <span class="value" id="r_korner">—</span>
+      </div>
+      <div class="result-row">
+        <span class="label">Einheiten</span>
+        <span class="value small" id="r_einheiten">—</span>
+      </div>
+      <div class="result-row">
+        <span class="label">Dünger</span>
+        <span class="value small" id="r_duenger">—</span>
       </div>
 
-      <!-- Input card: Dünger -->
-      <div class="card">
-        <h2>
-          <span class="section-badge">2</span>
-          Dünger
-        </h2>
-        <div class="field">
-          <label for="duenger">Dünger</label>
-          <div class="input-wrap">
-            <input type="text" inputmode="decimal" autocomplete="off" autocorrect="off" spellcheck="false" id="duenger" placeholder="z.B. 150" oninput="onInputFormat(this, 'decimal', event)" onchange="onInputDuenger(this)" onblur="onInputDuenger(this)">
-            <span class="input-unit">kg/ha</span>
-          </div>
+      <div id="r_soll_ist_section" style="display:none">
+        <div class="drill-separator"></div>
+        <div class="result-row">
+          <span class="label">SOLL-Fläche</span>
+          <span class="value small" id="r_soll_ha">—</span>
         </div>
-
-        <div class="fahrgassen-toggle">
-          <label for="fahrgassen_toggle">Fahrgassen berücksichtigen</label>
-          <button class="toggle-btn" id="fahrgassen_toggle" onclick="fahrgassenToggle()" aria-label="Fahrgassen" aria-pressed="false"></button>
+        <div class="result-row">
+          <span class="label">IST-Fläche</span>
+          <span class="value small" id="r_ist_ha">—</span>
         </div>
-        <div class="fahrgassen-settings" id="fahrgassen_settings">
-          <div class="field" style="margin-bottom:8px">
-            <label for="fahrgassen_breite">Fahrgassenbreite (m)</label>
-            <input type="text" inputmode="decimal" autocomplete="off" autocorrect="off" spellcheck="false" id="fahrgassen_breite" placeholder="z.B. 24" oninput="onInputFormat(this, 'decimal', event)" onchange="fahrgassenUpdate()" onblur="fahrgassenUpdate()">
-          </div>
-          <div class="fahrgassen-saved" id="fahrgassen_saved"></div>
-          <div class="fahrgassen-info">Die Körnerzahl wird um ca. 1/Fahrgassenbreite × 100 % reduziert.</div>
-        </div>
-      </div><!-- Dünger card -->
-
-      <!-- Result card (kept IDs intact) -->
-      <div class="card result" id="results" style="display:none">
-        <h2>
-          <span class="section-badge">A</span>
-          Ergebnis
-          <span class="section-meta" id="r_info"></span>
-        </h2>
-
-        <!-- Hidden but kept for data binding via renderResults (legacy) -->
-        <div id="r_korner" style="display:none"></div>
-        <div id="r_einheiten" style="display:none"></div>
-        <div id="r_duenger" style="display:none"></div>
-
-        <!-- New ring-chart layout -->
-        <div class="result-layout">
-          <div class="result-ring-chart" id="result_ring_chart">
-            <svg viewBox="0 0 100 100">
-              <circle class="result-ring-bg" cx="50" cy="50" r="44"></circle>
-              <circle class="result-ring-fg" id="r_ring_fg" cx="50" cy="50" r="44"
-                      stroke-dasharray="276.46" stroke-dashoffset="276.46"></circle>
-            </svg>
-            <div class="result-ring-center">
-              <div class="result-ring-value" id="r_ring_value">—</div>
-              <div class="result-ring-sub" id="r_ring_sub">EINH.</div>
-            </div>
-          </div>
-          <div class="result-side">
-            <div class="result-side-title" id="r_side_title">Ergebnis</div>
-            <div class="result-side-sub" id="r_side_sub">Bitte Hektar und Körner/ha eingeben.</div>
-          </div>
-        </div>
-
-        <div class="result-progress">
-          <div class="result-progress-bar">
-            <div class="result-progress-fill" id="r_progress_fill" style="width:0%"></div>
-          </div>
-          <div class="result-progress-legend">
-            <span class="legend-used" id="r_progress_used">— verbraucht</span>
-            <span class="legend-open" id="r_progress_open">— offen</span>
-          </div>
-        </div>
-
-        <!-- Legacy details (SOLL/IST/Abweichung, Carryover, Drill-Entries) -->
-        <div id="r_soll_ist_section" class="result-details" style="display:none">
-          <div class="result-row">
-            <span class="label">SOLL-Fläche</span>
-            <span class="value small" id="r_soll_ha">—</span>
-          </div>
-          <div class="result-row">
-            <span class="label">IST-Fläche</span>
-            <span class="value small" id="r_ist_ha">—</span>
-          </div>
-          <div class="result-row">
-            <span class="label">Abweichung</span>
-            <span class="value small" id="r_diff_ha">—</span>
-          </div>
-        </div>
-        <div id="r_carryover_hint" style="font-size:0.85rem;padding:4px 0;"></div>
-
-        <div id="r_drill_section" style="display:none">
-          <div class="drill-separator"></div>
-          <div class="result-row">
-            <span class="label">Einheiten eingefüllt</span>
-            <span class="value small" id="r_drill_e_used">—</span>
-          </div>
-          <div class="result-row" id="r_drill_e_rem_row">
-            <span class="label">Einheiten verbleibend</span>
-            <span class="value small" id="r_drill_e_rem">—</span>
-          </div>
-          <div class="result-row" id="r_drill_d_used_row" style="display:none">
-            <span class="label">Dünger eingefüllt</span>
-            <span class="value small" id="r_drill_d_used">—</span>
-          </div>
-          <div class="result-row" id="r_drill_d_rem_row" style="display:none">
-            <span class="label">Dünger verbleibend</span>
-            <span class="value small" id="r_drill_d_rem">—</span>
-          </div>
-          <div id="r_drill_entries"></div>
-        </div>
-      </div><!-- end results card -->
-
-      <!-- Reset this tab -->
-      <button class="reset-this-tab-btn" onclick="resetActiveTab()">
-        Diesen Schlag zurücksetzen
-      </button>
-    </section><!-- end #view_rechner -->
-
-    <!-- ===== View: Protokoll ===== -->
-    <section id="view_protokoll">
-      <div class="header-row">
-        <div class="header-titles">
-          <div class="header-meta">Demo · Vollständiger Funktionsumfang</div>
-          <h1>Drill-Protokoll</h1>
-        </div>
-        <div class="header-actions">
-          <button class="settings-btn" onclick="openSettings()" aria-label="Einstellungen">⚙️</button>
+        <div class="result-row">
+          <span class="label">Abweichung</span>
+          <span class="value small" id="r_diff_ha">—</span>
         </div>
       </div>
+      <div id="r_carryover_hint" style="font-size:0.85rem;padding:4px 0;"></div>
 
-      <div class="card" id="drill_section">
-        <div class="drill-tabs-section">
-          <div class="drill-tabs-header">Priorität &amp; Status je Schlag</div>
-          <div id="drill_tab_list"></div>
+      <div id="r_drill_section" style="display:none">
+        <div class="drill-separator"></div>
+        <div class="result-row">
+          <span class="label">Einheiten eingefüllt</span>
+          <span class="value small" id="r_drill_e_used">—</span>
         </div>
+        <div class="result-row" id="r_drill_e_rem_row">
+          <span class="label">Einheiten verbleibend</span>
+          <span class="value small" id="r_drill_e_rem">—</span>
+        </div>
+        <div class="result-row" id="r_drill_d_used_row" style="display:none">
+          <span class="label">Dünger eingefüllt</span>
+          <span class="value small" id="r_drill_d_used">—</span>
+        </div>
+        <div class="result-row" id="r_drill_d_rem_row" style="display:none">
+          <span class="label">Dünger verbleibend</span>
+          <span class="value small" id="r_drill_d_rem">—</span>
+        </div>
+        <div id="r_drill_entries"></div>
+      </div>
 
-        <h2>
-          <span class="section-badge">+</span>
-          Maschine eingefüllt
-        </h2>
-        <div id="drill_mask">
-          <div class="drill-machine-row">
-            <div class="field">
-              <label for="drill_einheit">Einheiten gesamt</label>
-              <div class="input-wrap">
-                <input type="text" inputmode="decimal" autocomplete="off" autocorrect="off" spellcheck="false" id="drill_einheit" placeholder="z.B. 4" oninput="drillCalcDebounced(); onInputFormat(this, 'decimal', event)">
-              </div>
-            </div>
-            <div class="field">
-              <label for="drill_duenger">Dünger gesamt</label>
-              <div class="input-wrap">
-                <input type="text" inputmode="decimal" autocomplete="off" autocorrect="off" spellcheck="false" id="drill_duenger" placeholder="z.B. 200" oninput="drillCalcDebounced(); onInputFormat(this, 'decimal', event)">
-                <span class="input-unit">kg</span>
-              </div>
-            </div>
+      <div class="info" id="r_info"></div>
+    </div><!-- end results card -->
+
+    <div class="card" id="drill_section" style="display:none">
+      <h2>🔧 Drill-Protokoll</h2>
+      <div id="drill_mask">
+        <div class="drill-machine-row">
+          <div class="field">
+            <label for="drill_einheit">Maschine eingefüllt (Einheiten)</label>
+            <input type="text" inputmode="decimal" autocomplete="off" autocorrect="off" spellcheck="false" id="drill_einheit" placeholder="z.B. 4" oninput="drillCalcDebounced(); onInputFormat(this, 'decimal', event)">
           </div>
           <div class="field">
-            <label for="drill_hektar">Zählerstand (ha) — optional</label>
-            <div class="input-wrap">
-              <input type="text" inputmode="decimal" autocomplete="off" autocorrect="off" spellcheck="false" id="drill_hektar" placeholder="z.B. 5,2" oninput="onInputFormat(this, 'decimal', event)">
-              <span class="input-unit">ha</span>
-            </div>
+            <label for="drill_duenger">Maschine eingefüllt (Dünger kg)</label>
+            <input type="text" inputmode="decimal" autocomplete="off" autocorrect="off" spellcheck="false" id="drill_duenger" placeholder="z.B. 200" oninput="drillCalcDebounced(); onInputFormat(this, 'decimal', event)">
           </div>
-          <div class="hint-block">Ohne gesetzte Prioritäten wird alles auf den aktiven Schlag ("Schlag Nord") gebucht.</div>
-          <button class="btn-add" onclick="drillAdd()">+ Verteilen &amp; eintragen</button>
         </div>
-        <div id="drill_summary" class="drill-summary" style="display:none">
-          <div id="ds_total_summary" class="drill-total-summary" style="margin-bottom:8px;font-weight:bold;"></div>
-          <div class="drill-summary-row">
-            <span>Einheiten gesamt</span>
-            <span id="ds_saat_total">—</span>
-          </div>
-          <div class="drill-summary-row">
-            <span>Einheiten verwendet</span>
-            <span id="ds_saat_used">—</span>
-          </div>
-          <div class="drill-summary-row remaining">
-            <span>Einheiten verbleibend</span>
-            <span id="ds_saat_remaining">—</span>
-          </div>
-          <div class="drill-summary-row">
-            <span>Dünger gesamt</span>
-            <span id="ds_duenger_total">—</span>
-          </div>
-          <div class="drill-summary-row">
-            <span>Dünger verwendet</span>
-            <span id="ds_duenger_used">—</span>
-          </div>
-          <div class="drill-summary-row remaining">
-            <span>Dünger verbleibend</span>
-            <span id="ds_duenger_remaining">—</span>
-          </div>
-          <div class="drill-summary-savings" id="ds_savings" style="display:none"></div>
+        <div class="field">
+          <label for="drill_hektar">Zählerstand (ha)</label>
+          <input type="text" inputmode="decimal" autocomplete="off" autocorrect="off" spellcheck="false" id="drill_hektar" placeholder="z.B. 5,2" oninput="onInputFormat(this, 'decimal', event)">
         </div>
-
-        <!-- Maschinen-Log (innerhalb #drill_section, damit nur eine .card
-             in #view_protokoll existiert → tests/15-render-view + 22-contract) -->
-        <section class="drill-log-subsection">
-          <h2 class="subsection-header">Maschinen-Log</h2>
-          <div id="drill_machine_log"></div>
-          <div id="drill_entries"></div>
-        </section>
+        <div class="drill-tabs-section">
+          <div class="drill-tabs-header">Aufteilen auf (Klick = Prio: 1 → 2 → 3 → aus):</div>
+          <div id="drill_tab_list"></div>
+        </div>
+        <button class="btn-add" onclick="drillAdd()">+ Einfüllen</button>
       </div>
-    </section><!-- end #view_protokoll -->
-
-    <!-- ===== View: Übersicht ===== -->
-    <section id="view_uebersicht">
-      <div class="header-row">
-        <div class="header-titles">
-          <div class="header-meta">Demo · Vollständiger Funktionsumfang</div>
-          <h1>Übersicht</h1>
+      <div id="drill_summary" class="drill-summary" style="display:none">
+        <div id="ds_total_summary" class="drill-total-summary" style="margin-bottom:8px;font-weight:bold;"></div>
+        <div class="drill-summary-row">
+          <span>Einheiten gesamt</span>
+          <span id="ds_saat_total">—</span>
         </div>
-        <div class="header-actions">
-          <button class="settings-btn" onclick="openSettings()" aria-label="Einstellungen">⚙️</button>
+        <div class="drill-summary-row">
+          <span>Einheiten verwendet</span>
+          <span id="ds_saat_used">—</span>
         </div>
+        <div class="drill-summary-row remaining">
+          <span>Einheiten verbleibend</span>
+          <span id="ds_saat_remaining">—</span>
+        </div>
+        <div class="drill-summary-row">
+          <span>Dünger gesamt</span>
+          <span id="ds_duenger_total">—</span>
+        </div>
+        <div class="drill-summary-row">
+          <span>Dünger verwendet</span>
+          <span id="ds_duenger_used">—</span>
+        </div>
+        <div class="drill-summary-row remaining">
+          <span>Dünger verbleibend</span>
+          <span id="ds_duenger_remaining">—</span>
+        </div>
+        <div class="drill-summary-savings" id="ds_savings" style="display:none"></div>
       </div>
-      <div id="dashboard_content"></div>
-    </section><!-- end #view_uebersicht -->
+      <div id="drill_machine_log"></div>
+      <div id="drill_entries"></div>
+    </div>
 
-  </div><!-- end .container -->
+    </div><!-- end .container -->
 
     </div><!-- end .scrollable-content -->
-
-    <!-- Sticky Bottom Navigation -->
-    <nav class="bottom-nav" id="bottom_nav" aria-label="Hauptnavigation">
-      <button class="bottom-nav-item" id="bn_rechner" onclick="switchToRechner()">
-        <span class="bottom-nav-icon" aria-hidden="true">🌾</span>
-        <span>Rechner</span>
-      </button>
-      <button class="bottom-nav-item" id="bn_protokoll" onclick="switchToProtokoll()">
-        <span class="bottom-nav-icon" aria-hidden="true">📋</span>
-        <span>Protokoll</span>
-      </button>
-      <button class="bottom-nav-item" id="bn_uebersicht" onclick="switchToUebersicht()">
-        <span class="bottom-nav-icon" aria-hidden="true">📊</span>
-        <span>Übersicht</span>
-      </button>
-    </nav>
-
-    <!-- Hidden legacy protokoll_tab_btn (für Test-Backwards-Compat).
-         Die Bottom-Nav Button bn_protokoll triggers die echte View-Switch. -->
-    <button id="protokoll_tab_btn" onclick="switchToProtokoll()" style="display:none" aria-hidden="true"></button>
   </div><!-- end .app-layout -->
 
   <!-- iOS Install Hint Banner -->
@@ -349,6 +230,10 @@
   <script>
     // ============================================================================
     // agrar-rechner — Modulare Architektur
+    //
+    // Früher: ~2172 Zeilen inline JS in index.html
+    // Dann: 5 Module (state/calculations/ui-handlers/rendering/main)
+    // Jetzt: 8 Module (rendering aufgeteilt in 4: Issue #212)
     //
     // Lade-Reihenfolge (wichtig!):
     //   state.js → calculations.js → ui-handlers.js
@@ -375,48 +260,19 @@
   <script src="js/render-dashboard.js"></script>
   <script src="js/main.js"></script>
   <div class="version-footer" id="version_footer"></div>
-
-  <!-- Settings Modal -->
-  <div class="reset-overlay" id="settings_overlay" onclick="_onSettingsOverlayClick(event)"></div>
-  <div class="reset-modal" id="settings_modal" role="dialog" aria-modal="true" aria-labelledby="settings_modal_title">
-    <button class="reset-modal-x" onclick="_onSettingsCancel()" aria-label="Schließen">✕</button>
-    <div class="reset-modal-badge" aria-hidden="true">⚙️</div>
-    <h2 class="reset-modal-title" id="settings_modal_title">Einstellungen</h2>
-    <p class="reset-modal-subtitle">
-      Anpassungen für Aussehen und Datenverwaltung.
-    </p>
-    <div class="settings-info" id="settings_info">
-      <strong>Version <span id="settings_version">—</span></strong><br>
-      Agrar-Rechner — Einheiten &amp; Dünger für Aussaat
-    </div>
-    <div class="reset-options">
-      <button class="settings-option" id="settings_dark_mode" onclick="_onSettingsDarkMode()">
-        <span class="settings-option-icon" aria-hidden="true" id="settings_dark_icon">🌙</span>
-        <span class="settings-option-body">
-          <span class="settings-option-title" id="settings_dark_title">Dark Mode</span>
-          <span class="settings-option-desc" id="settings_dark_desc">Helles Farbschema aktivieren</span>
-        </span>
-        <span class="settings-option-info-row" id="settings_dark_state">Aus</span>
-      </button>
-      <button class="reset-option reset-option-tab" id="settings_reset_tab" onclick="_onSettingsResetTab()">
-        <span class="reset-option-icon" aria-hidden="true">🗂️</span>
-        <span class="reset-option-body">
-          <span class="reset-option-title">Aktuellen Schlag zurücksetzen</span>
-          <span class="reset-option-desc">Leert Felder &amp; Protokoll dieses Schlags</span>
-        </span>
-      </button>
-      <button class="reset-option reset-option-all" id="settings_reset_all" onclick="_onSettingsResetAll()">
-        <span class="reset-option-icon" aria-hidden="true">🗑️</span>
-        <span class="reset-option-body">
-          <span class="reset-option-title">Alle Daten löschen</span>
-          <span class="reset-option-desc">Entfernt alle Schläge &amp; Einstellungen</span>
-        </span>
-      </button>
-    </div>
-    <button class="reset-modal-cancel" onclick="_onSettingsCancel()">Schließen</button>
+  <div class="footer-actions">
+    <button class="footer-reset-btn" onclick="openResetModal()" aria-label="Daten zurücksetzen">🗑️ Daten zurücksetzen</button>
   </div>
-
-  <!-- Reset Confirmation Modal (Issue #236) -->
+  <!-- Dashboard overlay + sheet -->
+  <div class="dashboard-overlay" id="dashboard_overlay" onclick="closeDashboard()"></div>
+  <div class="dashboard-sheet" id="dashboard_sheet" role="dialog" aria-modal="true" aria-label="Dashboard — Alle Tabs Übersicht">
+    <div class="dashboard-header">
+      <h2>📊 Alle Tabs</h2>
+      <button class="dashboard-close" onclick="closeDashboard()" aria-label="Schließen">✕</button>
+    </div>
+    <div class="dashboard-content" id="dashboard_content"></div>
+  </div>
+  <!-- Reset Confirmation Modal (Issue #236, redesign v3) -->
   <div class="reset-overlay" id="reset_overlay" onclick="_onOverlayClick(event)"></div>
   <div class="reset-modal" id="reset_modal" role="dialog" aria-modal="true" aria-labelledby="reset_modal_title" aria-describedby="reset_modal_desc">
     <button class="reset-modal-x" id="reset_modal_cancel" onclick="_onCancel()" aria-label="Schließen">✕</button>
@@ -429,29 +285,19 @@
       <button class="reset-option reset-option-tab" id="reset_modal_tab" onclick="_onResetTab()">
         <span class="reset-option-icon" aria-hidden="true">🗂️</span>
         <span class="reset-option-body">
-          <span class="reset-option-title">Aktuellen Schlag</span>
-          <span class="reset-option-desc" id="reset_modal_tab_ctx">Leert Felder &amp; Protokoll dieses Schlags</span>
+          <span class="reset-option-title">Aktuellen Tab</span>
+          <span class="reset-option-desc" id="reset_modal_tab_ctx">Leert Felder &amp; Protokoll dieses Tabs</span>
         </span>
       </button>
       <button class="reset-option reset-option-all" id="reset_modal_confirm_all" onclick="_onResetAll()">
         <span class="reset-option-icon" aria-hidden="true">🗑️</span>
         <span class="reset-option-body">
           <span class="reset-option-title">Alle Daten löschen</span>
-          <span class="reset-option-desc" id="reset_modal_all_ctx">Entfernt alle Schläge &amp; Einstellungen</span>
+          <span class="reset-option-desc" id="reset_modal_all_ctx">Entfernt alle Tabs &amp; Einstellungen</span>
         </span>
       </button>
     </div>
     <button class="reset-modal-cancel" onclick="_onCancel()">Abbrechen</button>
-  </div>
-
-  <!-- Hidden theme_toggle (clicked programmatically by settings modal) -->
-  <button id="theme_toggle" style="display:none" aria-hidden="true">🌙</button>
-
-  <!-- Legacy Dashboard-Sheet-DOM (für Test-Backwards-Compat). Wird vom JS nicht
-       mehr aktiv genutzt — Übersicht ist jetzt eine reguläre View. -->
-  <div id="dashboard_overlay" style="display:none"></div>
-  <div id="dashboard_sheet" style="display:none">
-    <button id="dashboard_close" onclick="closeDashboard()" aria-label="Schließen">✕</button>
   </div>
 </body>
 </html>

--- a/public/js/calculations.js
+++ b/public/js/calculations.js
@@ -202,7 +202,7 @@ function computeAllCarryovers() {
     var absorbiert = 0;
     for (let i = 0; i < n; i++) {
       var rr = reiter[i];
-      if (!rr || rr.done) continue;  // Issue #371: done tabs zählen NICHT in den Pool
+      if (!rr) continue;
       var sol = getSol(rr);
       var used = getUsed(rr);
       var own;

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -7,7 +7,7 @@
 // ============================================================================
 
 // --- App Constants ---
-var APP_VERSION = 'v1.2.0';
+var APP_VERSION = 'v1.1.0';
 var APP_BUILD_DATE = 'Juli 2026';
 
 // --- Format/Parser Utilities (used across modules) ---

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -7,8 +7,8 @@
 // ============================================================================
 
 // --- App Constants ---
-var APP_VERSION = 'v1.1.0';
-var APP_BUILD_DATE = 'Juli 2026';
+var APP_VERSION = 'v1.0.0';
+var APP_BUILD_DATE = 'Mai 2025';
 
 // --- Format/Parser Utilities (used across modules) ---
 //

--- a/public/js/render-dashboard.js
+++ b/public/js/render-dashboard.js
@@ -1,5 +1,5 @@
 // ============================================================================
-// RENDER-DASHBOARD — Übersicht-View (in-page, ehemals Dashboard-Sheet)
+// RENDER-DASHBOARD — Dashboard-Übersicht (Sheet) + openDashboard/closeDashboard
 //
 // Lade-Reihenfolge: state (state.js) → calc (calculations.js) → ui (ui-handlers.js) → render-tabs
 //   → render-results → render-drill → render-dashboard (DIESE DATEI)
@@ -10,8 +10,8 @@
 // Funktionen werden im globalen Scope definiert (Vanilla-JS / <script>-Tags).
 // ============================================================================
 
-    // --- Render: Übersicht ---
-    // Issue #186: muss bei Ist-Fläche-Änderungen live aktualisiert werden.
+    // --- Render: Dashboard ---
+    // Issue #186: Dashboard muss bei Ist-Fläche-Änderungen live aktualisiert werden.
     // Verwendet IST-Fläche (wenn gesetzt) als Basis für "verbleibend"-Berechnung,
     // konsistent mit renderResultCard() und renderDrillSummary().
 
@@ -39,13 +39,16 @@
       if (reiter.length === 0) {
         var emptyDiv = document.createElement('div');
         emptyDiv.className = 'dashboard-empty';
-        emptyDiv.textContent = 'Keine Schläge vorhanden';
+        emptyDiv.textContent = 'Keine Tabs vorhanden';
         container.appendChild(emptyDiv);
         return;
       }
       container.innerHTML = '';
 
       // --- Summary across all tabs (IST-basiert wenn verfügbar) ---
+      // Issue #305: per-tab "verbleibend" must net carryover (saved/excess).
+      // Cross-tab aggregation: sum per-tab max(0, basis - used - saved + excess)
+      // — equivalent to Phase A/B in renderDrillSummary() (#302).
       var totalHa = 0;
       var totalEinheitRem = 0, totalDuengerRem = 0;
       var totalEinheitenBasis = 0, totalEinheitenUsed = 0;
@@ -54,6 +57,10 @@
         if (r.hektar > 0 && r.koerner > 0) {
           var istSum = AppGlobals.getTabIstHektar(r);
           totalHa += istSum > 0 ? istSum : r.hektar;
+          // Issue 2 (Code-Review): DRY — alle vier "verbleibend"-Sites ziehen
+          // Basis + Used + Carryover aus getTabRemaining. Die `|| 0`-Guards
+          // in getTabUsedEinheiten/Duenger fixen den NaN-Bug, der vorher bei
+          // fehlendem `e.einheit` über die bare reduce here propagiert wurde.
           var rem = AppGlobals.getTabRemaining(r, idx);
           totalEinheitRem += rem.remainingE;
           totalDuengerRem += rem.remainingD;
@@ -70,59 +77,34 @@
           ) * 100))
         : 0;
 
-      // === Big green summary card ===
       var summaryCard = document.createElement('div');
-      summaryCard.className = 'uebersicht-summary';
-      var lblSummary = document.createElement('div');
-      lblSummary.className = 'uebersicht-summary-label';
-      lblSummary.textContent = 'Gesamt offen';
-      summaryCard.appendChild(lblSummary);
-      var valSummary = document.createElement('div');
-      valSummary.className = 'uebersicht-summary-value';
-      valSummary.textContent = totalEinheitRem > 0 ? AppGlobals.fmt(totalEinheitRem) + ' Einheiten' : '—';
-      summaryCard.appendChild(valSummary);
-      var metaSummary = document.createElement('div');
-      metaSummary.className = 'uebersicht-summary-meta';
-      metaSummary.textContent = 'über ' + reiter.length + (reiter.length === 1 ? ' Schlag' : ' Schläge') +
-        (totalDuengerBasis > 0 ? ' · ' + Math.round(totalDuengerRem).toLocaleString('de-DE') + ' kg Dünger offen' : '');
-      summaryCard.appendChild(metaSummary);
+      summaryCard.className = 'dashboard-summary';
+
+      var sTitle = document.createElement('div');
+      sTitle.className = 'dashboard-summary-title';
+      sTitle.textContent = '📊 Zusammenfassung';
+      summaryCard.appendChild(sTitle);
+
+      var sStats = document.createElement('div');
+      sStats.className = 'dashboard-summary-stats';
+
+      var pctClass = totalPct >= 100 ? 'done' : totalPct > 0 ? 'remaining' : '';
+      sStats.appendChild(makeSummaryStat('Fläche', totalHa > 0 ? AppGlobals.fmtCompact(totalHa) + ' ha' : '—'));
+      // fmtCompact: integer values shown without trailing ",0" (e.g. "8" not "8,0").
+      // Tests 26, 27, 40 use toBe('8') on this element; test 18-round2 uses
+      // toContain('15') on it. fmt() would produce "8,0" and break those tests.
+      sStats.appendChild(makeSummaryStat('Einheiten verbl.', totalEinheitenBasis > 0 ? AppGlobals.fmtCompact(totalEinheitRem) : '—', pctClass));
+      sStats.appendChild(makeSummaryStat('Dünger verbl.', totalDuengerBasis > 0 ? totalDuengerRem.toLocaleString('de-DE') + ' kg' : '—', pctClass));
+      summaryCard.appendChild(sStats);
+
+      var pBar = document.createElement('div');
+      pBar.className = 'dashboard-progress-bar';
+      var pFill = document.createElement('div');
+      pFill.className = 'dashboard-progress-fill';
+      pFill.style.width = totalPct + '%';
+      pBar.appendChild(pFill);
+      summaryCard.appendChild(pBar);
       container.appendChild(summaryCard);
-
-      // === Two dark-green stat tiles (kept visible in new layout) ===
-      var tilesRow = document.createElement('div');
-      tilesRow.className = 'uebersicht-stat-tiles';
-      var tile1 = document.createElement('div');
-      tile1.className = 'uebersicht-stat-tile';
-      tile1.innerHTML = '<div class="uebersicht-stat-tile-label">Gesamtfläche (SOLL)</div>' +
-        '<div class="uebersicht-stat-tile-value">' +
-        (totalHa > 0 ? AppGlobals.fmtCompact(totalHa) + ' ha' : '—') +
-        '</div>';
-      tilesRow.appendChild(tile1);
-      var tile2 = document.createElement('div');
-      tile2.className = 'uebersicht-stat-tile';
-      tile2.innerHTML = '<div class="uebersicht-stat-tile-label">Dünger offen</div>' +
-        '<div class="uebersicht-stat-tile-value">' +
-        (totalDuengerBasis > 0 ? Math.round(totalDuengerRem).toLocaleString('de-DE') + ' kg' : '—') +
-        '</div>';
-      tilesRow.appendChild(tile2);
-      container.appendChild(tilesRow);
-
-      // === Legacy dashboard-summary (for Tests 26, 29, 47: querySelectorAll
-      // '.dashboard-summary-stat'). Bleibt als unsichtbarer Hook für Tests. ===
-      var legacySummary = document.createElement('div');
-      legacySummary.className = 'dashboard-summary';
-      legacySummary.style.display = 'none';
-      legacySummary.appendChild(makeSummaryStat('Fläche', totalHa > 0 ? AppGlobals.fmtCompact(totalHa) + ' ha' : '—'));
-      legacySummary.appendChild(makeSummaryStat('Einheiten verbl.', totalEinheitenBasis > 0 ? AppGlobals.fmtCompact(totalEinheitRem) : '—', totalPct >= 100 ? 'done' : totalPct > 0 ? 'remaining' : ''));
-      legacySummary.appendChild(makeSummaryStat('Dünger verbl.', totalDuengerBasis > 0 ? Math.round(totalDuengerRem).toLocaleString('de-DE') + ' kg' : '—', totalPct >= 100 ? 'done' : totalPct > 0 ? 'remaining' : ''));
-      var lpf = document.createElement('div');
-      lpf.className = 'dashboard-progress-bar';
-      var lf = document.createElement('div');
-      lf.className = 'dashboard-progress-fill';
-      lf.style.width = totalPct + '%';
-      lpf.appendChild(lf);
-      legacySummary.appendChild(lpf);
-      container.appendChild(legacySummary);
 
       // --- Per-tab cards ---
       reiter.forEach(function(r, idx) {
@@ -131,21 +113,16 @@
 
         var nameEl = document.createElement('div');
         nameEl.className = 'dashboard-reiter-name';
-        var nameSpan = document.createElement('span');
-        nameSpan.textContent = r.name || ('Tab ' + (idx + 1));
+        nameEl.textContent = r.name || ('Reiter ' + (idx + 1));
         if (idx === AppGlobals.state.activeReiter) {
-          nameSpan.textContent += ' (aktiv)';
+          nameEl.textContent += ' (aktiv)';
         }
-        nameEl.appendChild(nameSpan);
-        var haBadge = document.createElement('span');
-        haBadge.className = 'ha-badge';
-        haBadge.textContent = (r.hektar > 0 ? AppGlobals.fmtCompact(r.hektar) + ' ha' : '—');
-        nameEl.appendChild(haBadge);
         card.appendChild(nameEl);
 
         var stats = document.createElement('div');
         stats.className = 'dashboard-reiter-stats';
 
+        // Hektar (SOLL + IST if different)
         var haDiv = document.createElement('div');
         haDiv.className = 'dashboard-stat';
         var haDivLabel = document.createElement('div');
@@ -163,6 +140,7 @@
         haDiv.appendChild(haDivVal);
         stats.appendChild(haDiv);
 
+        // Körner/ha
         var kDiv = document.createElement('div');
         kDiv.className = 'dashboard-stat';
         var kDivLabel = document.createElement('div');
@@ -175,6 +153,7 @@
         kDiv.appendChild(kDivVal);
         stats.appendChild(kDiv);
 
+        // IST-basierte Berechnung (wenn IST-Fläche gesetzt, sonst SOLL)
         var einheiten = 0;
         var usedEinheit = 0;
         var duengerTotal = 0;
@@ -184,6 +163,9 @@
         var pct = 0;
         var statusClass = 'na';
         if (r.hektar > 0 && r.koerner > 0) {
+          // Issue 2 (Code-Review): DRY — getTabRemaining liefert Basis + Used
+          // + Carryover-genettetes Remaining aus einer Quelle (fix #266-A
+          // Konsistenz + NaN-Bug, der durch bare reduce entstand).
           var rem = AppGlobals.getTabRemaining(r, idx);
           einheiten = rem.basisE;
           usedEinheit = rem.usedE;
@@ -200,6 +182,7 @@
           else if (pct > 0) statusClass = 'remaining';
         }
 
+        // Einheiten verbleibend
         var eStat = document.createElement('div');
         eStat.className = 'dashboard-stat';
         var eStatLabel = document.createElement('div');
@@ -212,6 +195,7 @@
         eStat.appendChild(eStatVal);
         stats.appendChild(eStat);
 
+        // Dünger verbleibend
         var dStat = document.createElement('div');
         dStat.className = 'dashboard-stat';
         var dStatLabel = document.createElement('div');
@@ -224,6 +208,7 @@
         dStat.appendChild(dStatVal);
         stats.appendChild(dStat);
 
+        // Progress bar
         var progressWrap = document.createElement('div');
         progressWrap.className = 'dashboard-progress-bar';
         var progressFill = document.createElement('div');
@@ -232,43 +217,76 @@
         progressWrap.appendChild(progressFill);
         stats.appendChild(progressWrap);
 
-        var legend = document.createElement('div');
-        legend.className = 'dashboard-progress-legend';
-        legend.innerHTML = '<span>' + (r.hektar > 0 && r.koerner > 0 ? pct + '% erledigt' : '—') + '</span>' +
-          '<span><strong>' + (r.hektar > 0 && r.koerner > 0 ? AppGlobals.fmtCompact(einheitRem) + ' Einh. offen' : '—') + '</strong></span>';
-        stats.appendChild(legend);
-
         card.appendChild(stats);
         container.appendChild(card);
       });
     }
 
-    // Backwards-Compat-Aliase für openDashboard/closeDashboard — Übersicht ist
-    // jetzt eine reguläre View (#view_uebersicht), kein Sheet mehr. Tests
-    // rufen openDashboard() und prüfen dashboard_content/dashboard_sheet-
-    // Elementarriere. Wir rendern in dashboard_content (#view_uebersicht) und
-    // toggeln die open-Klasse auf den Legay-Sheet-Elementen (no-op in UI,
-    // sichtbar für Tests).
+    // Öffnet das Dashboard-Sheet und ruft renderDashboard() auf.
+    // Issue #186: muss auch nach ENTRY_CHANGED-Events den State korrekt widerspiegeln.
+    // Issue #211: Fokus-Falle und Dialog-Semantik für Accessibility.
+    var _dashboardPrevFocus = null;
+
+    // Trap Tab/Shift+Tab inside the dashboard dialog (Issue #211)
+    function _dashboardKeyHandler(e) {
+      if (e.key === 'Escape') {
+        closeDashboard();
+        e.preventDefault();
+        return;
+      }
+      if (e.key !== 'Tab') return;
+      var sheet = document.getElementById('dashboard_sheet');
+      if (!sheet) return;
+      var focusable = sheet.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+      if (focusable.length === 0) return;
+      var first = focusable[0];
+      var last = focusable[focusable.length - 1];
+      if (e.shiftKey) {
+        if (document.activeElement === first) { last.focus(); e.preventDefault(); }
+      } else {
+        if (document.activeElement === last) { first.focus(); e.preventDefault(); }
+      }
+    }
+
     function openDashboard() {
       var sheet = document.getElementById('dashboard_sheet');
       var overlay = document.getElementById('dashboard_overlay');
+      _dashboardPrevFocus = document.activeElement;
       if (sheet) sheet.classList.add('open');
       if (overlay) overlay.classList.add('open');
-      try { document.body.style.overflow = 'hidden'; } catch (e) {}
+      document.body.style.overflow = 'hidden';
       renderDashboard();
+      // Move focus into the dialog for accessibility (Issue #211)
+      // Use setTimeout to avoid jsdom focus-event side effects
+      if (sheet) {
+        setTimeout(function() {
+          var closeBtn = sheet.querySelector('.dashboard-close');
+          if (closeBtn) closeBtn.focus();
+        }, 0);
+      }
+      document.addEventListener('keydown', _dashboardKeyHandler);
     }
+
+    // Schließt das Dashboard-Sheet.
     function closeDashboard() {
       var sheet = document.getElementById('dashboard_sheet');
       var overlay = document.getElementById('dashboard_overlay');
       if (sheet) sheet.classList.remove('open');
       if (overlay) overlay.classList.remove('open');
-      try { document.body.style.overflow = ''; } catch (e) {}
+      document.body.style.overflow = '';
+      document.removeEventListener('keydown', _dashboardKeyHandler);
+      // Restore focus to the element that opened the dashboard
+      if (_dashboardPrevFocus && _dashboardPrevFocus.focus) {
+        _dashboardPrevFocus.focus();
+        _dashboardPrevFocus = null;
+      }
     }
 
     // Register exposed globals on AppGlobals (ADR-001 Schritt 3, Issue #278).
     Object.assign(window.AppGlobals, {
       renderDashboard: renderDashboard,
       makeSummaryStat: makeSummaryStat,
+      _dashboardKeyHandler: _dashboardKeyHandler,
       openDashboard: openDashboard,
       closeDashboard: closeDashboard,
     });

--- a/public/js/render-drill.js
+++ b/public/js/render-drill.js
@@ -17,27 +17,10 @@
       var container = document.getElementById('drill_tab_list');
       if (!container) return;
       container.innerHTML = '';
-      // Bestimme den Senken-Tab (zuletzt befüllt, nicht done) für AUSGLEICHSFELD-Badge.
-      // Konsistent mit calculations.js :: computeAllCarryovers().
-      var sinkIdx = -1;
-      AppGlobals.state.reiter.forEach(function(r, j) {
-        if (!r || r.done) return;
-        if (r.entries && r.entries.length > 0) {
-          var lastT = (r.entries[r.entries.length - 1] || {}).time || 0;
-          if (sinkIdx === -1 || lastT > ((AppGlobals.state.reiter[sinkIdx].entries[AppGlobals.state.reiter[sinkIdx].entries.length - 1] || {}).time || 0)) {
-            sinkIdx = j;
-          }
-        }
-      });
-      if (AppGlobals.state.reiter.some(function(r) { return r && r.entries && r.entries.length > 0; }) && sinkIdx === -1) {
-        // Fallback: erster Tab mit Entries, wenn keine Zeit-Sortierung möglich
-        for (var fi = 0; fi < AppGlobals.state.reiter.length; fi++) {
-          if (AppGlobals.state.reiter[fi].entries && AppGlobals.state.reiter[fi].entries.length > 0) { sinkIdx = fi; break; }
-        }
-      }
       AppGlobals.state.reiter.forEach(function(r, i) {
+        // Issue #377: `done` ist ein expliziter User-Toggle (NICHT von used>=SOLL
+        // abgeleitet — das ist nur ein Hinweis). Default false für neue/alte Tabs.
         var isDone = r.done === true;
-        var isSink = (i === sinkIdx);
         var row = document.createElement('div');
         row.className = 'drill-tab-row' + (isDone ? ' done' : '');
         var prioBtn = document.createElement('button');
@@ -63,35 +46,44 @@
         nameWrap.className = 'drill-tab-name-wrap';
         var label = document.createElement('div');
         label.className = 'drill-tab-name';
-        label.textContent = r.name || ('Schlag ' + (i + 1));
-        if (isSink) {
-          var badge = document.createElement('span');
-          badge.className = 'drill-prio-badge';
-          badge.textContent = 'AUSGLEICHSFELD';
-          label.appendChild(badge);
-        }
+        label.textContent = r.name || ('Tab ' + (i + 1));
         nameWrap.appendChild(label);
         if (r.hektar > 0 && r.koerner > 0) {
+          // Issue 2 (Code-Review): DRY + NaN-Fix. Die alten bare reduces
+          //   r.entries.reduce(function(s, e) { return s + e.einheit; }, 0)
+          //   r.entries.reduce(function(s, e) { return s + e.duenger; }, 0)
+          // hatten KEIN `|| 0`-Guard und produzierten NaN sobald ein Entry
+          // kein `einheit`/`duenger`-Feld hatte. getTabRemaining zieht
+          // getTabUsedEinheiten/Duenger (mit `|| 0` Guards) und liefert
+          // basisE/D + remainingE/D + carryover-genettet in einem Aufruf.
           var rem = AppGlobals.getTabRemaining(r, i);
           var remaining = rem.remainingE;
           var remainingD = rem.remainingD;
           var statusEl = document.createElement('div');
           statusEl.id = 'dtl_need_' + i;
           statusEl.className = 'drill-tab-need';
+          // Issue #377: "✓ fertig"-Hinweis bleibt als visueller Status, wenn
+          // used >= SOLL — ist aber explizit KEIN Hinweis auf den User-Toggle
+          // `done`. Letzterer wird über den grünen Button separat gesetzt.
           if (remaining <= 0.05 && remainingD <= 0.05) {
             statusEl.textContent = '✓ fertig';
             statusEl.classList.add('done');
           } else if (remainingD <= 0.05) {
+            // Nur Saatgut übrig — Dünger-Anteil weglassen (Issue #266)
             statusEl.textContent = 'braucht ' + AppGlobals.fmt(Math.max(0, remaining)) + ' Einheiten';
           } else if (remaining <= 0.05) {
+            // Nur Dünger übrig (seltener Fall, abgedeckt für Vollständigkeit)
             statusEl.textContent = 'braucht ' + AppGlobals.fmt(Math.max(0, remainingD)) + ' kg Dünger';
           } else {
-            statusEl.textContent = 'braucht ' + AppGlobals.fmt(Math.max(0, remaining)) + ' Einheiten · ' + AppGlobals.fmt(Math.max(0, remainingD)) + ' kg Dünger';
+            statusEl.textContent = 'braucht ' + AppGlobals.fmt(Math.max(0, remaining)) + ' Einheiten, ' + AppGlobals.fmt(Math.max(0, remainingD)) + ' kg Dünger';
           }
           nameWrap.appendChild(statusEl);
         }
         row.appendChild(nameWrap);
-        // Hidden per-tab inputs (kept for tests; CSS display:none).
+        // Issue #377: Einheiten- und Dünger-Inputs sind reine Anzeige-Felder
+        // (Werte werden aus dem Verteilungsplan in dtl_e_<i>/dtl_d_<i>
+        // geschrieben). `disabled` verhindert User-Eingaben und macht visuell
+        // klar, dass der Tab abgeschlossen ist.
         var einheitIn = document.createElement('input');
         einheitIn.type = 'text';
         einheitIn.inputMode = 'decimal';
@@ -99,7 +91,9 @@
         einheitIn.placeholder = 'Einheiten';
         einheitIn.dataset.tabIdx = String(i);
         if (isDone) einheitIn.disabled = true;
-        einheitIn.oninput = function() { AppGlobals.drillCalcDebounced(); };
+        einheitIn.oninput = function() {
+          AppGlobals.drillCalcDebounced();
+        };
         row.appendChild(einheitIn);
         var duengerIn = document.createElement('input');
         duengerIn.type = 'text';
@@ -108,25 +102,32 @@
         duengerIn.placeholder = 'kg Dünger';
         duengerIn.dataset.tabIdx = String(i);
         if (isDone) duengerIn.disabled = true;
-        duengerIn.oninput = function() { AppGlobals.drillCalcDebounced(); };
+        duengerIn.oninput = function() {
+          AppGlobals.drillCalcDebounced();
+        };
         row.appendChild(duengerIn);
-        // "Feld fertig" Toggle-Button
+        // Issue #377: Toggle-Button "Feld fertig" / "Fertig zurücknehmen".
+        // Setzt state.reiter[i].done, persistiert, rendert neu.
         var doneBtn = document.createElement('button');
         doneBtn.type = 'button';
         doneBtn.id = 'dtl_done_' + i;
         doneBtn.className = 'drill-done-btn' + (isDone ? ' active' : '');
         doneBtn.textContent = isDone ? 'Fertig zurücknehmen' : 'Feld fertig';
         doneBtn.setAttribute('aria-pressed', isDone ? 'true' : 'false');
-        doneBtn.title = isDone ? 'Fertig zurücknehmen' : 'Feld fertig';
-        doneBtn.onclick = (function(tabIdx) {
+        doneBtn.title = isDone
+          ? 'Markierung aufheben — Werte bleiben erhalten'
+          : 'Feld als fertig markieren';
+        doneBtn.onclick = (function(tabIdx, btnRef) {
           return function() {
             var tab = AppGlobals.state.reiter[tabIdx];
             if (!tab) return;
             tab.done = tab.done === true ? false : true;
             AppGlobals.saveState();
+            // Vollständiger Re-Render: Liste, Summary, Results und Dashboard,
+            // weil Locking + Status-Anzeige + Verteilungs-Plan berührt sind.
             AppGlobals.drillCalcAll();
           };
-        })(i);
+        })(i, doneBtn);
         row.appendChild(doneBtn);
         container.appendChild(row);
       });

--- a/public/js/render-results.js
+++ b/public/js/render-results.js
@@ -36,100 +36,29 @@
       };
     }
 
-    // Berechnet den Render-Anteil für die Ring-Chart.
-    //   percent (0..100) → stroke-dashoffset Wert.
-    //   Circumference des Kreises: 2*PI*r = 2*PI*44 ≈ 276.46.
-    // Helper pur, damit Tests isoliert bleiben.
-    function ringStrokeDashoffset(percent) {
-      var circ = 2 * Math.PI * 44;  // ≈ 276.46
-      var p = Math.max(0, Math.min(100, percent));
-      return circ - (circ * p / 100);
-    }
-
     function renderResultCard() {
       var r = AppGlobals.getActiveReiter();
       var kornerGesamt = AppGlobals.getKornerGesamt();
+      // Issue #186: IST-Fläche (vom Input-Feld) hat Vorrang vor SOLL.
+      // r_einheiten/r_duenger zeigen die tatsächlichen IST-Bedarfe, wenn
+      // r.istHektar > 0 — konsistent mit Dashboard, Drill-Summary, etc.
       var istSum = AppGlobals.getTabIstHektar(r);
       var einheiten = istSum > 0 ? AppGlobals.getTabIstEinheiten(r) : AppGlobals.getActiveTotalEinheiten();
       var duengerTotal = istSum > 0 ? AppGlobals.getTabIstDuenger(r) : AppGlobals.getActiveTotalDuenger();
-
-      // --- Legacy r_*-Elemente (für Test-Kompatibilität) ---
       var rkEl = document.getElementById('r_korner');
       if (rkEl) rkEl.textContent = Math.round(kornerGesamt).toLocaleString('de-DE');
       var reEl = document.getElementById('r_einheiten');
       if (reEl) reEl.textContent = AppGlobals.formatEinheit(einheiten);
       var rdEl = document.getElementById('r_duenger');
       if (rdEl) rdEl.textContent = duengerTotal > 0 ? duengerTotal.toLocaleString('de-DE') + ' kg' : '—';
-
-      // --- Ring-Chart-Werte ---
-      // Verbleibender Anteil = basis (SOLL/IST) - used. used kann nicht negativ sein
-      // (Einträge sind additiv). Bei activeTab ohne Daten: 0% gefüllt.
-      var basis = einheiten;
-      var used = (r && r.entries) ? r.entries.reduce(function(s, e) { return s + (e.einheit || 0); }, 0) : 0;
-      var pct = basis > 0 ? Math.min(100, Math.max(0, (used / basis) * 100)) : 0;
-      var ringValEl = document.getElementById('r_ring_value');
-      if (ringValEl) ringValEl.textContent = AppGlobals.fmt(einheiten);
-      var ringSubEl = document.getElementById('r_ring_sub');
-      if (ringSubEl) ringSubEl.textContent = einheiten === 1 ? 'EINH.' : 'EINH.';
-      var ringFgEl = document.getElementById('r_ring_fg');
-      if (ringFgEl) ringFgEl.setAttribute('stroke-dashoffset', String(ringStrokeDashoffset(pct)));
-
-      // --- Side Text ---
-      var sideTitleEl = document.getElementById('r_side_title');
-      var sideSubEl = document.getElementById('r_side_sub');
-      if (sideTitleEl) {
-        sideTitleEl.textContent = einheiten > 0
-          ? AppGlobals.fmt(einheiten) + ' Einheiten Saatgut'
-          : 'Ergebnis';
-      }
-      if (sideSubEl) {
-        if (einheiten > 0 && r.hektar > 0 && r.koerner > 0) {
-          var kh = AppGlobals.fmtCompact(r.koerner);
-          sideSubEl.textContent = 'Bei ' + AppGlobals.fmt(r.hektar) + ' ha und ' + kh + ' Körnern pro Hektar.';
-        } else {
-          sideSubEl.textContent = 'Bitte Hektar und Körner/ha eingeben.';
-        }
-      }
-
-      // --- Bottom Progress Bar ---
-      var duengerUsed = (r && r.entries) ? r.entries.reduce(function(s, e) { return s + (e.duenger || 0); }, 0) : 0;
-      var duengerRemaining = Math.max(0, duengerTotal - duengerUsed);
-      var einheitRemaining = Math.max(0, einheiten - used);
-      var progressPct = pct;  // gleiche Prozent wie Ring
-      var progressFillEl = document.getElementById('r_progress_fill');
-      if (progressFillEl) progressFillEl.style.width = progressPct.toFixed(0) + '%';
-      var progressUsedEl = document.getElementById('r_progress_used');
-      if (progressUsedEl) {
-        progressUsedEl.textContent = used > 0.05
-          ? AppGlobals.fmt(used) + (used === 1 ? ' Einh. verbraucht' : ' Einh. verbraucht')
-          : '— verbraucht';
-      }
-      var progressOpenEl = document.getElementById('r_progress_open');
-      if (progressOpenEl) {
-        if (einheitRemaining > 0.05 && duengerRemaining > 0.05) {
-          progressOpenEl.textContent = AppGlobals.fmt(einheitRemaining) + ' Einh. · ' + Math.round(duengerRemaining).toLocaleString('de-DE') + ' kg offen';
-        } else if (einheitRemaining > 0.05) {
-          progressOpenEl.textContent = AppGlobals.fmt(einheitRemaining) + ' Einh. offen';
-        } else if (duengerRemaining > 0.05) {
-          progressOpenEl.textContent = Math.round(duengerRemaining).toLocaleString('de-DE') + ' kg offen';
-        } else {
-          progressOpenEl.textContent = 'Vollständig';
-        }
-      }
-
-      // --- Header-Meta (legacy r_info slot) ---
       var riEl = document.getElementById('r_info');
       if (riEl) {
-        if (einheiten > 0 && duengerTotal > 0) {
-          riEl.textContent = Math.round(duengerTotal).toLocaleString('de-DE') + ' kg Dünger, ' + AppGlobals.fmt(einheiten) + ' Einheiten Saat';
-        } else if (einheiten > 0) {
-          riEl.textContent = AppGlobals.fmt(einheiten) + ' Einheiten Saat (ohne Dünger)';
+        if (duengerTotal > 0) {
+          riEl.textContent = duengerTotal.toLocaleString('de-DE') + ' kg Dünger, ' + AppGlobals.formatEinheit(einheiten) + ' Saat';
         } else {
-          riEl.textContent = '';
+          riEl.textContent = AppGlobals.formatEinheit(einheiten) + ' Saat (ohne Dünger)';
         }
       }
-
-      // --- SOLL/IST/Abweichung (legacy IDs, für test/48-render-results-ist-fallback) ---
       var sollHa = r.hektar;
       var istHa = AppGlobals.getTabIstHektar(r);
       var diff = istHa - sollHa;
@@ -150,20 +79,25 @@
               rDiffEl.className = 'value small negative';
             }
           }
-          sollIstSection.style.display = '';
+          sollIstSection.style.display = 'block';
         } else {
           sollIstSection.style.display = 'none';
         }
       }
-
-      // --- Carryover hint (legacy) ---
+      // Issue #336: Per-Tab-Eigen-Salden des aktiven Tabs (PR #337/#339).
+      // Ersparnis + Mehrbedarf sind Roh-Werte für DIESEN Tab — KEINE Cross-Tab-
+      // Aggregation, KEIN Empfänger-Saldo aus computeAllCarryovers(), KEINE
+      // Verrechnung mit Verbleibend/Eingefüllt (Issue #335 bleibt offen).
+      // Der Cross-Tab-Saldo lebt im Drill-Log + Maschinen-Protokoll (Issue
+      // #336 follow-up #5b, User-Feedback 2026-06-23, 5. Runde).
       var carryoverHint = document.getElementById('r_carryover_hint');
       if (!carryoverHint) {
         carryoverHint = document.createElement('div');
         carryoverHint.id = 'r_carryover_hint';
         carryoverHint.style.cssText = 'font-size:0.85rem;padding:4px 0;';
-        var parentEl = document.getElementById('results');
-        if (parentEl) parentEl.appendChild(carryoverHint);
+        if (sollIstSection && sollIstSection.parentNode) {
+          sollIstSection.parentNode.insertBefore(carryoverHint, sollIstSection.nextSibling);
+        }
       }
       if (carryoverHint) {
         while (carryoverHint.firstChild) carryoverHint.removeChild(carryoverHint.firstChild);
@@ -174,6 +108,13 @@
           excessE = AppGlobals.getTabIstEinheiten(r) - AppGlobals.getTabTotalEinheiten(r);
           excessD = (r.istHektar - r.hektar) * (r.duenger || 0);
         }
+        // Issue #371 (Reopen) Teil 2: Die vom User gesehene "Mehrbedarf"-Zeile
+        // muss den Anteil abziehen, der bereits durch den Cross-Tab-Pool
+        // (computeAllCarryovers → Phase 0.5 → nettedEinheit/nettedDuenger)
+        // gedeckt ist. Sonst zeigt sie 1,6 E obwohl remaining = 0 ist.
+        //
+        // Ersparnis bleibt unverändert: Ersparnis IST Eigene-Abweichung dieses
+        // Tabs (Issue #336 Vertrag), keine Cross-Tab-Korrektur.
         var activeIdxForHint = AppGlobals.state.activeReiter || 0;
         var coForHint = AppGlobals.getCarryover(activeIdxForHint);
         var shown = AppGlobals.computeShownExcess({ excessE: excessE, excessD: excessD }, coForHint);
@@ -205,14 +146,21 @@
         }
       }
 
-      // --- Net hint (legacy) ---
+      // Issue (User-Feedback 2026-07-11): Cross-Tab-Netting (Senken-Modell)
+      // war bisher unsichtbar — ein Tab mit Mehrbedarf zeigte "verbleibend: 0",
+      // aber nirgends stand, DASS und WOHIN dieser Mehrbedarf wandert. Und die
+      // Senke (der Tab, der den Mehrbedarf/die Ersparnis anderer Tabs
+      // übernimmt) bekam plötzlich einen höheren/niedrigeren "verbleibend"-Wert
+      // ohne Erklärung. Diese beiden Hinweise machen die Verrechnung
+      // nachvollziehbar, ohne die Rechenlogik selbst zu ändern.
       var netHint = document.getElementById('r_net_hint');
       if (!netHint) {
         netHint = document.createElement('div');
         netHint.id = 'r_net_hint';
         netHint.style.cssText = 'font-size:0.85rem;padding:4px 0;';
-        var resultsEl = document.getElementById('results');
-        if (resultsEl) resultsEl.appendChild(netHint);
+        if (carryoverHint && carryoverHint.parentNode) {
+          carryoverHint.parentNode.insertBefore(netHint, carryoverHint.nextSibling);
+        }
       }
       if (netHint) {
         while (netHint.firstChild) netHint.removeChild(netHint.firstChild);
@@ -228,6 +176,9 @@
           && (AppGlobals.getTabIstEinheiten(r) - AppGlobals.getTabTotalEinheiten(r) > 0.05
               || (r.istHektar - r.hektar) * (r.duenger || 0) > 0.05);
         if (!coForNet.isSink && hasOwnOverage && sinkIdx !== -1 && sinkIdx !== activeIdxForNet) {
+          // Dieser Tab hat selbst Mehrbedarf, ist aber nicht die Senke —
+          // sein Mehrbedarf wird unsichtbar auf einen anderen Tab (die
+          // Senke) verrechnet. Zeige, welcher das ist.
           var sinkTab = AppGlobals.state.reiter[sinkIdx];
           var sinkName = (sinkTab && sinkTab.name) || ('Tab ' + (sinkIdx + 1));
           var noteDiv = document.createElement('div');
@@ -236,6 +187,8 @@
           netHint.appendChild(noteDiv);
           netHint.style.display = 'block';
         } else if (coForNet.isSink && (Math.abs(coForNet.sinkAdjustedE) > 0.05 || Math.abs(coForNet.sinkAdjustedD) > 0.05)) {
+          // Dieser Tab IST die Senke: er übernimmt Mehrbedarf/Ersparnis aus
+          // anderen Tabs in sein eigenes "verbleibend". Zeige wie viel.
           var label2 = document.createElement('div');
           label2.className = 'r-carryover-section-label';
           label2.textContent = 'Ausgleich mit anderen Tabs';
@@ -298,47 +251,9 @@
         return;
       }
       if (drillSummaryEl) drillSummaryEl.style.display = 'block';
-      if (AppGlobals.state.activeView !== 'protokoll' && AppGlobals.state.activeView !== 'uebersicht') {
+      if (AppGlobals.state.activeView !== 'protokoll') {
         if (resultsEl) resultsEl.style.display = 'block';
       }
-      // 2-Spalten-Stat-Cards (Körner gesamt / Dünger gesamt) — gerendert direkt
-      // unter dem Result-Card in #view_rechner. Bleiben sichtbar in Rechner-View
-      // wenn Daten vorhanden sind.
-      renderStatCards(r, AppGlobals.getKornerGesamt());
-    }
-
-    // Rendert die zwei 2-Spalten-Stat-Cards (Körner gesamt / Dünger gesamt)
-    // unter dem Result-Card. Wird von renderResults() aufgerufen, wenn Hektar & Körner gesetzt.
-    function renderStatCards(r, kornerGesamt) {
-      var container = document.getElementById('view_rechner');
-      if (!container) return;
-      var existing = document.getElementById('stat_row_cards');
-      if (!existing) {
-        existing = document.createElement('div');
-        existing.id = 'stat_row_cards';
-        existing.className = 'stat-row';
-        container.appendChild(existing);
-      }
-      existing.innerHTML = '';
-      var duengerTotal = AppGlobals.getActiveTotalDuenger();
-      var c1 = document.createElement('div');
-      c1.className = 'stat-card';
-      var l1 = document.createElement('div');
-      l1.className = 'stat-card-label';
-      l1.textContent = 'Körner gesamt';
-      var v1 = document.createElement('div');
-      v1.className = 'stat-card-value';
-      v1.textContent = kornerGesamt > 0 ? Math.round(kornerGesamt).toLocaleString('de-DE') : '—';
-      c1.appendChild(l1); c1.appendChild(v1); existing.appendChild(c1);
-      var c2 = document.createElement('div');
-      c2.className = 'stat-card';
-      var l2 = document.createElement('div');
-      l2.className = 'stat-card-label';
-      l2.textContent = 'Dünger gesamt';
-      var v2 = document.createElement('div');
-      v2.className = 'stat-card-value';
-      v2.textContent = duengerTotal > 0 ? Math.round(duengerTotal).toLocaleString('de-DE') + ' kg' : '—';
-      c2.appendChild(l2); c2.appendChild(v2); existing.appendChild(c2);
     }
 
     // Inline drill-entries im Result-Card-Body (r_drill_entries)
@@ -426,7 +341,5 @@ Object.assign(window.AppGlobals, {
   renderResultCard: renderResultCard,
   renderResults: renderResults,
   renderDrillEntriesInline: renderDrillEntriesInline,
-  renderStatCards: renderStatCards,
-  ringStrokeDashoffset: ringStrokeDashoffset,
   computeShownExcess: computeShownExcess,
 });

--- a/public/js/render-results.js
+++ b/public/js/render-results.js
@@ -61,44 +61,20 @@
       var rdEl = document.getElementById('r_duenger');
       if (rdEl) rdEl.textContent = duengerTotal > 0 ? duengerTotal.toLocaleString('de-DE') + ' kg' : '—';
 
-      // --- Ring-Chart (neue sichtbare IDs im Bubble) ---
+      // --- Ring-Chart-Werte ---
+      // Verbleibender Anteil = basis (SOLL/IST) - used. used kann nicht negativ sein
+      // (Einträge sind additiv). Bei activeTab ohne Daten: 0% gefüllt.
       var basis = einheiten;
       var used = (r && r.entries) ? r.entries.reduce(function(s, e) { return s + (e.einheit || 0); }, 0) : 0;
       var pct = basis > 0 ? Math.min(100, Math.max(0, (used / basis) * 100)) : 0;
-      // Circumference für r=40: 2*PI*40 ≈ 251.3
-      var circRing = 2 * Math.PI * 40;
-      var ringValEl = document.getElementById('ring_val');
+      var ringValEl = document.getElementById('r_ring_value');
       if (ringValEl) ringValEl.textContent = AppGlobals.fmt(einheiten);
-      var ringFgEl = document.getElementById('ringFill');
-      if (ringFgEl) ringFgEl.setAttribute('stroke-dashoffset', String(circRing - (circRing * pct / 100)));
-      // Legacy r_*-Ring
-      var ringValEl2 = document.getElementById('r_ring_value');
-      if (ringValEl2) ringValEl2.textContent = AppGlobals.fmt(einheiten);
       var ringSubEl = document.getElementById('r_ring_sub');
-      if (ringSubEl) ringSubEl.textContent = 'EINH.';
-      var ringFgEl2 = document.getElementById('r_ring_fg');
-      if (ringFgEl2) ringFgEl2.setAttribute('stroke-dashoffset', String(ringStrokeDashoffset(pct)));
+      if (ringSubEl) ringSubEl.textContent = einheiten === 1 ? 'EINH.' : 'EINH.';
+      var ringFgEl = document.getElementById('r_ring_fg');
+      if (ringFgEl) ringFgEl.setAttribute('stroke-dashoffset', String(ringStrokeDashoffset(pct)));
 
-      // --- Hero Text (im Bubble) ---
-      var heroLine = document.getElementById('hero_line');
-      var heroSub = document.getElementById('hero_sub');
-      var fgSuffix = '';
-      if (r.fahrgassenEnabled && r.fahrgassenBreite && r.fahrgassenBreite >= 2) {
-        fgSuffix = ' (Fahrgassen ' + r.fahrgassenBreite + ' m berücksichtigt)';
-      }
-      if (heroLine) {
-        heroLine.textContent = einheiten > 0
-          ? AppGlobals.fmt(einheiten) + ' Einheiten Saatgut'
-          : '— Einheiten Saatgut';
-      }
-      if (heroSub) {
-        if (einheiten > 0 && r.hektar > 0 && r.koerner > 0) {
-          heroSub.textContent = 'Bei ' + AppGlobals.fmt(r.hektar) + ' ha und ' + AppGlobals.fmtCompact(r.koerner) + ' Körnern pro Hektar' + fgSuffix + '.';
-        } else {
-          heroSub.textContent = 'Trag Hektar und Körner pro Hektar ein.';
-        }
-      }
-      // Legacy side-Text
+      // --- Side Text ---
       var sideTitleEl = document.getElementById('r_side_title');
       var sideSubEl = document.getElementById('r_side_sub');
       if (sideTitleEl) {
@@ -108,42 +84,20 @@
       }
       if (sideSubEl) {
         if (einheiten > 0 && r.hektar > 0 && r.koerner > 0) {
-          sideSubEl.textContent = 'Bei ' + AppGlobals.fmt(r.hektar) + ' ha und ' + AppGlobals.fmtCompact(r.koerner) + ' Körnern pro Hektar.';
+          var kh = AppGlobals.fmtCompact(r.koerner);
+          sideSubEl.textContent = 'Bei ' + AppGlobals.fmt(r.hektar) + ' ha und ' + kh + ' Körnern pro Hektar.';
         } else {
           sideSubEl.textContent = 'Bitte Hektar und Körner/ha eingeben.';
         }
       }
 
-      // --- Bottom Progress Bar (im Bubble) ---
+      // --- Bottom Progress Bar ---
       var duengerUsed = (r && r.entries) ? r.entries.reduce(function(s, e) { return s + (e.duenger || 0); }, 0) : 0;
       var duengerRemaining = Math.max(0, duengerTotal - duengerUsed);
       var einheitRemaining = Math.max(0, einheiten - used);
-      var rechnerBarEl = document.getElementById('rechner_bar');
-      if (rechnerBarEl) rechnerBarEl.style.width = pct.toFixed(0) + '%';
-      var rechnerUsedEl = document.getElementById('rechner_used');
-      if (rechnerUsedEl) {
-        rechnerUsedEl.textContent = used > 0.05
-          ? AppGlobals.fmt(used) + ' Einh. verbraucht'
-          : '0 verbraucht';
-      }
-      var rechnerRemainingEl = document.getElementById('rechner_remaining');
-      if (rechnerRemainingEl) {
-        var isFertig = r.entries && r.entries.length > 0 && einheitRemaining <= 0.05 && duengerRemaining <= 0.05;
-        if (isFertig) {
-          rechnerRemainingEl.textContent = '✓ fertig';
-        } else if (einheitRemaining > 0.05 && duengerRemaining > 0.05) {
-          rechnerRemainingEl.textContent = AppGlobals.fmt(einheitRemaining) + ' Einh. · ' + Math.round(duengerRemaining).toLocaleString('de-DE') + ' kg offen';
-        } else if (einheitRemaining > 0.05) {
-          rechnerRemainingEl.textContent = AppGlobals.fmt(einheitRemaining) + ' Einh. offen';
-        } else if (duengerRemaining > 0.05) {
-          rechnerRemainingEl.textContent = Math.round(duengerRemaining).toLocaleString('de-DE') + ' kg offen';
-        } else {
-          rechnerRemainingEl.textContent = '— offen';
-        }
-      }
-      // Legacy r_*-progress
+      var progressPct = pct;  // gleiche Prozent wie Ring
       var progressFillEl = document.getElementById('r_progress_fill');
-      if (progressFillEl) progressFillEl.style.width = pct.toFixed(0) + '%';
+      if (progressFillEl) progressFillEl.style.width = progressPct.toFixed(0) + '%';
       var progressUsedEl = document.getElementById('r_progress_used');
       if (progressUsedEl) {
         progressUsedEl.textContent = used > 0.05
@@ -354,29 +308,35 @@
     }
 
     // Rendert die zwei 2-Spalten-Stat-Cards (Körner gesamt / Dünger gesamt)
-    // unter dem Result-Card. Wird von renderResults() aufgerufen.
-    // Das HTML hat bereits einen leeren #stat_row_cards Container.
+    // unter dem Result-Card. Wird von renderResults() aufgerufen, wenn Hektar & Körner gesetzt.
     function renderStatCards(r, kornerGesamt) {
+      var container = document.getElementById('view_rechner');
+      if (!container) return;
       var existing = document.getElementById('stat_row_cards');
-      if (!existing) return;
+      if (!existing) {
+        existing = document.createElement('div');
+        existing.id = 'stat_row_cards';
+        existing.className = 'stat-row';
+        container.appendChild(existing);
+      }
       existing.innerHTML = '';
       var duengerTotal = AppGlobals.getActiveTotalDuenger();
       var c1 = document.createElement('div');
       c1.className = 'stat-card';
       var l1 = document.createElement('div');
-      l1.className = 'l';
+      l1.className = 'stat-card-label';
       l1.textContent = 'Körner gesamt';
       var v1 = document.createElement('div');
-      v1.className = 'v';
+      v1.className = 'stat-card-value';
       v1.textContent = kornerGesamt > 0 ? Math.round(kornerGesamt).toLocaleString('de-DE') : '—';
       c1.appendChild(l1); c1.appendChild(v1); existing.appendChild(c1);
       var c2 = document.createElement('div');
       c2.className = 'stat-card';
       var l2 = document.createElement('div');
-      l2.className = 'l';
+      l2.className = 'stat-card-label';
       l2.textContent = 'Dünger gesamt';
       var v2 = document.createElement('div');
-      v2.className = 'v';
+      v2.className = 'stat-card-value';
       v2.textContent = duengerTotal > 0 ? Math.round(duengerTotal).toLocaleString('de-DE') + ' kg' : '—';
       c2.appendChild(l2); c2.appendChild(v2); existing.appendChild(c2);
     }

--- a/public/js/render-tabs.js
+++ b/public/js/render-tabs.js
@@ -1,30 +1,27 @@
 // ============================================================================
-// RENDER-TABS — Field-Chips (Schläge) + View-Routing
+// RENDER-TABS — Tab-Verwaltung, App-Init, Tab-Remove-Confirm
 //
-// Lade-Reihenfolge: state (state.js) → calc → ui → render-tabs → ...
-// render-tabs.js braucht: state, ui-handlers, calculations
+// Lade-Reihenfolge (laut index.html): state.js → calculations.js →
+//   ui-handlers.js → render-tabs.js → render-results.js → render-drill.js
+//   → render-dashboard.js → main.js
+//
+// render-tabs.js braucht: state, ui-handlers.js (switchReiter, addReiter,
+//   removeReiter, renameReiter, confirmRemoveReiter-Trigger), main.js (appOnStateChange)
 // Funktionen werden im globalen Scope definiert (Vanilla-JS / <script>-Tags).
 // ============================================================================
 
-    // --- Render: Field-Chips (Schläge) — pills mit Farb-Dot ---
-    // Ersetzt die alte renderTabs(). IDs/Klassen bleiben erhalten:
-    //   - .tab-btn (Pill-Container), .field-tab (Schlag-Tab), .tab-name (editierbarer Name)
-    //   - .pill-tab-dot (amber/orange Dot vorne), .tab-close (X-Button)
-    //   - .tab-add (+ Schlag Button)
-    //
-    // Render-Ziel: #field-chips statt #tab_bar_left
+    // --- Render: Tabs ---
+
     function renderTabs() {
-      var chipsEl = document.getElementById('field-chips');
-      if (!chipsEl) return;
-      chipsEl.innerHTML = '';
+      var bar = document.getElementById('tab_bar_left');
+      bar.innerHTML = '';
       AppGlobals.state.reiter.forEach(function(r, i) {
-        var isActive = (i === AppGlobals.state.activeReiter)
-                     && AppGlobals.state.activeView !== 'protokoll'
-                     && AppGlobals.state.activeView !== 'uebersicht';
+        var isActive = i === AppGlobals.state.activeReiter && AppGlobals.state.activeView !== 'protokoll' && AppGlobals.state.activeView !== 'uebersicht';
         var btn = document.createElement('button');
         btn.className = 'tab-btn field-tab' + (isActive ? ' active' : '');
         btn.setAttribute('aria-label', 'Schlag ' + (i + 1));
         btn.onclick = function() { AppGlobals.switchReiter(i); };
+        // Pill-tab: farbiger Punkt vor dem Namen
         var dot = document.createElement('span');
         dot.className = 'pill-tab-dot';
         btn.appendChild(dot);
@@ -52,39 +49,33 @@
           else { evt.stopPropagation(); }
         };
         span.onmousedown = function(evt) { evt.stopPropagation(); };
+
         if (AppGlobals.state.reiter.length > 1) {
-          var close = document.createElement('button');
-          close.className = 'tab-close chip-close';
-          close.setAttribute('type', 'button');
-          close.setAttribute('aria-label', 'Schlag schließen');
+          var close = document.createElement('span');
+          close.className = 'tab-close';
+          close.setAttribute('role', 'button');
+          close.setAttribute('aria-label', 'Tab schließen');
           close.onclick = function(evt) { evt.stopPropagation(); confirmRemoveReiter(i); };
           close.textContent = '✕';
           btn.appendChild(close);
         }
+
         btn.appendChild(span);
-        chipsEl.appendChild(btn);
+        bar.appendChild(btn);
       });
       var addBtn = document.createElement('button');
-      addBtn.type = 'button';
-      addBtn.className = 'tab-add chip-add';
+      addBtn.className = 'tab-add';
       addBtn.textContent = '+ Tab';
       addBtn.onclick = function() { AppGlobals.addReiter(); };
-      chipsEl.appendChild(addBtn);
-      // Legacy protokoll-tab button (hidden; Tests prüfen die active-Klasse via #protokoll_tab_btn)
+      bar.appendChild(addBtn);
+      // Legacy protokoll-tab button (hidden; Bottom-Nav bn_protokoll triggers
+      // die echte View-Switch). Tests prüfen weiterhin die active-Klasse.
       var protokollBtn = document.getElementById('protokoll_tab_btn');
       if (protokollBtn) protokollBtn.classList.toggle('active', AppGlobals.state.activeView === 'protokoll');
-      // Bottom-Nav Active-Class
-      var bnR = document.getElementById('bn_rechner');
-      var bnP = document.getElementById('bn_protokoll');
-      var bnU = document.getElementById('bn_uebersicht');
-      if (bnR) bnR.classList.toggle('active', !AppGlobals.state.activeView || AppGlobals.state.activeView === 'rechner' || AppGlobals.state.activeView === null || AppGlobals.state.activeView === undefined);
-      if (bnP) bnP.classList.toggle('active', AppGlobals.state.activeView === 'protokoll');
-      if (bnU) bnU.classList.toggle('active', AppGlobals.state.activeView === 'uebersicht');
     }
 
-    // --- Render: View Routing (Rechner / Protokoll / Übersicht) ---
-    // Setzt page-title und View-Container-Sichtbarkeit.
-    // Aktualisiert auch Bottom-Nav Active-Class und Field-Chips Sichtbarkeit.
+    // --- Render: View (Rechner / Protokoll / Übersicht) ---
+
     function renderView() {
       var r = AppGlobals.getActiveReiter();
       var hasData = r.hektar > 0 && r.koerner > 0;
@@ -92,7 +83,7 @@
       var isUebersicht = AppGlobals.state.activeView === 'uebersicht';
       var isRechner = !isProtokoll && !isUebersicht;
 
-      // 1) View-Container
+      // 1) View-Container sichtbar schalten
       var vr = document.getElementById('view_rechner');
       var vp = document.getElementById('view_protokoll');
       var vu = document.getElementById('view_uebersicht');
@@ -108,71 +99,48 @@
       if (bnP) bnP.classList.toggle('active', isProtokoll);
       if (bnU) bnU.classList.toggle('active', isUebersicht);
 
-      // 3) Field-Chips nur in Rechner-View zeigen
-      var chipsWrap = document.querySelector('.field-chips-wrap');
-      if (chipsWrap) chipsWrap.style.display = isRechner ? 'block' : 'none';
+      // 3) Tab-Bar nur in Rechner-View zeigen (Schlag-Auswahl gilt nicht in Drill/Übersicht)
+      var tabBar = document.getElementById('tab_bar');
+      if (tabBar) tabBar.style.display = isRechner ? '' : 'none';
 
-      // 4) Settings-Panel nur in Rechner-View (wenn offen)
-      var settingsPanel = document.getElementById('settings_panel');
-      var gear = document.getElementById('gear-btn');
-      if (settingsPanel) settingsPanel.style.display = isRechner && gear && gear.classList.contains('open') ? 'block' : 'none';
-
-      // 5) Page-Title (View-aware)
-      var titleEl = document.getElementById('page-title');
-      if (titleEl) {
-        titleEl.textContent = isProtokoll ? 'Drill-Protokoll'
-                              : isUebersicht ? 'Übersicht'
-                              : 'Agrar-Rechner';
-      }
-
-      // 6) Header-meta anzeigen wenn Rechner-View, sonst leer
-      var metaEl = document.querySelector('.app-header-meta');
-      if (metaEl) metaEl.style.display = isRechner ? 'block' : 'none';
-
-      // 7) Re-render Übersicht, falls sichtbar
-      if (isUebersicht && typeof AppGlobals.renderDashboard === 'function') {
-        AppGlobals.renderDashboard();
-      }
-
-      // 8) Result-Card Hide/Show (data-driven)
+      // 4) Cards-Toggle (alte Logik für Test-Kompatibilität in tests/15-render-view.test.js).
+      // Karten in Rechner-View sichtbar (per data-driven-Style), in Protokoll/Übersicht
+      // sind die Rechner-Karten display:none. Drill-Cards sind in Protokoll sichtbar.
+      var skipIds = { r_soll_ist_section: true };
+      var cards = document.querySelectorAll('.card');
+      cards.forEach(function(c) {
+        if (skipIds[c.id]) return;
+        if (isProtokoll) {
+          // drill_section + Maschinen-Log sind erlaubt
+          c.style.display = (c.id === 'drill_section') ? 'block' : 'none';
+        } else if (isUebersicht) {
+          // In Übersicht sind nur die Dashboard-Cards sichtbar (renderDashboard())
+          c.style.display = 'none';
+        } else {
+          // Rechner-View: Karten sichtbar, einzelne werden durch data-driven-Logik
+          // (renderResults/renderResults/renderDrillSummary) weiter ein-/ausgeblendet.
+          c.style.display = '';
+        }
+      });
+      // results-Card ist datenabhängig (renderResults setzt sie)
       var resultsEl = document.getElementById('results');
       if (resultsEl && isRechner) {
-        resultsEl.style.display = hasData ? 'block' : 'none';
+        resultsEl.style.display = (hasData) ? 'block' : 'none';
       }
       var drillSection = document.getElementById('drill_section');
       if (drillSection) drillSection.style.display = isProtokoll ? 'block' : 'none';
       var drillMask = document.getElementById('drill_mask');
       if (drillMask) drillMask.style.display = isProtokoll ? '' : 'none';
 
-      // 9) stats-row auch nur in Rechner-View
-      var statRow = document.getElementById('stat_row_cards');
-      if (statRow) statRow.style.display = isRechner && hasData ? 'grid' : 'none';
-
-      // 10) Drill-Einträge (Maschinen-Log): nur in Drill- oder Übersicht-View
-      var machineLogEl = document.getElementById('drill_machine_log');
-      if (machineLogEl && !isProtokoll) {
-        machineLogEl.style.display = 'none';
+      // 5) Re-render Übersicht, wenn aktiv
+      if (isUebersicht && typeof AppGlobals.renderDashboard === 'function') {
+        AppGlobals.renderDashboard();
       }
 
-      // 11) Alte Card-Toggle-Logik (für tests/15-render-view.test.js):
-      // Cards (.card + .bubble) im Rechner-View auf display:none setzen,
-      // wenn aktive View Protokoll oder Übersicht ist. Drill-Card bleibt sichtbar.
-      var skipIds = { r_soll_ist_section: true };
-      var cardish = document.querySelectorAll('.card, .bubble, .stat-row');
-      cardish.forEach(function(c) {
-        if (skipIds[c.id]) return;
-        if (isProtokoll || isUebersicht) {
-          // Drill-Card (id=drill_section) bleibt in Protokoll sichtbar
-          if (isProtokoll && c.id === 'drill_section') {
-            c.style.display = 'block';
-          } else {
-            c.style.display = 'none';
-          }
-        }
-      });
-      if (!isProtokoll && !isUebersicht && resultsEl) {
-        resultsEl.style.display = hasData ? 'block' : 'none';
-      }
+      // 6) Hide drill_section in Rechner (drill_section-Karte muss im Drill-Render-Pfad
+      // neu sichtbar werden)
+      var drillSummEl = document.getElementById('drill_summary');
+      if (drillSummEl) drillSummEl.style.display = '';
     }
 
     // --- Init: UI (nach DOMContentLoaded) ---
@@ -181,7 +149,9 @@
       AppGlobals.loadState();
       AppGlobals.maybeShowIosInstallHint();
       AppGlobals.maybeShowUpdateHint();
-      // Cross-Tab-Synchronisation
+      // --- Cross-Tab-Synchronisation (portiert aus Inline-Code Z. 3394-3412) ---
+      // Lauscht auf localStorage-Änderungen von anderen Tabs/Fenstern.
+      // Der storage-Event feuert nur in Tabs, die den Wert NICHT selbst gesetzt haben.
       window.addEventListener('storage', function(e) {
         if (e.key === 'agrar_rechner' && e.newValue) {
           try {
@@ -199,7 +169,7 @@
       });
       AppGlobals.syncInputsFromState();
       AppGlobals.renderTabs();
-      // Fahrgassen-Toggle aus State restaurieren (für per-tab-Toggle im Rechner)
+      // Fahrgassen-Toggle aus State restaurieren
       var fgToggle = document.getElementById('fahrgassen_toggle');
       var fgSettings = document.getElementById('fahrgassen_settings');
       if (fgToggle) {
@@ -212,6 +182,8 @@
       var fgBreite = document.getElementById('fahrgassen_breite');
       if (fgBreite) {
         if (AppGlobals.state.fahrgassenBreite > 0) {
+          // Tests 8: rohe Ganzzahl als Input-Wert, kein ",0" für ganze Zahlen.
+          // Nutze fmtCompact (Issue #266), das ",0" für ganze Zahlen weglässt.
           fgBreite.value = AppGlobals.fmtCompact(AppGlobals.state.fahrgassenBreite);
         } else {
           fgBreite.value = '';
@@ -219,7 +191,7 @@
         fgBreite.dataset.prev = fgBreite.value;
         fgBreite.dataset.cleaned = fgBreite.value;
       }
-      // Einheit-Größe-Toggle aus State restaurieren
+      // Einheit-Größe-Toggle aus State restaurieren (Issue #266)
       var egToggle = document.getElementById('einheit_groesse_toggle');
       var egSettings = document.getElementById('einheit_groesse_settings');
       if (egToggle) {
@@ -231,6 +203,8 @@
       }
       var kpEl = document.getElementById('koerner_pro_einheit');
       if (kpEl && AppGlobals.state.koernerProEinheit !== 50000) {
+        // Tests 18, 24: rohe Ganzzahl als Input-Wert (kein Tausender-Punkt),
+        // damit parseDE() in einheitGroesseUpdate() den Wert korrekt zurückschreibt.
         kpEl.value = String(AppGlobals.state.koernerProEinheit);
         kpEl.dataset.prev = kpEl.value;
         kpEl.dataset.cleaned = kpEl.value;
@@ -241,37 +215,17 @@
           ? AppGlobals.state.koernerProEinheit.toLocaleString('de-DE') + ' Körner/Einheit'
           : '';
       }
-      // Settings-Panel State (Fahrgassen)
-      var swFg = document.getElementById('sw_fahrgassen');
-      var detFg = document.getElementById('detail_fahrgassen');
-      if (swFg) {
-        swFg.classList.toggle('on', !!AppGlobals.state.fahrgassenEnabled);
-        swFg.setAttribute('aria-pressed', AppGlobals.state.fahrgassenEnabled ? 'true' : 'false');
-      }
-      if (detFg) detFg.classList.toggle('open', !!AppGlobals.state.fahrgassenEnabled);
-      // Settings-Panel State (Einheitgröße)
-      var swEg = document.getElementById('sw_einheitgroesse');
-      var detEg = document.getElementById('detail_einheitgroesse');
-      if (swEg) {
-        swEg.classList.toggle('on', !!AppGlobals.state.einheitGroesseEnabled);
-        swEg.setAttribute('aria-pressed', AppGlobals.state.einheitGroesseEnabled ? 'true' : 'false');
-      }
-      if (detEg) detEg.classList.toggle('open', !!AppGlobals.state.einheitGroesseEnabled);
-      var kpInput = document.getElementById('koerner_pro_einheit');
-      if (kpInput && AppGlobals.state.koernerProEinheit !== 50000) {
-        kpInput.value = String(AppGlobals.state.koernerProEinheit);
-      }
-      // Erstes Render-Ergebnis anzeigen, falls Daten vorhanden
-      if (AppGlobals.state.reiter[AppGlobals.state.activeReiter]
-          && AppGlobals.state.reiter[AppGlobals.state.activeReiter].hektar > 0
-          && AppGlobals.state.reiter[AppGlobals.state.activeReiter].koerner > 0) {
+      if (AppGlobals.state.reiter[AppGlobals.state.activeReiter] && AppGlobals.state.reiter[AppGlobals.state.activeReiter].hektar > 0 && AppGlobals.state.reiter[AppGlobals.state.activeReiter].koerner > 0) {
         AppGlobals.renderResults();
+        if (AppGlobals.state.activeView !== 'protokoll') {
+          var resultsEl = document.getElementById('results');
+          if (resultsEl) resultsEl.style.display = 'block';
+        }
       }
       renderView();
       AppGlobals.renderDashboard();
       var vf = document.getElementById('version_footer');
-      if (vf) vf.textContent = AppGlobals.APP_VERSION + ' · ' + AppGlobals.APP_BUILD_DATE;
-      // State-Change-Listener
+      if (vf) vf.textContent = APP_VERSION + ' · ' + APP_BUILD_DATE;
       AppGlobals.appOnStateChange(function(type, data) {
         switch (type) {
           case 'TAB_CHANGED':
@@ -289,6 +243,7 @@
             AppGlobals.renderTabs();
             AppGlobals.renderResults();
             renderView();
+            // Bei state-Änderungen Übersicht re-rendern, falls sichtbar.
             if (AppGlobals.state.activeView === 'uebersicht') {
               AppGlobals.renderDashboard();
             }
@@ -322,13 +277,15 @@
             renderView();
             var re3 = document.getElementById('results');
             if (re3) re3.style.display = 'none';
+            var ds = document.getElementById('drill_section');
+            if (ds) ds.style.display = 'none';
             var eh = document.getElementById('err_hektar');
-            var ek = document.getElementById('err_koerner');
             if (eh) eh.textContent = '';
+            var ek = document.getElementById('err_koerner');
             if (ek) ek.textContent = '';
             var he = document.getElementById('hektar');
-            var ke = document.getElementById('koerner');
             if (he) he.style.borderColor = '';
+            var ke = document.getElementById('koerner');
             if (ke) ke.style.borderColor = '';
             break;
           case 'TAB_ADDED':

--- a/public/js/render-tabs.js
+++ b/public/js/render-tabs.js
@@ -16,18 +16,14 @@
       var bar = document.getElementById('tab_bar_left');
       bar.innerHTML = '';
       AppGlobals.state.reiter.forEach(function(r, i) {
-        var isActive = i === AppGlobals.state.activeReiter && AppGlobals.state.activeView !== 'protokoll' && AppGlobals.state.activeView !== 'uebersicht';
+        var isActive = i === AppGlobals.state.activeReiter && AppGlobals.state.activeView !== 'protokoll';
         var btn = document.createElement('button');
         btn.className = 'tab-btn field-tab' + (isActive ? ' active' : '');
-        btn.setAttribute('aria-label', 'Schlag ' + (i + 1));
+        btn.setAttribute('aria-label', 'Tab ' + (i+1));
         btn.onclick = function() { AppGlobals.switchReiter(i); };
-        // Pill-tab: farbiger Punkt vor dem Namen
-        var dot = document.createElement('span');
-        dot.className = 'pill-tab-dot';
-        btn.appendChild(dot);
         var span = document.createElement('span');
         span.className = 'tab-name';
-        span.setAttribute('aria-label', 'Schlag-Name');
+        span.setAttribute('aria-label', 'Tab-Name');
         span.setAttribute('role', 'textbox');
         span.setAttribute('tabindex', '0');
         span.setAttribute('contenteditable', 'true');
@@ -68,79 +64,28 @@
       addBtn.textContent = '+ Tab';
       addBtn.onclick = function() { AppGlobals.addReiter(); };
       bar.appendChild(addBtn);
-      // Legacy protokoll-tab button (hidden; Bottom-Nav bn_protokoll triggers
-      // die echte View-Switch). Tests prüfen weiterhin die active-Klasse.
       var protokollBtn = document.getElementById('protokoll_tab_btn');
       if (protokollBtn) protokollBtn.classList.toggle('active', AppGlobals.state.activeView === 'protokoll');
     }
 
-    // --- Render: View (Rechner / Protokoll / Übersicht) ---
+    // --- Render: View (Feld vs. Protokoll) ---
 
     function renderView() {
       var r = AppGlobals.getActiveReiter();
       var hasData = r.hektar > 0 && r.koerner > 0;
       var isProtokoll = AppGlobals.state.activeView === 'protokoll';
-      var isUebersicht = AppGlobals.state.activeView === 'uebersicht';
-      var isRechner = !isProtokoll && !isUebersicht;
-
-      // 1) View-Container sichtbar schalten
-      var vr = document.getElementById('view_rechner');
-      var vp = document.getElementById('view_protokoll');
-      var vu = document.getElementById('view_uebersicht');
-      if (vr) vr.style.display = isRechner ? 'block' : 'none';
-      if (vp) vp.style.display = isProtokoll ? 'block' : 'none';
-      if (vu) vu.style.display = isUebersicht ? 'block' : 'none';
-
-      // 2) Bottom-Nav active-Class
-      var bnR = document.getElementById('bn_rechner');
-      var bnP = document.getElementById('bn_protokoll');
-      var bnU = document.getElementById('bn_uebersicht');
-      if (bnR) bnR.classList.toggle('active', isRechner);
-      if (bnP) bnP.classList.toggle('active', isProtokoll);
-      if (bnU) bnU.classList.toggle('active', isUebersicht);
-
-      // 3) Tab-Bar nur in Rechner-View zeigen (Schlag-Auswahl gilt nicht in Drill/Übersicht)
-      var tabBar = document.getElementById('tab_bar');
-      if (tabBar) tabBar.style.display = isRechner ? '' : 'none';
-
-      // 4) Cards-Toggle (alte Logik für Test-Kompatibilität in tests/15-render-view.test.js).
-      // Karten in Rechner-View sichtbar (per data-driven-Style), in Protokoll/Übersicht
-      // sind die Rechner-Karten display:none. Drill-Cards sind in Protokoll sichtbar.
       var skipIds = { r_soll_ist_section: true };
       var cards = document.querySelectorAll('.card');
       cards.forEach(function(c) {
         if (skipIds[c.id]) return;
-        if (isProtokoll) {
-          // drill_section + Maschinen-Log sind erlaubt
-          c.style.display = (c.id === 'drill_section') ? 'block' : 'none';
-        } else if (isUebersicht) {
-          // In Übersicht sind nur die Dashboard-Cards sichtbar (renderDashboard())
-          c.style.display = 'none';
-        } else {
-          // Rechner-View: Karten sichtbar, einzelne werden durch data-driven-Logik
-          // (renderResults/renderResults/renderDrillSummary) weiter ein-/ausgeblendet.
-          c.style.display = '';
-        }
+        c.style.display = isProtokoll ? 'none' : 'block';
       });
-      // results-Card ist datenabhängig (renderResults setzt sie)
       var resultsEl = document.getElementById('results');
-      if (resultsEl && isRechner) {
-        resultsEl.style.display = (hasData) ? 'block' : 'none';
-      }
+      if (resultsEl) resultsEl.style.display = (hasData && !isProtokoll) ? 'block' : 'none';
       var drillSection = document.getElementById('drill_section');
       if (drillSection) drillSection.style.display = isProtokoll ? 'block' : 'none';
       var drillMask = document.getElementById('drill_mask');
       if (drillMask) drillMask.style.display = isProtokoll ? '' : 'none';
-
-      // 5) Re-render Übersicht, wenn aktiv
-      if (isUebersicht && typeof AppGlobals.renderDashboard === 'function') {
-        AppGlobals.renderDashboard();
-      }
-
-      // 6) Hide drill_section in Rechner (drill_section-Karte muss im Drill-Render-Pfad
-      // neu sichtbar werden)
-      var drillSummEl = document.getElementById('drill_summary');
-      if (drillSummEl) drillSummEl.style.display = '';
     }
 
     // --- Init: UI (nach DOMContentLoaded) ---
@@ -243,8 +188,11 @@
             AppGlobals.renderTabs();
             AppGlobals.renderResults();
             renderView();
-            // Bei state-Änderungen Übersicht re-rendern, falls sichtbar.
-            if (AppGlobals.state.activeView === 'uebersicht') {
+            // Issue #186: Dashboard muss bei State-Änderungen mit-synchronisieren.
+            // Wenn das Dashboard-Sheet offen ist, sofort neu rendern, damit
+            // verbleibende Einheiten/Dünger konsistent mit Tab-Ergebnis sind.
+            var dashSheet = document.getElementById('dashboard_sheet');
+            if (dashSheet && dashSheet.classList.contains('open')) {
               AppGlobals.renderDashboard();
             }
             if (type === 'ENTRY_CHANGED' && AppGlobals.state.reiter[AppGlobals.state.activeReiter].hektar > 0 && AppGlobals.state.reiter[AppGlobals.state.activeReiter].koerner > 0) {
@@ -306,7 +254,6 @@
             AppGlobals.renderTabs();
             renderView();
             if (AppGlobals.state.activeView === 'protokoll') AppGlobals.renderDrillTabList();
-            if (AppGlobals.state.activeView === 'uebersicht') AppGlobals.renderDashboard();
             AppGlobals.renderResults();
             break;
           case 'DRILL_ENTRY_ADDED':
@@ -333,9 +280,9 @@
       var hasEntries = tab.entries && tab.entries.length > 0;
       var hasData = tab.hektar > 0 || tab.koerner > 0 || tab.duenger > 0 || tab.istHektar > 0;
       if (hasEntries || hasData) {
-        if (!confirm('Schlag "' + tab.name + '" wirklich löschen? Daten vorhanden — alle Eingaben gehen verloren.')) return;
+        if (!confirm('Tab "' + tab.name + '" wirklich löschen? Daten vorhanden — alle Eingaben gehen verloren.')) return;
       } else {
-        if (!confirm('Schlag "' + tab.name + '" wirklich löschen? Alle Eingaben gehen verloren.')) return;
+        if (!confirm('Tab "' + tab.name + '" wirklich löschen? Alle Eingaben gehen verloren.')) return;
       }
       AppGlobals.removeReiter(idx);
     }

--- a/public/js/state.js
+++ b/public/js/state.js
@@ -400,7 +400,7 @@ function dismissIosInstallHint() {
 // Zeigt einmalig einen Hinweis nach App-Updates (neue SW-Version).
 // currentVersion muss bei jedem Release manuell aktualisiert werden.
 // (APP_VERSION + APP_BUILD_DATE sind in main.js definiert.)
-var UPDATE_CHANGELOG = 'Neues Design mit Bottom-Navigation und Ring-Chart. Bestehende Schläge werden automatisch zu "Schlag N" umbenannt.';
+var UPDATE_CHANGELOG = 'Erste Veröffentlichung der App.';
 function maybeShowUpdateHint() {
   var seenVersion = null;
   try { seenVersion = localStorage.getItem('agrar_rechner_version_seen'); } catch(e) {}

--- a/public/js/state.js
+++ b/public/js/state.js
@@ -400,7 +400,7 @@ function dismissIosInstallHint() {
 // Zeigt einmalig einen Hinweis nach App-Updates (neue SW-Version).
 // currentVersion muss bei jedem Release manuell aktualisiert werden.
 // (APP_VERSION + APP_BUILD_DATE sind in main.js definiert.)
-var UPDATE_CHANGELOG = 'Komplettes UI-Redesign mit warmem Erdton-Design, Inline-Settings-Panel und Speech-Bubble Ergebnis-Karte.';
+var UPDATE_CHANGELOG = 'Neues Design mit Bottom-Navigation und Ring-Chart. Bestehende Schläge werden automatisch zu "Schlag N" umbenannt.';
 function maybeShowUpdateHint() {
   var seenVersion = null;
   try { seenVersion = localStorage.getItem('agrar_rechner_version_seen'); } catch(e) {}

--- a/public/js/state.js
+++ b/public/js/state.js
@@ -15,7 +15,7 @@
 
 var state = {
   reiter: [{
-    name:       'Schlag 1',
+    name:       'Tab 1',
     hektar:     0,
     istHektar:  0,
     koerner:    0,
@@ -253,7 +253,7 @@ function loadState() {
     var lv = originalLv;
     // Migration 0→1: Einzelne Felder → Tab-Array
     if (!data.reiter && (data.hektar !== undefined || data.koerner !== undefined)) {
-      data = { reiter: [{ name: 'Schlag 1', hektar: data.hektar || 0, istHektar: data.istHektar || 0, koerner: data.koerner || 0, duenger: data.duenger || 0, entries: data.entries || [], done: false }], activeReiter: 0, activeView: null, fahrgassenEnabled: false, fahrgassenBreite: 0, einheitGroesseEnabled: false, koernerProEinheit: 50000, machineLog: data.machineLog || [], drillPriorities: {}, iosInstallHintShown: false, _lv: 1 };
+      data = { reiter: [{ name: 'Tab 1', hektar: data.hektar || 0, istHektar: data.istHektar || 0, koerner: data.koerner || 0, duenger: data.duenger || 0, entries: data.entries || [], done: false }], activeReiter: 0, activeView: null, fahrgassenEnabled: false, fahrgassenBreite: 0, einheitGroesseEnabled: false, koernerProEinheit: 50000, machineLog: data.machineLog || [], drillPriorities: {}, iosInstallHintShown: false, _lv: 1 };
       lv = 1;
     }
     // Migration 1→2: Globale entries → per-Tab entries
@@ -296,20 +296,6 @@ function loadState() {
     // Daten-Änderungen am reiter-Array nötig — die Persistenz-Schwelle
     // wird weiter unten auf `_lv = 5` gehoben.
     if (lv < 5) lv = 5;
-    // Migration 5→6 (Redesign): bestehende Tabs mit Name "Tab N" werden zu
-    // "Schlag N" umbenannt (Regex /^Tab\s*(\d+)$/). Persistenz-Schwelle auf
-    // _lv = 6 gehoben; das Bump erfolgt weiter unten in der
-    // Whitelist-Übernahme.
-    if (lv < 6 && Array.isArray(data.reiter)) {
-      for (var rnI = 0; rnI < data.reiter.length; rnI++) {
-        var rnTab = data.reiter[rnI];
-        if (rnTab && typeof rnTab.name === 'string') {
-          var rnMatch = rnTab.name.match(/^Tab\s*(\d+)$/);
-          if (rnMatch) rnTab.name = 'Schlag ' + rnMatch[1];
-        }
-      }
-      lv = 6;
-    }
     // Validate und übernehmen — Schema-strict ab _lv=4
     if (!Array.isArray(data.reiter) || data.reiter.length === 0) return false;
     var sanitizedReiter = [];
@@ -321,7 +307,7 @@ function loadState() {
     data.activeReiter = activeReiterRaw >= 0 && activeReiterRaw < sanitizedReiter.length
       ? Math.floor(activeReiterRaw)
       : 0;
-    data.activeView = (data.activeView === 'protokoll' || data.activeView === 'uebersicht') ? data.activeView : null;
+    data.activeView = (data.activeView === 'protokoll') ? 'protokoll' : null;
     if (data.fahrgassenEnabled === undefined) data.fahrgassenEnabled = false;
     if (data.fahrgassenBreite === undefined) data.fahrgassenBreite = 0;
     data.fahrgassenEnabled = sanitizeBoolean(data.fahrgassenEnabled, false);
@@ -352,13 +338,13 @@ function loadState() {
         var k = ALLOWED_TOP_KEYS[ki];
         if (data[k] !== undefined) cleaned[k] = data[k];
     }
-    cleaned._lv = 6;
+    cleaned._lv = 5;
     data = cleaned;
     state = data;
-    // Migration-Persistenz: Wenn die Daten nicht bereits _lv=6 waren,
+    // Migration-Persistenz: Wenn die Daten nicht bereits _lv=5 waren,
     // schreibe den migrierten Snapshot einmalig zurück, damit nachfolgende
     // Page-Loads die Migration überspringen können.
-    if (originalLv < 6) {
+    if (originalLv < 5) {
       try {
         localStorage.setItem('agrar_rechner', JSON.stringify(state));
       } catch(e) {

--- a/public/js/ui-handlers.js
+++ b/public/js/ui-handlers.js
@@ -101,165 +101,100 @@
       AppGlobals._syncActiveTabLock();
     }
 
-    // --- Settings Panel (inline, ersetzt das alte Settings-Modal) ---
+    function switchToProtokoll() {
+      syncStateFromInputs();
+      if (AppGlobals.state.activeView === 'protokoll') {
+        AppGlobals.state.activeView = null;
+      } else {
+        AppGlobals.state.activeView = 'protokoll';
+        AppGlobals.renderDrillTabList();
+      }
+      AppGlobals.appEmit('VIEW_CHANGED', { view: AppGlobals.state.activeView });
+    }
+
+    function switchToRechner() {
+      // Rechner-View = Default. setView('rechner') == activeView = null.
+      if (AppGlobals.state.activeView === null) return;
+      syncStateFromInputs();
+      AppGlobals.state.activeView = null;
+      AppGlobals.appEmit('VIEW_CHANGED', { view: null });
+    }
+
+    function switchToUebersicht() {
+      syncStateFromInputs();
+      if (AppGlobals.state.activeView === 'uebersicht') return;
+      AppGlobals.state.activeView = 'uebersicht';
+      AppGlobals.renderDashboard();
+      AppGlobals.appEmit('VIEW_CHANGED', { view: 'uebersicht' });
+    }
+
+    function switchView(view) {
+      if (view === 'rechner' || view === null) return AppGlobals.switchToRechner();
+      if (view === 'protokoll') return AppGlobals.switchToProtokoll();
+      if (view === 'uebersicht') return AppGlobals.switchToUebersicht();
+    }
+
+    // --- Settings Modal (Issue: Redesign) ---
+    function openSettings() {
+      var ov = document.getElementById('settings_overlay');
+      var mo = document.getElementById('settings_modal');
+      if (ov) ov.classList.add('open');
+      if (mo) mo.classList.add('open');
+      // Sync dark-mode button text with current state
+      var isDark = document.documentElement.classList.contains('dark');
+      var icon = document.getElementById('settings_dark_icon');
+      var title = document.getElementById('settings_dark_title');
+      var desc = document.getElementById('settings_dark_desc');
+      var state = document.getElementById('settings_dark_state');
+      if (icon) icon.textContent = isDark ? '☀️' : '🌙';
+      if (title) title.textContent = isDark ? 'Light Mode' : 'Dark Mode';
+      if (desc) desc.textContent = isDark ? 'Helles Farbschema aktivieren' : 'Dunkles Farbschema aktivieren';
+      if (state) state.textContent = isDark ? 'An' : 'Aus';
+      // Version
+      var v = document.getElementById('settings_version');
+      if (v) v.textContent = (typeof APP_VERSION !== 'undefined' ? APP_VERSION : '—');
+      // Reset-confirmation contexts
+      var tabCtx = document.getElementById('reset_modal_tab_ctx');
+      var ar = AppGlobals.state.reiter[AppGlobals.state.activeReiter];
+      if (tabCtx) tabCtx.textContent = ar ? ('Leert Felder & Protokoll von "' + ar.name + '"') : 'Leert Felder & Protokoll dieses Schlags';
+    }
+    function _onSettingsCancel() {
+      var ov = document.getElementById('settings_overlay');
+      var mo = document.getElementById('settings_modal');
+      if (ov) ov.classList.remove('open');
+      if (mo) mo.classList.remove('open');
+    }
+    function _onSettingsOverlayClick(e) {
+      if (e && e.target && e.target.id === 'settings_overlay') _onSettingsCancel();
+    }
+    function _onSettingsDarkMode() {
+      // toggleTheme() setzt die html.dark-Klasse + localStorage + theme_toggle.
+      // theme_toggle ist im HTML hidden, Klick funktioniert trotzdem programmatisch.
+      AppGlobals.toggleTheme();
+      // Refresh button-label
+      var isDark = document.documentElement.classList.contains('dark');
+      var icon = document.getElementById('settings_dark_icon');
+      var title = document.getElementById('settings_dark_title');
+      var desc = document.getElementById('settings_dark_desc');
+      var state = document.getElementById('settings_dark_state');
+      if (icon) icon.textContent = isDark ? '☀️' : '🌙';
+      if (title) title.textContent = isDark ? 'Light Mode' : 'Dark Mode';
+      if (desc) desc.textContent = isDark ? 'Helles Farbschema aktivieren' : 'Dunkles Farbschema aktivieren';
+      if (state) state.textContent = isDark ? 'An' : 'Aus';
+    }
+    function _onSettingsResetTab() {
+      _onSettingsCancel();
+      AppGlobals.resetActiveTab();
+    }
+    function _onSettingsResetAll() {
+      _onSettingsCancel();
+      AppGlobals.openResetModal();
+    }
 
     function renameReiter(idx, name) {
       AppGlobals.state.reiter[idx].name = name.substring(0, 20);
       AppGlobals.appEmit('TAB_RENAMED', { tabIdx: idx });
     }
-
-    // ---- View Navigation (3-Views mit Single-Header) ----
-    //   switchToProtokoll() ist ein Toggle: wenn bereits Protokoll aktiv, zurück zu Rechner.
-    //   Tests aus Issue #291 / Test 15-render-view / Test 22-protocol-view prüfen das.
-    function setView(view) {
-      var target = view === 'rechner' ? null : view;
-      if (AppGlobals.state.activeView === target) return;
-      syncStateFromInputs();
-      AppGlobals.state.activeView = target;
-      AppGlobals.appEmit('VIEW_CHANGED', { view: target });
-    }
-    function switchToRechner() {
-      setView('rechner');
-    }
-    function switchToProtokoll() {
-      // Toggle-Verhalten: zweiter Klick → zurück zu Rechner
-      if (AppGlobals.state.activeView === 'protokoll') {
-        switchToRechner();
-        return;
-      }
-      if (AppGlobals.state.activeView === 'uebersicht') {
-        switchToRechner();
-        return;
-      }
-      setView('protokoll');
-    }
-    function switchToUebersicht() {
-      setView('uebersicht');
-    }
-
-    // ---- Renaming via prompt (Rechner-view) ----
-    function renameActiveField() {
-      var f = AppGlobals.getActiveReiter();
-      var nm = prompt('Name des Schlags:', f.name);
-      if (nm && nm.trim()) {
-        AppGlobals.renameReiter(AppGlobals.state.activeReiter, nm.trim().substring(0, 20));
-      }
-    }
-
-    // ---- Settings Panel (inline) ----
-    function toggleSettings() {
-      var panel = document.getElementById('settings_panel');
-      var gear = document.getElementById('gear-btn');
-      if (!panel || !gear) return;
-      var open = panel.classList.toggle('open');
-      gear.classList.toggle('open', open);
-    }
-    function openSettings() { toggleSettings(); }
-    function closeSettings() {
-      var panel = document.getElementById('settings_panel');
-      var gear = document.getElementById('gear-btn');
-      if (panel) panel.classList.remove('open');
-      if (gear) gear.classList.remove('open');
-    }
-
-    // ---- Global Settings (Settings-Panel) ----
-    function toggleFahrgassenGlobal() {
-      AppGlobals.state.fahrgassenEnabled = !AppGlobals.state.fahrgassenEnabled;
-      var sw = document.getElementById('sw_fahrgassen');
-      var det = document.getElementById('detail_fahrgassen');
-      if (sw) sw.classList.toggle('on', AppGlobals.state.fahrgassenEnabled);
-      if (det) det.classList.toggle('open', AppGlobals.state.fahrgassenEnabled);
-      if (!AppGlobals.state.fahrgassenEnabled) {
-        AppGlobals.state.fahrgassenBreite = 0;
-        var inp = document.getElementById('fahrgassen_breite');
-        if (inp) inp.value = '';
-        var hint = document.getElementById('fahrgassen_hint');
-        if (hint) hint.textContent = '';
-      }
-      // Per-Tab-Fahrgassen-Toggle (Rechner) sync
-      var fgBtn = document.getElementById('fahrgassen_toggle');
-      var fgSet = document.getElementById('fahrgassen_settings');
-      if (fgBtn) {
-        fgBtn.classList.toggle('active', AppGlobals.state.fahrgassenEnabled);
-        fgBtn.setAttribute('aria-pressed', AppGlobals.state.fahrgassenEnabled ? 'true' : 'false');
-      }
-      if (fgSet) fgSet.classList.toggle('open', AppGlobals.state.fahrgassenEnabled);
-      AppGlobals.state.reiter.forEach(function(r) {
-        r.fahrgassenEnabled = AppGlobals.state.fahrgassenEnabled;
-        r.fahrgassenBreite = AppGlobals.state.fahrgassenBreite;
-      });
-      AppGlobals.appEmit('SETTINGS_CHANGED', { setting: 'fahrgassenEnabled' });
-    }
-    function updateFahrgassenBreite() {
-      var inp = document.getElementById('fahrgassen_breite');
-      var hint = document.getElementById('fahrgassen_hint');
-      var saved = document.getElementById('fahrgassen_saved');
-      if (!inp || !hint) return;
-      var val = AppGlobals.parseDE(inp.value);
-      if (val >= 2) {
-        AppGlobals.state.fahrgassenBreite = val;
-        var pct = ((val - 1) / val) * 100;
-        hint.textContent = val + ' m → ~' + pct.toFixed(1) + '% bestellte Fläche';
-        if (saved) saved.textContent = '';
-        AppGlobals.state.reiter.forEach(function(r) {
-          r.fahrgassenEnabled = AppGlobals.state.fahrgassenEnabled;
-          r.fahrgassenBreite = val;
-        });
-      } else {
-        hint.textContent = val > 0
-          ? 'Fahrgassenbreite muss mindestens 2 m betragen'
-          : '';
-        if (val === 0) {
-          AppGlobals.state.fahrgassenBreite = 0;
-          if (saved) saved.textContent = '';
-          AppGlobals.state.reiter.forEach(function(r) {
-            r.fahrgassenEnabled = AppGlobals.state.fahrgassenEnabled;
-            r.fahrgassenBreite = 0;
-          });
-        }
-      }
-      AppGlobals.appEmit('SETTINGS_CHANGED', { setting: 'fahrgassenBreite' });
-    }
-    function toggleEinheitgroesseGlobal() {
-      AppGlobals.state.einheitGroesseEnabled = !AppGlobals.state.einheitGroesseEnabled;
-      var sw = document.getElementById('sw_einheitgroesse');
-      var det = document.getElementById('detail_einheitgroesse');
-      if (sw) sw.classList.toggle('on', AppGlobals.state.einheitGroesseEnabled);
-      if (det) det.classList.toggle('open', AppGlobals.state.einheitGroesseEnabled);
-      if (!AppGlobals.state.einheitGroesseEnabled) {
-        AppGlobals.state.koernerProEinheit = 50000;
-        var inp = document.getElementById('koerner_pro_einheit');
-        if (inp) inp.value = '';
-        var hint = document.getElementById('einheitgroesse_hint');
-        if (hint) hint.textContent = '';
-        var saved = document.getElementById('einheit_groesse_saved');
-        if (saved) saved.textContent = '';
-      }
-      AppGlobals.appEmit('SETTINGS_CHANGED', { setting: 'einheitGroesseEnabled' });
-    }
-    function updateEinheitgroesse() {
-      var inp = document.getElementById('koerner_pro_einheit');
-      var hint = document.getElementById('einheitgroesse_hint');
-      var saved = document.getElementById('einheit_groesse_saved');
-      if (!inp) return;
-      var val = AppGlobals.parseDE(inp.value);
-      if (val > 0 && val <= 999999) {
-        AppGlobals.state.koernerProEinheit = Math.round(val);
-        if (hint) hint.textContent = AppGlobals.state.koernerProEinheit === 50000
-          ? ''
-          : AppGlobals.state.koernerProEinheit.toLocaleString('de-DE') + ' Körner/Einheit';
-        if (saved) saved.textContent = AppGlobals.state.koernerProEinheit === 50000
-          ? ''
-          : AppGlobals.state.koernerProEinheit.toLocaleString('de-DE') + ' Körner/Einheit';
-      }
-      AppGlobals.appEmit('SETTINGS_CHANGED', { setting: 'koernerProEinheit' });
-    }
-    function doResetAll() {
-      if (!confirm('Wirklich ALLE Daten zurücksetzen? Das kann nicht rückgängig gemacht werden.')) return;
-      AppGlobals.resetAll();
-    }
-    // Alias für Tests / Settings-Panel-Button (deutsch)
-    function _onSettingsResetAll() { doResetAll(); }
 
     // --- Fahrgassen ---
 
@@ -1084,16 +1019,13 @@ Object.assign(window.AppGlobals, {
   switchToProtokoll: switchToProtokoll,
   switchToRechner: switchToRechner,
   switchToUebersicht: switchToUebersicht,
-  setView: setView,
-  renameActiveField: renameActiveField,
-  toggleSettings: toggleSettings,
+  switchView: switchView,
   openSettings: openSettings,
-  closeSettings: closeSettings,
-  toggleFahrgassenGlobal: toggleFahrgassenGlobal,
-  updateFahrgassenBreite: updateFahrgassenBreite,
-  toggleEinheitgroesseGlobal: toggleEinheitgroesseGlobal,
-  updateEinheitgroesse: updateEinheitgroesse,
-  doResetAll: doResetAll,
+  _onSettingsCancel: _onSettingsCancel,
+  _onSettingsOverlayClick: _onSettingsOverlayClick,
+  _onSettingsDarkMode: _onSettingsDarkMode,
+  _onSettingsResetTab: _onSettingsResetTab,
+  _onSettingsResetAll: _onSettingsResetAll,
   fahrgassenToggle: fahrgassenToggle,
   fahrgassenUpdate: fahrgassenUpdate,
   einheitGroesseToggle: einheitGroesseToggle,

--- a/public/js/ui-handlers.js
+++ b/public/js/ui-handlers.js
@@ -50,17 +50,8 @@
     function addReiter() {
       syncStateFromInputs();
       var maxIdx = 0;
-      AppGlobals.state.reiter.forEach(function(r, i) {
-        var m = parseInt((r.name || '').replace(/\D+/g, ''));
-        if (!isNaN(m) && m > maxIdx) maxIdx = m;
-      });
-      AppGlobals.state.reiter.push({
-        name: 'Schlag ' + (maxIdx + 1),
-        hektar: 0, istHektar: 0, koerner: 0, duenger: 0,
-        entries: [], done: false,
-        fahrgassenEnabled: AppGlobals.state.fahrgassenEnabled,
-        fahrgassenBreite: AppGlobals.state.fahrgassenBreite
-      });
+      AppGlobals.state.reiter.forEach(function(r, i) { var m = parseInt(r.name.replace(/\D+/g, '')); if (!isNaN(m) && m > maxIdx) maxIdx = m; });
+      AppGlobals.state.reiter.push({ name: 'Tab ' + (maxIdx + 1), hektar: 0, istHektar: 0, koerner: 0, duenger: 0, entries: [], done: false, fahrgassenEnabled: AppGlobals.state.fahrgassenEnabled, fahrgassenBreite: AppGlobals.state.fahrgassenBreite });
       AppGlobals.state.activeReiter = AppGlobals.state.reiter.length - 1;
       AppGlobals.appEmit('TAB_ADDED', { tabIdx: AppGlobals.state.activeReiter });
       document.getElementById('hektar').focus();
@@ -110,85 +101,6 @@
         AppGlobals.renderDrillTabList();
       }
       AppGlobals.appEmit('VIEW_CHANGED', { view: AppGlobals.state.activeView });
-    }
-
-    function switchToRechner() {
-      // Rechner-View = Default. setView('rechner') == activeView = null.
-      if (AppGlobals.state.activeView === null) return;
-      syncStateFromInputs();
-      AppGlobals.state.activeView = null;
-      AppGlobals.appEmit('VIEW_CHANGED', { view: null });
-    }
-
-    function switchToUebersicht() {
-      syncStateFromInputs();
-      if (AppGlobals.state.activeView === 'uebersicht') return;
-      AppGlobals.state.activeView = 'uebersicht';
-      AppGlobals.renderDashboard();
-      AppGlobals.appEmit('VIEW_CHANGED', { view: 'uebersicht' });
-    }
-
-    function switchView(view) {
-      if (view === 'rechner' || view === null) return AppGlobals.switchToRechner();
-      if (view === 'protokoll') return AppGlobals.switchToProtokoll();
-      if (view === 'uebersicht') return AppGlobals.switchToUebersicht();
-    }
-
-    // --- Settings Modal (Issue: Redesign) ---
-    function openSettings() {
-      var ov = document.getElementById('settings_overlay');
-      var mo = document.getElementById('settings_modal');
-      if (ov) ov.classList.add('open');
-      if (mo) mo.classList.add('open');
-      // Sync dark-mode button text with current state
-      var isDark = document.documentElement.classList.contains('dark');
-      var icon = document.getElementById('settings_dark_icon');
-      var title = document.getElementById('settings_dark_title');
-      var desc = document.getElementById('settings_dark_desc');
-      var state = document.getElementById('settings_dark_state');
-      if (icon) icon.textContent = isDark ? '☀️' : '🌙';
-      if (title) title.textContent = isDark ? 'Light Mode' : 'Dark Mode';
-      if (desc) desc.textContent = isDark ? 'Helles Farbschema aktivieren' : 'Dunkles Farbschema aktivieren';
-      if (state) state.textContent = isDark ? 'An' : 'Aus';
-      // Version
-      var v = document.getElementById('settings_version');
-      if (v) v.textContent = (typeof APP_VERSION !== 'undefined' ? APP_VERSION : '—');
-      // Reset-confirmation contexts
-      var tabCtx = document.getElementById('reset_modal_tab_ctx');
-      var ar = AppGlobals.state.reiter[AppGlobals.state.activeReiter];
-      if (tabCtx) tabCtx.textContent = ar ? ('Leert Felder & Protokoll von "' + ar.name + '"') : 'Leert Felder & Protokoll dieses Schlags';
-    }
-    function _onSettingsCancel() {
-      var ov = document.getElementById('settings_overlay');
-      var mo = document.getElementById('settings_modal');
-      if (ov) ov.classList.remove('open');
-      if (mo) mo.classList.remove('open');
-    }
-    function _onSettingsOverlayClick(e) {
-      if (e && e.target && e.target.id === 'settings_overlay') _onSettingsCancel();
-    }
-    function _onSettingsDarkMode() {
-      // toggleTheme() setzt die html.dark-Klasse + localStorage + theme_toggle.
-      // theme_toggle ist im HTML hidden, Klick funktioniert trotzdem programmatisch.
-      AppGlobals.toggleTheme();
-      // Refresh button-label
-      var isDark = document.documentElement.classList.contains('dark');
-      var icon = document.getElementById('settings_dark_icon');
-      var title = document.getElementById('settings_dark_title');
-      var desc = document.getElementById('settings_dark_desc');
-      var state = document.getElementById('settings_dark_state');
-      if (icon) icon.textContent = isDark ? '☀️' : '🌙';
-      if (title) title.textContent = isDark ? 'Light Mode' : 'Dark Mode';
-      if (desc) desc.textContent = isDark ? 'Helles Farbschema aktivieren' : 'Dunkles Farbschema aktivieren';
-      if (state) state.textContent = isDark ? 'An' : 'Aus';
-    }
-    function _onSettingsResetTab() {
-      _onSettingsCancel();
-      AppGlobals.resetActiveTab();
-    }
-    function _onSettingsResetAll() {
-      _onSettingsCancel();
-      AppGlobals.openResetModal();
     }
 
     function renameReiter(idx, name) {
@@ -347,7 +259,7 @@
       // Preserve UI-prefs that "Daten zurücksetzen" should NOT wipe.
       var keepIosHint = AppGlobals.state.iosInstallHintShown;
       AppGlobals.state = {
-        reiter: [{ name: 'Schlag 1', hektar: 0, istHektar: 0, koerner: 0, duenger: 0, entries: [], done: false, fahrgassenEnabled: false, fahrgassenBreite: 0 }],
+        reiter: [{ name: 'Tab 1', hektar: 0, istHektar: 0, koerner: 0, duenger: 0, entries: [], done: false, fahrgassenEnabled: false, fahrgassenBreite: 0 }],
         activeReiter: 0,
         activeView: null,
         fahrgassenEnabled: false,
@@ -1017,15 +929,6 @@ Object.assign(window.AppGlobals, {
   switchReiter: switchReiter,
   renameReiter: renameReiter,
   switchToProtokoll: switchToProtokoll,
-  switchToRechner: switchToRechner,
-  switchToUebersicht: switchToUebersicht,
-  switchView: switchView,
-  openSettings: openSettings,
-  _onSettingsCancel: _onSettingsCancel,
-  _onSettingsOverlayClick: _onSettingsOverlayClick,
-  _onSettingsDarkMode: _onSettingsDarkMode,
-  _onSettingsResetTab: _onSettingsResetTab,
-  _onSettingsResetAll: _onSettingsResetAll,
   fahrgassenToggle: fahrgassenToggle,
   fahrgassenUpdate: fahrgassenUpdate,
   einheitGroesseToggle: einheitGroesseToggle,

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // ⚠️ CACHE_VERSION muss bei jedem Release manuell gebumpet werden!
 // Bei Vergessen bekommen Nutzer die alte Version aus dem Cache.
 // alternativa: Build-Script das Hash/Zeitstempel injiziert.
-const CACHE_VERSION = 'agrar-rechner-v47';
+const CACHE_VERSION = 'agrar-rechner-v46';
 const STATIC_ASSETS = [
     '/',
     '/index.html',

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // ⚠️ CACHE_VERSION muss bei jedem Release manuell gebumpet werden!
 // Bei Vergessen bekommen Nutzer die alte Version aus dem Cache.
 // alternativa: Build-Script das Hash/Zeitstempel injiziert.
-const CACHE_VERSION = 'agrar-rechner-v48';
+const CACHE_VERSION = 'agrar-rechner-v47';
 const STATIC_ASSETS = [
     '/',
     '/index.html',

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // ⚠️ CACHE_VERSION muss bei jedem Release manuell gebumpet werden!
 // Bei Vergessen bekommen Nutzer die alte Version aus dem Cache.
 // alternativa: Build-Script das Hash/Zeitstempel injiziert.
-const CACHE_VERSION = 'agrar-rechner-v46';
+const CACHE_VERSION = 'agrar-rechner-v45';
 const STATIC_ASSETS = [
     '/',
     '/index.html',

--- a/tests/06-tab-management.test.js
+++ b/tests/06-tab-management.test.js
@@ -19,7 +19,7 @@ describe('Tab management', () => {
       w.addReiter();
       expect(w.state.reiter.length).toBe(2);
       expect(w.state.activeReiter).toBe(1);
-      expect(w.state.reiter[1].name).toBe('Schlag 2');
+      expect(w.state.reiter[1].name).toBe('Tab 2');
     });
 
     it('new tab has default values', () => {
@@ -36,9 +36,9 @@ describe('Tab management', () => {
       w.addReiter();
       w.addReiter();
       expect(w.state.reiter.length).toBe(4);
-      expect(w.state.reiter[1].name).toBe('Schlag 2');
-      expect(w.state.reiter[2].name).toBe('Schlag 3');
-      expect(w.state.reiter[3].name).toBe('Schlag 4');
+      expect(w.state.reiter[1].name).toBe('Tab 2');
+      expect(w.state.reiter[2].name).toBe('Tab 3');
+      expect(w.state.reiter[3].name).toBe('Tab 4');
     });
 
     it('preserves first tab data when adding new tab', () => {
@@ -239,7 +239,7 @@ describe('Tab management', () => {
       w.renderTabs();
       const spans = doc.querySelectorAll('.tab-name');
       expect(spans.length).toBe(1);
-      expect(spans[0].textContent).toBe('Schlag 1');
+      expect(spans[0].textContent).toBe('Tab 1');
       // Simulate renaming by setting textContent and triggering blur
       spans[0].textContent = 'Mein Feld';
       spans[0].onblur();

--- a/tests/07-state-persistence.test.js
+++ b/tests/07-state-persistence.test.js
@@ -152,10 +152,9 @@ describe('State persistence', () => {
       expect(w.state.reiter[0].entries[0].einheit).toBe(1);
     });
 
-    it('persists migrated snapshot so _lv advances to 6 after first load', () => {
-      // Alt-State ohne _lv → Migration 0→6 sollte durchlaufen
-      // (Schema-Validation + Tab-Rename Tab→Schlag), und das Ergebnis einmalig
-      // zurück in localStorage geschrieben werden.
+    it('persists migrated snapshot so _lv advances to 5 after first load', () => {
+      // Alt-State ohne _lv → Migration 0→5 sollte durchlaufen
+      // und das Ergebnis einmalig zurück in localStorage geschrieben werden.
       store['agrar_rechner'] = JSON.stringify({
         reiter: [{ name: 'Tab 1', hektar: 10, koerner: 90000, duenger: 150, entries: [] }],
         activeReiter: 0,
@@ -163,13 +162,11 @@ describe('State persistence', () => {
         fahrgassenBreite: 0,
       });
       w.loadState();
-      // Nach Migration: gespeicherter Snapshot hat _lv=6
+      // Nach Migration: gespeicherter Snapshot hat _lv=5
       var persisted = JSON.parse(store['agrar_rechner']);
-      expect(persisted._lv).toBe(6);
+      expect(persisted._lv).toBe(5);
       // Issue #377: `done: false` wird via sanitizeTab auf bestehende Tabs gesetzt
       expect(persisted.reiter[0].done).toBe(false);
-      // Migration 5→6: Tab N wird zu Schlag N
-      expect(persisted.reiter[0].name).toBe('Schlag 1');
     });
 
     it('does not re-run migration on second load (idempotent at storage level)', () => {
@@ -181,13 +178,13 @@ describe('State persistence', () => {
       });
       w.loadState();
       var afterFirst = JSON.parse(store['agrar_rechner']);
-      // Zweiter Load: _lv ist schon 6, also kein Re-Migration-Touch.
+      // Zweiter Load: _lv ist schon 5, also kein Re-Migration-Touch.
       // Wenn loadState erneut schreiben würde, wäre das ein No-Op für die
       // Felder; der Test sichert ab, dass _lv erhalten bleibt und keine
       // Re-Schreibung passiert (idempotent = kein Drift).
       w.loadState();
       var afterSecond = JSON.parse(store['agrar_rechner']);
-      expect(afterSecond._lv).toBe(6);
+      expect(afterSecond._lv).toBe(5);
       expect(afterSecond.reiter[0].hektar).toBe(10);
     });
   });

--- a/tests/14-drill-multitab.test.js
+++ b/tests/14-drill-multitab.test.js
@@ -33,11 +33,11 @@ describe('renderDrillTabList', () => {
   it('shows tab name', () => {
     w.renderDrillTabList();
     var name = w.document.getElementById('drill_tab_list').querySelector('.drill-tab-name');
-    expect(name.textContent).toBe('Schlag 1');
+    expect(name.textContent).toBe('Tab 1');
   });
 
   it('shows "fertig" when tab is completely drilled', () => {
-    w.state.reiter[0] = { name: 'Schlag 1', hektar: 10, koerner: 90000, duenger: 0, entries: [
+    w.state.reiter[0] = { name: 'Tab 1', hektar: 10, koerner: 90000, duenger: 0, entries: [
       { einheit: 18, duenger: 0, hektar: 10, time: '12:00' }
     ]};
     w.renderDrillTabList();
@@ -47,7 +47,7 @@ describe('renderDrillTabList', () => {
   });
 
   it('shows remaining need when partially drilled', () => {
-    w.state.reiter[0] = { name: 'Schlag 1', hektar: 10, koerner: 90000, duenger: 150, entries: [
+    w.state.reiter[0] = { name: 'Tab 1', hektar: 10, koerner: 90000, duenger: 150, entries: [
       { einheit: 5, duenger: 500, hektar: 3, time: '12:00' }
     ]};
     w.renderDrillTabList();

--- a/tests/19-savings-carryover.test.js
+++ b/tests/19-savings-carryover.test.js
@@ -340,7 +340,7 @@ describe('IST/SOLL Savings & Carryover', () => {
     // Specifically: tab 0 must show a savings block (IST < SOLL with entry).
     // Find tab 0's header (first one), then assert a savings block follows it.
     const tab0HeaderIdx = children.findIndex(c =>
-      c.classList.contains('drill-entry-tab-header') && c.textContent.includes('Schlag 1'));
+      c.classList.contains('drill-entry-tab-header') && c.textContent.includes('Tab 1'));
     expect(tab0HeaderIdx).toBeGreaterThanOrEqual(0);
     // The next child after tab 0's header must be its savings block (since tab 0
     // is a savings source with an entry, it has drill-savings).

--- a/tests/29-open-close-dashboard.test.js
+++ b/tests/29-open-close-dashboard.test.js
@@ -60,7 +60,7 @@ describe('Dashboard open/close', () => {
     w.openDashboard();
     const cards = doc.querySelectorAll('.dashboard-reiter-card');
     expect(cards.length).toBe(1);
-    expect(doc.getElementById('dashboard_content').textContent).toContain('Schlag 1');
+    expect(doc.getElementById('dashboard_content').textContent).toContain('Tab 1');
   });
 
   it('dashboard shows multiple tabs correctly', () => {

--- a/tests/38-update-banner.test.js
+++ b/tests/38-update-banner.test.js
@@ -35,7 +35,7 @@ describe('Update Banner ("What\'s New")', () => {
       delete store['agrar_rechner_version_seen'];
       w.initUI();
       const verEl = doc.getElementById('update_version');
-      expect(verEl.textContent).toBe('v1.1.0');
+      expect(verEl.textContent).toBe('v1.0.0');
     });
 
     it('fills changelog text correctly', () => {
@@ -66,7 +66,7 @@ describe('Update Banner ("What\'s New")', () => {
     it('saves current version to localStorage after dismiss', () => {
       delete store['agrar_rechner_version_seen'];
       w.dismissUpdateHint();
-      expect(store['agrar_rechner_version_seen']).toBe('v1.1.0');
+      expect(store['agrar_rechner_version_seen']).toBe('v1.0.0');
     });
 
     it('second initUI does not re-show banner after dismiss', () => {
@@ -80,8 +80,8 @@ describe('Update Banner ("What\'s New")', () => {
   });
 
   describe('APP_VERSION constant', () => {
-    it('APP_VERSION is defined as v1.1.0', () => {
-      expect(w.APP_VERSION).toBe('v1.1.0');
+    it('APP_VERSION is defined as v1.0.0', () => {
+      expect(w.APP_VERSION).toBe('v1.0.0');
     });
 
     it('APP_BUILD_DATE is a non-empty string', () => {
@@ -101,7 +101,7 @@ describe('Update Banner ("What\'s New")', () => {
       w.initUI();
       const footer = doc.getElementById('version_footer');
       expect(footer).toBeTruthy();
-      expect(footer.textContent).toBe('v1.1.0 · Juli 2026');
+      expect(footer.textContent).toBe('v1.0.0 · Mai 2025');
     });
   });
 });

--- a/tests/38-update-banner.test.js
+++ b/tests/38-update-banner.test.js
@@ -35,7 +35,7 @@ describe('Update Banner ("What\'s New")', () => {
       delete store['agrar_rechner_version_seen'];
       w.initUI();
       const verEl = doc.getElementById('update_version');
-      expect(verEl.textContent).toBe('v1.2.0');
+      expect(verEl.textContent).toBe('v1.1.0');
     });
 
     it('fills changelog text correctly', () => {
@@ -66,7 +66,7 @@ describe('Update Banner ("What\'s New")', () => {
     it('saves current version to localStorage after dismiss', () => {
       delete store['agrar_rechner_version_seen'];
       w.dismissUpdateHint();
-      expect(store['agrar_rechner_version_seen']).toBe('v1.2.0');
+      expect(store['agrar_rechner_version_seen']).toBe('v1.1.0');
     });
 
     it('second initUI does not re-show banner after dismiss', () => {
@@ -80,8 +80,8 @@ describe('Update Banner ("What\'s New")', () => {
   });
 
   describe('APP_VERSION constant', () => {
-    it('APP_VERSION is defined as v1.2.0', () => {
-      expect(w.APP_VERSION).toBe('v1.2.0');
+    it('APP_VERSION is defined as v1.1.0', () => {
+      expect(w.APP_VERSION).toBe('v1.1.0');
     });
 
     it('APP_BUILD_DATE is a non-empty string', () => {
@@ -101,7 +101,7 @@ describe('Update Banner ("What\'s New")', () => {
       w.initUI();
       const footer = doc.getElementById('version_footer');
       expect(footer).toBeTruthy();
-      expect(footer.textContent).toBe('v1.2.0 · Juli 2026');
+      expect(footer.textContent).toBe('v1.1.0 · Juli 2026');
     });
   });
 });

--- a/tests/43-loadstate-schema-validation.test.js
+++ b/tests/43-loadstate-schema-validation.test.js
@@ -237,7 +237,7 @@ describe('loadState() schema validation (Issue #237)', () => {
 
         it('strips unknown top-level state fields but keeps recognized ones', () => {
             store['agrar_rechner'] = JSON.stringify({
-                reiter: [{ name: 'Schlag 1', entries: [] }],
+                reiter: [{ name: 'Tab 1', entries: [] }],
                 _lv: 4,
                 xss: 'top-level',
                 injected: { evil: true },
@@ -254,7 +254,7 @@ describe('loadState() schema validation (Issue #237)', () => {
     describe('activeView coercion (Pre-#291 View-Toggle pattern)', () => {
         it('coerces activeView to null unless literally "protokoll"', () => {
             store['agrar_rechner'] = JSON.stringify({
-                reiter: [{ name: 'Schlag 1', entries: [] }],
+                reiter: [{ name: 'Tab 1', entries: [] }],
                 activeView: 'random-string',
                 _lv: 4
             });
@@ -264,7 +264,7 @@ describe('loadState() schema validation (Issue #237)', () => {
 
         it('preserves activeView = "protokoll"', () => {
             store['agrar_rechner'] = JSON.stringify({
-                reiter: [{ name: 'Schlag 1', entries: [] }],
+                reiter: [{ name: 'Tab 1', entries: [] }],
                 activeView: 'protokoll',
                 _lv: 4
             });
@@ -274,7 +274,7 @@ describe('loadState() schema validation (Issue #237)', () => {
 
         it('coerces non-string activeView values (numbers, objects, arrays) to null', () => {
             store['agrar_rechner'] = JSON.stringify({
-                reiter: [{ name: 'Schlag 1', entries: [] }],
+                reiter: [{ name: 'Tab 1', entries: [] }],
                 activeView: 42,
                 _lv: 4
             });
@@ -282,7 +282,7 @@ describe('loadState() schema validation (Issue #237)', () => {
             expect(w.state.activeView).toBeNull();
 
             store['agrar_rechner'] = JSON.stringify({
-                reiter: [{ name: 'Schlag 1', entries: [] }],
+                reiter: [{ name: 'Tab 1', entries: [] }],
                 activeView: { evil: true },
                 _lv: 4
             });
@@ -292,7 +292,7 @@ describe('loadState() schema validation (Issue #237)', () => {
 
         it('defaults activeView to null when missing from persisted state', () => {
             store['agrar_rechner'] = JSON.stringify({
-                reiter: [{ name: 'Schlag 1', entries: [] }],
+                reiter: [{ name: 'Tab 1', entries: [] }],
                 _lv: 4
             });
             w.loadState();
@@ -423,7 +423,7 @@ describe('loadState() schema validation (Issue #237)', () => {
             expect(() => w.loadState()).not.toThrow();
             // State unverändert (Default bleibt)
             expect(w.state.reiter.length).toBe(1);
-            expect(w.state.reiter[0].name).toBe('Schlag 1');
+            expect(w.state.reiter[0].name).toBe('Tab 1');
 
             store['agrar_rechner'] = '42';
             expect(() => w.loadState()).not.toThrow();


### PR DESCRIPTION
Setzt dev auf den Stand nach #392 zurück (vor allen Redesign-Releases).

Reverts (neueste zuerst):
- Revert "Merge branch 'feat/visual-redesign-v2' into dev" (d3bd4d3)
- Revert "chore(release): v1.1.0 — visual redesign" (b47363d)
- Revert "Merge branch 'feat/visual-redesign-bottom-nav' into dev" (8d8f597)
- Revert "chore: CACHE_VERSION v47 → v48 — invalidate SW cache (#393)" (f9929fe)

Endzustand:
- CACHE_VERSION: v45
- APP_VERSION: v1.0.0
- APP_BUILD_DATE: Mai 2025

Backup-Tags auf origin (Recovery falls nötig):
- backup/dev-with-redesigns-v1.1-v1.2 (Stand vor diesem PR)
- backup/dev-before-v1.2.0-revert (Stand vor Cache-Bump #393)

Alle 792 Vitest-Tests grün auf dem Re-vert-Stand.