### PR TITLE
UI/UX: v6 — Tab → Schlag Umbenennung + Tab-Leiste im Protokoll aus

### DIFF
--- a/public/js/render-drill.js
+++ b/public/js/render-drill.js
@@ -46,7 +46,7 @@
         nameWrap.className = 'drill-tab-name-wrap';
         var label = document.createElement('div');
         label.className = 'drill-tab-name';
-        label.textContent = r.name || ('Tab ' + (i + 1));
+        label.textContent = r.name || ('Schlag ' + (i + 1));
         nameWrap.appendChild(label);
         if (r.hektar > 0 && r.koerner > 0) {
           // Issue 2 (Code-Review): DRY + NaN-Fix. Die alten bare reduces
@@ -431,7 +431,7 @@
         if (!hasEntries && !_tabHasCarryoverSignal(tabIdx, rt)) return;
         var header = document.createElement('div');
         header.className = 'drill-entry-tab-header';
-        header.textContent = rt.name || ('Tab ' + (tabIdx + 1));
+        header.textContent = rt.name || ('Schlag ' + (tabIdx + 1));
         container.appendChild(header);
         // Carryover blocks (Ersparnis / Übertrag / Mehrbedarf) directly below
         // the tab-header so users can see which tab each block belongs to.
@@ -521,7 +521,7 @@
         if (!rt || !_tabHasCarryoverSignal(tabIdx, rt)) return;
         var sub = document.createElement('div');
         sub.className = 'drill-entry-tab-header drill-machine-log-tab-subheader';
-        sub.textContent = rt.name || ('Tab ' + (tabIdx + 1));
+        sub.textContent = rt.name || ('Schlag ' + (tabIdx + 1));
         container.appendChild(sub);
         _appendTabCarryoverBlocks(tabIdx, rt, container);
       });

--- a/public/js/render-results.js
+++ b/public/js/render-results.js
@@ -180,7 +180,7 @@
           // sein Mehrbedarf wird unsichtbar auf einen anderen Tab (die
           // Senke) verrechnet. Zeige, welcher das ist.
           var sinkTab = AppGlobals.state.reiter[sinkIdx];
-          var sinkName = (sinkTab && sinkTab.name) || ('Tab ' + (sinkIdx + 1));
+          var sinkName = (sinkTab && sinkTab.name) || ('Schlag ' + (sinkIdx + 1));
           var noteDiv = document.createElement('div');
           noteDiv.className = 'r-carryover-row r-carryover-carryover';
           noteDiv.textContent = '↳ wird über den Tab-Ausgleich von „' + sinkName + '\u201c gedeckt';

--- a/public/js/render-tabs.js
+++ b/public/js/render-tabs.js
@@ -19,7 +19,7 @@
         var isActive = i === AppGlobals.state.activeReiter && AppGlobals.state.activeView !== 'protokoll';
         var btn = document.createElement('button');
         btn.className = 'tab-btn field-tab' + (isActive ? ' active' : '');
-        btn.setAttribute('aria-label', 'Tab ' + (i+1));
+        btn.setAttribute('aria-label', 'Schlag ' + (i+1));
         btn.onclick = function() { AppGlobals.switchReiter(i); };
         var span = document.createElement('span');
         span.className = 'tab-name';
@@ -50,7 +50,7 @@
           var close = document.createElement('span');
           close.className = 'tab-close';
           close.setAttribute('role', 'button');
-          close.setAttribute('aria-label', 'Tab schließen');
+          close.setAttribute('aria-label', 'Schlag schließen');
           close.onclick = function(evt) { evt.stopPropagation(); confirmRemoveReiter(i); };
           close.textContent = '✕';
           btn.appendChild(close);
@@ -95,6 +95,8 @@
       if (drillSection) drillSection.style.display = isProtokoll ? 'block' : 'none';
       var drillMask = document.getElementById('drill_mask');
       if (drillMask) drillMask.style.display = isProtokoll ? '' : 'none';
+      var tabBar = document.getElementById('tab_bar');
+      if (tabBar) tabBar.style.display = isProtokoll ? 'none' : 'flex';
     }
 
     // --- Init: UI (nach DOMContentLoaded) ---
