### PR TITLE
UI/UX: v5 — Reset-Button nach scrollable-content, Version ausgeblendet, Nav flacher

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1889,3 +1889,41 @@ body {
   min-height: 0;
 }
 
+
+/* ---- Demo-Alignment v5: !important, Version ausgeblendet, Nav flacher ---- */
+
+/* !important damit die Ausblendung auch sicher hält, falls woanders eine
+   konkurrierende display-Regel für dieselben Elemente sitzt. */
+.dashboard-open-btn,
+#protokoll_tab_btn {
+  display: none !important;
+}
+
+/* Versionsnummer im Footer: Element bleibt im DOM (Tests lesen textContent),
+   wird nur unsichtbar gemacht. Reset-Button wurde parallel in index.html
+   ans Ende von .scrollable-content verschoben, damit er unter der neuen
+   sticky Nav-Leiste nicht unerreichbar wird. */
+#version_footer {
+  display: none;
+}
+.footer-actions {
+  margin: 4px 0 0;
+}
+
+/* Nav-Leiste flacher: Icon + Label nebeneinander statt gestapelt, weniger
+   Padding, etwas kleinere Ecken — spart vertikalen Platz im Viewport. */
+.bottom-nav {
+  padding: 5px 6px calc(5px + env(safe-area-inset-bottom));
+  border-radius: 16px;
+}
+.nav-btn {
+  flex-direction: row;
+  justify-content: center;
+  gap: 5px;
+  border-radius: 11px;
+  font-size: 0.72rem;
+}
+.nav-btn .ic {
+  font-size: 0.95rem;
+  line-height: 1;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -217,6 +217,10 @@
 
     </div><!-- end .container -->
 
+    <div class="version-footer" id="version_footer"></div>
+    <div class="footer-actions">
+      <button class="footer-reset-btn" onclick="openResetModal()" aria-label="Daten zurücksetzen">🗑️ Daten zurücksetzen</button>
+    </div>
     </div><!-- end .scrollable-content -->
 
     <nav class="bottom-nav">
@@ -277,10 +281,6 @@
   <script src="js/render-drill.js"></script>
   <script src="js/render-dashboard.js"></script>
   <script src="js/main.js"></script>
-  <div class="version-footer" id="version_footer"></div>
-  <div class="footer-actions">
-    <button class="footer-reset-btn" onclick="openResetModal()" aria-label="Daten zurücksetzen">🗑️ Daten zurücksetzen</button>
-  </div>
   <!-- Dashboard overlay + sheet -->
   <div class="dashboard-overlay" id="dashboard_overlay" onclick="closeDashboard()"></div>
   <div class="dashboard-sheet" id="dashboard_sheet" role="dialog" aria-modal="true" aria-label="Dashboard — Alle Tabs Übersicht">


### PR DESCRIPTION
Baut auf #400 (v4) auf.

## Was ist neu in v5
- **Reset-Button ans Ende von `.scrollable-content` verschoben**: war vorher außerhalb (im `<body>`), wäre unter der fixen Nav-Leiste unerreichbar geworden. Jetzt beim Runterscrollen weiterhin erreichbar.
- **`<div class="version-footer" id="version_footer">` ausgeblendet** per `display:none` (Element bleibt im DOM, da Tests den textContent lesen).
- **Display-Regel auf `!important` hochgestuft** für `.dashboard-open-btn` / `#protokoll_tab_btn`, damit sie garantiert versteckt sind.
- **Nav-Leiste flacher**: Icon + Label nebeneinander statt gestapelt (`flex-direction: row`), weniger Padding, kleinere Ecken.

## Mit aus v3+v4 übernommen
- Sticky Bottom-Nav (Rechner/Protokoll/Übersicht)
- Bugfix Ergebnis-Ring (zeigt nur die Zahl statt "18,0 Einheiten")
- Bugfix überlappende Pro-Tab-Zeile im Drill-Protokoll (2-Zeilen-Grid)

## Funktional unangetastet
- 47/47 test files · 792/792 grün.
- Keine IDs/Klassen/Handler entfernt oder umbenannt.

## Files changed
```
 public/css/styles.css | 38 ++++++++++++++++++++++++++++++++++++++
 public/index.html     |  8 ++++----
 2 files changed, 42 insertions(+), 4 deletions(-)
```
