### PR TITLE
fix(css): Plus-Tab unter die Reiter + mehr Platz fuer Schlag 99

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -323,7 +323,7 @@
       font-size: 0.8rem;
       cursor: pointer;
       transition: background 0.15s, border-color 0.15s;
-      max-width: 116px;
+      max-width: 140px;
       flex: 0 1 auto;
       min-height: 44px;
       /* Ensure tap area covers entire button */
@@ -344,17 +344,18 @@
       font-size: 0.8rem;
       font-weight: 600;
       color: inherit;
-      width: 64px;
-      max-width: 64px;
+      width: 76px;
+      max-width: 76px;
       padding: 14px 4px 14px 10px;
       outline: none;
       pointer-events: auto;
       cursor: pointer;
       min-height: 48px;
       display: inline-block;
-      /* Verhindert hässlichen Mittendrin-Umbruch („Schla / g 4") bei den
-         automatisch vergebenen Default-Namen „Schlag N". Lange Custom-Namen
-         (>9 Zeichen) laufen per Ellipsis aus statt zu sprengen. */
+      /* Verhindert haesslichen Mittendrin-Umbruch („Schla / g 4") bei den
+         automatisch vergebenen Default-Namen „Schlag N". 76 px reicht fuer
+         „Schlag 99" einzeilig (8 Zeichen * ~7 px + Padding 14 = 70 px).
+         Lange Custom-Namen (>12 Zeichen) laufen per Ellipsis aus. */
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
@@ -420,6 +421,11 @@
       display: flex;
       align-items: center;
       justify-content: center;
+      /* Wandert in eine eigene Zeile unter den Reitern (anstatt mit ihnen
+         in einer Reihe um Platz zu kaempfen). */
+      flex-basis: 100%;
+      margin-top: 8px;
+      max-width: 180px;
     }
     .tab-add:active {
       background: var(--color-bg-hover);


### PR DESCRIPTION
Rein CSS-Update, baut auf #404 (tab-close-smaller) auf.

## Problem
Nach #404 passten zwar 3 Schlaege + Plus-Tab in eine Zeile, aber:
- Schlag 10/11/12/... wurden weiterhin zu Schlag... abgeschnitten (zu wenig Platz im .tab-name Container).
- Der Plus-Tab Button verdraengte die Reiter auf 2-3 Zeilen sobald man 5+ Schlaege hatte (Screenshot 18.07. 21:34).

## Fix
Drei Regeln in `public/css/styles.css`:

1. **`.tab-name` width 64px zu 76px** - 8 Zeichen Schlag 99 (8 * ca. 7 px + 14 Padding = 70 px) passen jetzt einzeilig ohne Schlag...
2. **`.tab-btn` max-width 116px zu 140px** - mehr Luft fuer Custom-Namen
3. **`.tab-add` mit `flex-basis: 100%` + margin-top: 8px** - Plus-Tab rutscht in eine eigene Zeile unter die Reiter. max-width 180 px damit er nicht die volle Breite faesst (waere sonst zu lang).

## Resultat
- Schlag 1 bis Schlag 99: einzeilig lesbar
- Plus-Tab steht unter den Reitern in eigener Zeile, verdraengt sie nicht mehr
- 3+ Schlaege ordnen sich sauber in Reihen, ohne dass der Plus-Button dazwischenfunkt
- Custom-Namen > ca. 12 Zeichen weiter mit Ellipsis (Standard-UX auf Mobile)

## Funktional unangetastet
- 47/47 test files - 792/792 gruen.
- Keine HTML/JS Aenderung.

## Files changed
```
 public/css/styles.css | 18 ++++++++++++------
 1 file changed, 12 insertions(+), 6 deletions(-)
```