@@ -289,9 +291,9 @@
       var hasEntries = tab.entries && tab.entries.length > 0;
       var hasData = tab.hektar > 0 || tab.koerner > 0 || tab.duenger > 0 || tab.istHektar > 0;
       if (hasEntries || hasData) {
-        if (!confirm('Tab "' + tab.name + '" wirklich löschen? Daten vorhanden — alle Eingaben gehen verloren.')) return;
+        if (!confirm('Schlag "' + tab.name + '" wirklich löschen? Daten vorhanden — alle Eingaben gehen verloren.')) return;
       } else {
-        if (!confirm('Tab "' + tab.name + '" wirklich löschen? Alle Eingaben gehen verloren.')) return;
+        if (!confirm('Schlag "' + tab.name + '" wirklich löschen? Alle Eingaben gehen verloren.')) return;
       }
       AppGlobals.removeReiter(idx);
     }

--- a/public/js/state.js
+++ b/public/js/state.js
@@ -15,7 +15,7 @@
 
 var state = {
   reiter: [{
-    name:       'Tab 1',
+    name:       'Schlag 1',
     hektar:     0,
     istHektar:  0,
     koerner:    0,
@@ -188,10 +188,10 @@ function sanitizeMachineLogEntry(raw) {
 
 function sanitizeTab(raw) {
   if (!isPlainObject(raw)) {
-    return { name: 'Tab', hektar: 0, istHektar: 0, koerner: 0, duenger: 0, entries: [], done: false };
+    return { name: 'Schlag', hektar: 0, istHektar: 0, koerner: 0, duenger: 0, entries: [], done: false };
   }
   var tab = {
-    name:      sanitizeString(raw.name, 'Tab', 64),
+    name:      sanitizeString(raw.name, 'Schlag', 64),
     hektar:    sanitizeNumber(raw.hektar, 0),
     istHektar: sanitizeNumber(raw.istHektar, 0),
     koerner:   sanitizeNumber(raw.koerner, 0),
@@ -253,7 +253,7 @@ function loadState() {
     var lv = originalLv;
     // Migration 0→1: Einzelne Felder → Tab-Array
     if (!data.reiter && (data.hektar !== undefined || data.koerner !== undefined)) {
-      data = { reiter: [{ name: 'Tab 1', hektar: data.hektar || 0, istHektar: data.istHektar || 0, koerner: data.koerner || 0, duenger: data.duenger || 0, entries: data.entries || [], done: false }], activeReiter: 0, activeView: null, fahrgassenEnabled: false, fahrgassenBreite: 0, einheitGroesseEnabled: false, koernerProEinheit: 50000, machineLog: data.machineLog || [], drillPriorities: {}, iosInstallHintShown: false, _lv: 1 };
+      data = { reiter: [{ name: 'Schlag 1', hektar: data.hektar || 0, istHektar: data.istHektar || 0, koerner: data.koerner || 0, duenger: data.duenger || 0, entries: data.entries || [], done: false }], activeReiter: 0, activeView: null, fahrgassenEnabled: false, fahrgassenBreite: 0, einheitGroesseEnabled: false, koernerProEinheit: 50000, machineLog: data.machineLog || [], drillPriorities: {}, iosInstallHintShown: false, _lv: 1 };
       lv = 1;
     }
     // Migration 1→2: Globale entries → per-Tab entries

--- a/public/js/ui-handlers.js
+++ b/public/js/ui-handlers.js
@@ -51,7 +51,7 @@
       syncStateFromInputs();
       var maxIdx = 0;
       AppGlobals.state.reiter.forEach(function(r, i) { var m = parseInt(r.name.replace(/\D+/g, '')); if (!isNaN(m) && m > maxIdx) maxIdx = m; });
-      AppGlobals.state.reiter.push({ name: 'Tab ' + (maxIdx + 1), hektar: 0, istHektar: 0, koerner: 0, duenger: 0, entries: [], done: false, fahrgassenEnabled: AppGlobals.state.fahrgassenEnabled, fahrgassenBreite: AppGlobals.state.fahrgassenBreite });
+      AppGlobals.state.reiter.push({ name: 'Schlag ' + (maxIdx + 1), hektar: 0, istHektar: 0, koerner: 0, duenger: 0, entries: [], done: false, fahrgassenEnabled: AppGlobals.state.fahrgassenEnabled, fahrgassenBreite: AppGlobals.state.fahrgassenBreite });
       AppGlobals.state.activeReiter = AppGlobals.state.reiter.length - 1;
       AppGlobals.appEmit('TAB_ADDED', { tabIdx: AppGlobals.state.activeReiter });
       document.getElementById('hektar').focus();
@@ -275,7 +275,7 @@
       // Preserve UI-prefs that "Daten zurücksetzen" should NOT wipe.
       var keepIosHint = AppGlobals.state.iosInstallHintShown;
       AppGlobals.state = {
-        reiter: [{ name: 'Tab 1', hektar: 0, istHektar: 0, koerner: 0, duenger: 0, entries: [], done: false, fahrgassenEnabled: false, fahrgassenBreite: 0 }],
+        reiter: [{ name: 'Schlag 1', hektar: 0, istHektar: 0, koerner: 0, duenger: 0, entries: [], done: false, fahrgassenEnabled: false, fahrgassenBreite: 0 }],
         activeReiter: 0,
         activeView: null,
         fahrgassenEnabled: false,

--- a/tests/06-tab-management.test.js
+++ b/tests/06-tab-management.test.js
@@ -19,7 +19,7 @@ describe('Tab management', () => {
       w.addReiter();
       expect(w.state.reiter.length).toBe(2);
       expect(w.state.activeReiter).toBe(1);
-      expect(w.state.reiter[1].name).toBe('Tab 2');
+      expect(w.state.reiter[1].name).toBe('Schlag 2');
     });
 
     it('new tab has default values', () => {
@@ -36,9 +36,9 @@ describe('Tab management', () => {
       w.addReiter();
       w.addReiter();
       expect(w.state.reiter.length).toBe(4);
-      expect(w.state.reiter[1].name).toBe('Tab 2');
-      expect(w.state.reiter[2].name).toBe('Tab 3');
-      expect(w.state.reiter[3].name).toBe('Tab 4');
+      expect(w.state.reiter[1].name).toBe('Schlag 2');
+      expect(w.state.reiter[2].name).toBe('Schlag 3');
+      expect(w.state.reiter[3].name).toBe('Schlag 4');
     });
 
     it('preserves first tab data when adding new tab', () => {
@@ -239,7 +239,7 @@ describe('Tab management', () => {
       w.renderTabs();
       const spans = doc.querySelectorAll('.tab-name');
       expect(spans.length).toBe(1);
-      expect(spans[0].textContent).toBe('Tab 1');
+      expect(spans[0].textContent).toBe('Schlag 1');
       // Simulate renaming by setting textContent and triggering blur
       spans[0].textContent = 'Mein Feld';
       spans[0].onblur();

--- a/tests/14-drill-multitab.test.js
+++ b/tests/14-drill-multitab.test.js
@@ -33,7 +33,7 @@ describe('renderDrillTabList', () => {
   it('shows tab name', () => {
     w.renderDrillTabList();
     var name = w.document.getElementById('drill_tab_list').querySelector('.drill-tab-name');
-    expect(name.textContent).toBe('Tab 1');
+    expect(name.textContent).toBe('Schlag 1');
   });
 
   it('shows "fertig" when tab is completely drilled', () => {

--- a/tests/19-savings-carryover.test.js
+++ b/tests/19-savings-carryover.test.js
@@ -340,7 +340,7 @@ describe('IST/SOLL Savings & Carryover', () => {
     // Specifically: tab 0 must show a savings block (IST < SOLL with entry).
     // Find tab 0's header (first one), then assert a savings block follows it.
     const tab0HeaderIdx = children.findIndex(c =>
-      c.classList.contains('drill-entry-tab-header') && c.textContent.includes('Tab 1'));
+      c.classList.contains('drill-entry-tab-header') && c.textContent.includes('Schlag 1'));
     expect(tab0HeaderIdx).toBeGreaterThanOrEqual(0);
     // The next child after tab 0's header must be its savings block (since tab 0
     // is a savings source with an entry, it has drill-savings).

--- a/tests/29-open-close-dashboard.test.js
+++ b/tests/29-open-close-dashboard.test.js
@@ -56,11 +56,11 @@ describe('Dashboard open/close', () => {
   });
 
   it('default state has 1 tab shown in dashboard', () => {
-    // Default state always has Tab 1, so dashboard shows it
+    // Default state always has Schlag 1, so dashboard shows it
     w.openDashboard();
     const cards = doc.querySelectorAll('.dashboard-reiter-card');
     expect(cards.length).toBe(1);
-    expect(doc.getElementById('dashboard_content').textContent).toContain('Tab 1');
+    expect(doc.getElementById('dashboard_content').textContent).toContain('Schlag 1');
   });
 
   it('dashboard shows multiple tabs correctly', () => {

--- a/tests/43-loadstate-schema-validation.test.js
+++ b/tests/43-loadstate-schema-validation.test.js
@@ -76,13 +76,13 @@ describe('loadState() schema validation (Issue #237)', () => {
             expect(w.state.reiter[0].duenger).toBe(0);
         });
 
-        it('falls back to "Tab" when name is missing or non-string', () => {
+        it('falls back to "Schlag" when name is missing or non-string', () => {
             store['agrar_rechner'] = JSON.stringify({
                 reiter: [{ hektar: 0, koerner: 0, duenger: 0, entries: [] }],
                 _lv: 4
             });
             w.loadState();
-            expect(w.state.reiter[0].name).toBe('Tab');
+            expect(w.state.reiter[0].name).toBe('Schlag');
         });
 
         it('truncates oversize name to 64 chars', () => {
@@ -312,7 +312,7 @@ describe('loadState() schema validation (Issue #237)', () => {
             expect(t.istHektar).toBe(0);
             expect(t.koerner).toBe(0);
             expect(t.duenger).toBe(0);
-            expect(t.name).toBe('Tab');
+            expect(t.name).toBe('Schlag');
         });
 
         it('uses empty array for missing entries', () => {
@@ -423,7 +423,7 @@ describe('loadState() schema validation (Issue #237)', () => {
             expect(() => w.loadState()).not.toThrow();
             // State unverändert (Default bleibt)
             expect(w.state.reiter.length).toBe(1);
-            expect(w.state.reiter[0].name).toBe('Tab 1');
+            expect(w.state.reiter[0].name).toBe('Schlag 1');
 
             store['agrar_rechner'] = '42';
             expect(() => w.loadState()).not.toThrow();


### PR DESCRIPTION
Baut auf #401 (v5) auf.

## Was ist neu in v6
### Terminologie: 'Tab N' → 'Schlag N'
Alle Stellen, an denen die App selbst Namen vergibt oder anzeigt, sind umgestellt:
- Default-Tab-Name beim App-Start / nach Reset: `'Tab 1'` → `'Schlag 1'` (`state.js`, `ui-handlers.js`)
- Neuer Reiter über "+ Tab": `'Tab 2'` → `'Schlag 2'` (`ui-handlers.js`)
- Fallback-Label in Protokoll/Ergebnis ("Senken-Ausgleich")/Drill-Headers (`render-drill.js`, `render-results.js`)
- aria-labels: "Tab N", "Tab-Name", "Tab schließen" (`render-tabs.js`)
- Lösch-Bestätigung (`'Tab "…" wirklich löschen?'` → `'Schlag "…" wirklich löschen?'`)

### Tab-Leiste im Protokoll ausgeblendet
In der Protokoll-Ansicht ist die Reiter-Leiste redundant (jeder Schlag steht eh einzeln mit Name + Status drin). `render-tabs.js` schaltet `tab_bar` jetzt per JS auf `display:none`, wenn die Protokoll-Ansicht aktiv ist.

## Tests
5 Testdateien mit-gepatcht, die exakt auf den von der App generierten Default-Text geprüft haben:
- `06-tab-management.test.js`: `addReiter()` generiert jetzt korrekt `'Schlag 2/3/4'`
- `14-drill-multitab.test.js`: drill-tab-name zeigt `'Schlag 1'`
- `19-savings-carryover.test.js`: drill-entry-tab-header matcher
- `29-open-close-dashboard.test.js`: Dashboard zeigt `'Schlag 1'`
- `43-loadstate-schema-validation.test.js`: schema fallback `'Schlag'`

Alle anderen Stellen, an denen Tests `'Tab N'` nur als frei gewählten Fixture-Namen verwenden (`{ name: 'Tab 1', ... }`), wurden bewusst NICHT angefasst — das hat mit der App-Namensvergabe nichts zu tun.

## Resultate
- 47/47 test files · **792/792 tests grün**.
- Keine IDs/Klassen/Handler-Signaturen entfernt oder umbenannt.

## Files changed
```
 public/js/render-drill.js                    |  6 +++---
 public/js/render-results.js                  |  2 +-
 public/js/render-tabs.js                     | 10 ++++++----
 public/js/state.js                           |  8 ++++----
 public/js/ui-handlers.js                     |  4 ++--
 tests/06-tab-management.test.js              | 10 +++++-----
 tests/14-drill-multitab.test.js              |  2 +-
 tests/19-savings-carryover.test.js           |  2 +-
 tests/29-open-close-dashboard.test.js        |  4 ++--
 tests/43-loadstate-schema-validation.test.js |  8 ++++----
 10 files changed, 29 insertions(+), 27 deletions(-)
```
