### PR TITLE
fix(css): Reiter nutzen volle Breite, schlankerer Text-Container, Plus-Tab eigene Zeile

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -116,8 +116,8 @@
       -webkit-font-smoothing: antialiased;
     }
     .container {
-      max-width: 420px;
-      margin: 0 auto;
+      max-width: 100%;
+      padding: 0 6px;
     }
     h1 {
       text-align: center;
@@ -323,8 +323,8 @@
       font-size: 0.8rem;
       cursor: pointer;
       transition: background 0.15s, border-color 0.15s;
-      max-width: 116px;
-      flex: 0 1 auto;
+      max-width: 130px;
+      flex: 1 1 auto;
       min-height: 44px;
       /* Ensure tap area covers entire button */
       position: relative;
@@ -344,17 +344,16 @@
       font-size: 0.8rem;
       font-weight: 600;
       color: inherit;
-      width: 64px;
-      max-width: 64px;
-      padding: 14px 4px 14px 10px;
+      flex: 1 1 auto;
+      min-width: 0;
+      padding: 14px 6px 14px 6px;
       outline: none;
       pointer-events: auto;
       cursor: pointer;
       min-height: 48px;
       display: inline-block;
-      /* Verhindert hässlichen Mittendrin-Umbruch („Schla / g 4") bei den
-         automatisch vergebenen Default-Namen „Schlag N". Lange Custom-Namen
-         (>9 Zeichen) laufen per Ellipsis aus statt zu sprengen. */
+      /* Kein Mittendrin-Umbruch („Schla / g 4"). Lange Custom-Namen laufen
+         per Ellipsis aus statt zu sprengen. */
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
@@ -420,6 +419,10 @@
       display: flex;
       align-items: center;
       justify-content: center;
+      /* Wandert in eine eigene Zeile unter den Reitern */
+      flex-basis: 100%;
+      margin-top: 8px;
+      max-width: 180px;
     }
     .tab-add:active {
       background: var(--color-bg-hover);


### PR DESCRIPTION
Rein CSS-Update. Setzt auf dem #406-Revert-Stand auf.

## Problem
Zwei Layout-Probleme, beide aus dem vorigen Patch nicht geloest:
1. 40-50 px tote Luecke rechts: `.container` hatte `max-width: 420px; margin: 0 auto` und zentrierte damit die ganze App.
2. Toter Raum im Reiter zwischen X und Text: `.tab-name` war auf `width: 64px` fixiert bei 116 px breitem Reiter.

## Fix
Vier Aenderungen in `public/css/styles.css`:

1. `.container`: max-width 420px auf 100% plus padding 0 6px. App geht bis fast an den Rand.
2. `.tab-name`: von fixer width weg zu flex 1 1 auto, min-width 0, plus reduziertes Padding (14px 6px 14px 6px). Text-Container fuellt verfuegbaren Platz.
3. `.tab-btn`: flex 0 1 auto auf 1 1 auto, max-width 116 auf 130. Waechst mit dem verfuegbaren Platz mit.
4. `.tab-add`: flex-basis 100% / margin-top 8px / max-width 180px. Plus-Tab in eigene Zeile unter den Reitern.

## Resultat
- Voll nutzbare Bildschirm-Breite (keine Zentrier-Luecke)
- Schlag 10 / Schlag 99 lesbar einzeilig
- Schlag 1 - Schlag 9 etwas kompakter weil gleichmaessig verteilt
- Plus-Tab in eigener Zeile

## Funktional unangetastet
- 47/47 test files - 792/792 gruen
- Keine HTML/JS-Aenderung

## Files changed
```
 public/css/styles.css | 23 +++++++++++++----------
 1 file changed, 13 insertions(+), 10 deletions(-)
```
