### PR TITLE
fix(css): Reiter Schlag N einzeilig + Ellipsis statt Mittendrin-Umbruch

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -323,7 +323,8 @@
       font-size: 0.8rem;
       cursor: pointer;
       transition: background 0.15s, border-color 0.15s;
-      max-width: 130px;
+      max-width: 116px;
+      flex: 0 1 auto;
       min-height: 44px;
       /* Ensure tap area covers entire button */
       position: relative;
@@ -343,14 +344,20 @@
       font-size: 0.8rem;
       font-weight: 600;
       color: inherit;
-      width: 52px;
-      max-width: 52px;
+      width: 64px;
+      max-width: 64px;
       padding: 14px 4px 14px 10px;
       outline: none;
       pointer-events: auto;
       cursor: pointer;
       min-height: 48px;
       display: inline-block;
+      /* Verhindert hässlichen Mittendrin-Umbruch („Schla / g 4") bei den
+         automatisch vergebenen Default-Namen „Schlag N". Lange Custom-Namen
+         (>9 Zeichen) laufen per Ellipsis aus statt zu sprengen. */
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
       /* Prevent mobile copy/cut/paste menu on tap — edit only via double-click/tap */
       user-select: none;
       -webkit-user-select: none;


### PR DESCRIPTION
Rein CSS-Update, baut auf #402 (v6) auf.

## Problem
Auf schmalen Phone-Viewports (Screenshot vom 18.07.): die Default-Reiter-Beschriftung `Schlag N` wurde im aktiven Reiter zwischen z.B. `Schla` und `g 4` umgebrochen. Ursache war ein hartes `width: 52px; max-width: 52px` auf `.tab-name`, das aus der Zeit stammt, als die App noch `Tab 1` hieß.

## Fix
Zwei Regeln in `public/css/styles.css`:

1. **`.tab-name`:** `width` / `max-width`: 52px auf 64px, dazu `white-space: nowrap` (verhindert Mittendrin-Umbruch), `overflow: hidden` + `text-overflow: ellipsis` als Sicherheitsnetz für Custom-Namen > 9 Zeichen.
2. **`.tab-btn`:** `max-width`: 130px auf 116px und `flex: 0 1 auto` — schafft Platz fuer **3 Reiter + Plus-Tab in einer Zeile** im 420px-Container.

## Resultat
- Schlag 4 / Schlag 12 / Schlag 99: einzeilig
- Custom-Namen bis 9 Zeichen: einzeilig
- Custom-Namen > 9 Zeichen: einzeilig mit Ellipsis
- 3 Reiter + Plus-Tab nebeneinander passen rein

## Funktional unangetastet
- 47/47 test files - 792/792 gruen.

## Files changed
```
 public/css/styles.css | 13 ++++++++++---
 1 file changed, 10 insertions(+), 3 deletions(-)
```
