### PR TITLE
UI/UX: v4 — Nav-Leiste sticky + alte Wege ausgeblendet

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1860,3 +1860,32 @@ html.dark .bottom-nav {
 .scrollable-content {
   padding-bottom: 12px;
 }
+   Nav-Leiste gelöst). Die alten Wege bleiben FUNKTIONAL vollständig
+   erhalten (IDs, Klassen, Klick-Handler unverändert — die ~60 Tests
+   greifen teils direkt darauf zu), werden aber nur noch per CSS
+   ausgeblendet, weil die neue Leiste sie ersetzt. --------------------- */
+
+/* Alte Wege ausblenden (nicht entfernen — s.o.) */
+.dashboard-open-btn,
+#protokoll_tab_btn {
+  display: none;
+}
+
+/* Damit die Nav-Leiste wirklich am Bildschirmrand "sticky" bleibt, muss
+   .app-layout auf die tatsächliche Viewport-Höhe begrenzt werden (vorher
+   nur min-height → die ganze Seite wuchs mit dem Inhalt und scrollte als
+   Ganzes, die Nav-Leiste landete irgendwo am Ende statt fixiert unten). */
+html, body {
+  height: 100%;
+}
+body {
+  overflow: hidden;
+}
+.app-layout {
+  height: calc(100dvh - max(20px, env(safe-area-inset-top)) - max(20px, env(safe-area-inset-bottom)));
+  min-height: 0;
+}
+.scrollable-content {
+  min-height: 0;
+}
+


### PR DESCRIPTION
Reines CSS-Update, baut auf #399 auf (v3).

## Was ist neu in v4
- **Nav-Leiste jetzt wirklich sticky:** `.app-layout` bekommt eine **feste** Höhe (`calc(100dvh - safe-area)`), `body` `overflow:hidden` → ausschließlich `.scrollable-content` scrollt, Header + Nav-Leiste bleiben im Viewport fix.
- **Alte, jetzt redundante Wege ausgeblendet** (per `display:none`, nicht entfernt — Tests greifen direkt auf `#protokoll_tab_btn` und `#dashboard_open_btn` zu): der "🔧 Protokoll"-Tab oben und der "📊 Dashboard"-Button im Header.

## Mit aus v3 übernommen
- Bugfix: Ergebnis-Ring zeigt jetzt nur die Zahl (statt "18,0 Einheiten").
- Bugfix: überlappende Pro-Tab-Zeile im Drill-Protokoll (festes 2-Zeilen-Grid).
- Bottom-Nav, Eyebrow-Header, Moss-Gradient im Ring/Dashboard-Hero.

## Funktional unangetastet
- 47/47 test files · 792/792 grün.
- Keine IDs/Klassen entfernt oder umbenannt, alle JS-Handler intakt.

## Files changed
```
 public/css/styles.css | 29 +++++++++++++++++++++++++++++
 1 file changed, 29 insertions(+)
```
