### PR TITLE
Revert "fix(css): Plus-Tab unter die Reiter + mehr Platz fuer Schlag 99"

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -323,7 +323,7 @@
       font-size: 0.8rem;
       cursor: pointer;
       transition: background 0.15s, border-color 0.15s;
-      max-width: 140px;
+      max-width: 116px;
       flex: 0 1 auto;
       min-height: 44px;
       /* Ensure tap area covers entire button */
@@ -344,18 +344,17 @@
       font-size: 0.8rem;
       font-weight: 600;
       color: inherit;
-      width: 76px;
-      max-width: 76px;
+      width: 64px;
+      max-width: 64px;
       padding: 14px 4px 14px 10px;
       outline: none;
       pointer-events: auto;
       cursor: pointer;
       min-height: 48px;
       display: inline-block;
-      /* Verhindert haesslichen Mittendrin-Umbruch („Schla / g 4") bei den
-         automatisch vergebenen Default-Namen „Schlag N". 76 px reicht fuer
-         „Schlag 99" einzeilig (8 Zeichen * ~7 px + Padding 14 = 70 px).
-         Lange Custom-Namen (>12 Zeichen) laufen per Ellipsis aus. */
+      /* Verhindert hässlichen Mittendrin-Umbruch („Schla / g 4") bei den
+         automatisch vergebenen Default-Namen „Schlag N". Lange Custom-Namen
+         (>9 Zeichen) laufen per Ellipsis aus statt zu sprengen. */
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
@@ -421,11 +420,6 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      /* Wandert in eine eigene Zeile unter den Reitern (anstatt mit ihnen
-         in einer Reihe um Platz zu kaempfen). */
-      flex-basis: 100%;
-      margin-top: 8px;
-      max-width: 180px;
     }
     .tab-add:active {
       background: var(--color-bg-hover);


### PR DESCRIPTION
Revertiert #405, weil der Fix das Problem verschlimmert hat:
Mit den 76 px `.tab-name` und 140 px `.tab-btn` passen nur noch **2 Reiter pro Zeile** statt 3 (Screenshot 18.07. 21:52). Der Plus-Tab in eigener Zeile ist ok, aber der Verlust von 3-Reiter-pro-Zeile macht das Layout nicht wirklich besser.

## Resultat nach dem Revert
Stand wie nach #404:
- 3 Reiter + Plus-Tab in einer Zeile
- Schlag 10/11/12 werden als Schlag... abgekuerzt (Trade-off, mit dem du leben kannst, oder wir probieren eine andere Variante)

## Naechster Schritt offen
Wenn du magst, schauen wir uns was ganz anderes an (z.B. Reiter-Spalte links waagrecht wie eine Sidebar, oder ein Drop-Down). Sag Bescheid welcher Weg dir lieber ist - sonst bleibt's bei #404-Stand.

## Files changed
```
 public/css/styles.css | 18 ++++++------------
 1 file changed, 6 insertions(+), 12 deletions(-)
```
